### PR TITLE
Fix: Filter irrelevant update errors

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
 		"build": "electron-vite build",
 		"postbuild": "chmod +x ./bin/local-operator-ui.js",
 		"lint": "npx @biomejs/biome check src",
-		"lint:fix": "npx @biomejs/biome check --apply src",
+		"lint:fix": "npx @biomejs/biome check --write src",
 		"format": "npx @biomejs/biome format src",
 		"format:fix": "npx @biomejs/biome format --write src",
 		"prepublishOnly": "npm run build",


### PR DESCRIPTION
This PR introduces a mechanism to filter irrelevant update errors, preventing certain errors from being displayed to the user. This improves the user experience by hiding irrelevant or temporary errors.

Changes:
* package.json: Updated the `lint:fix` script.
* src/main/update-service.ts: Added a `shouldFilterUpdateError` method and modified the error handling logic to filter errors.
