### PR TITLE
feat(streaming): migrate to SSE with a WebSocket fallback

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -50,3 +50,4 @@ resources/python
 resources/python_aarch64
 
 *storybook.log
+node_modules

--- a/docs/sse-migration.md
+++ b/docs/sse-migration.md
@@ -1,0 +1,112 @@
+# Streaming transport: SSE, with a WebSocket fallback
+
+The renderer now streams a turn over **Server-Sent Events** where the backend
+offers it, and falls back to the WebSocket where it does not. Everything above
+the transport — the rAF coalescing, the equality gate, the global registry, the
+stores, the rendering — is unchanged, because both transports present the same
+emitter surface.
+
+## Why
+
+The socket only ever carried server-to-client data. The one frame the client
+sent upstream was a keepalive `ping`; cancellation was already an HTTP call.
+SSE therefore costs no capability and buys three things the socket cannot:
+
+- **Resume with a cursor.** `EventSource` reconnects on its own and replays
+  `Last-Event-ID`, so a dropped connection continues at the exact event. The
+  socket had no sequence and simply lost whatever arrived while away.
+- **Plain HTTP.** No upgrade handshake, so proxies, the Vite dev server and
+  ordinary tooling work without special handling.
+- **A server-driven keepalive.** The backend heartbeats every 15s, so there is
+  no client ping timer, and a stalled stream is *detectable* — the client now
+  notices instead of showing a live indicator over a black-holed connection.
+
+## The pieces
+
+| File | Role |
+| --- | --- |
+| `shared/api/local-operator/sse-api.ts` | `SseClient` — EventSource transport, same emitter surface as `WebSocketClient` |
+| `shared/api/local-operator/streaming-transport.ts` | `StreamingClient` — picks the transport, and falls back with the consumer unaware |
+| `shared/hooks/use-websocket-message.ts` | now builds a `StreamingClient` instead of a `WebSocketClient`; no call site changes |
+| `shared/api/local-operator/websocket-api.ts` | `EventEmitter` exported (one line) so both transports share the emitter |
+| `features/chat/components/sse-transport.stories.tsx` | no-backend fixture proving stream, resume, and both fallbacks |
+
+## Compatibility contract
+
+A backend that predates SSE answers **404** on `GET /v1/sse/capabilities`; that
+404 is the entire fallback signal, not an error. `record.update` /
+`record.complete` carry the legacy `CodeExecutionResult` dump verbatim
+(including the injected `message_id` and `connection_type` keys), and the
+client republishes it under `update:<messageId>` unchanged — so a consumer
+cannot tell which transport delivered its events.
+
+Two failure kinds are handled, and they are different:
+
+- **Backend too old** — detected once per base URL by the capability probe,
+  cached for the session.
+- **SSE broken in transit** (a buffering proxy) — the stream opens and goes
+  silent. Detected per connection by the stall timer (silence past 45s, versus
+  the server's 15s heartbeat) and by a terminal error before any frame. Falls
+  back for that message and remembers it, so the next message skips the doomed
+  attempt instead of paying the stall again. `resetTransportCache()` re-probes.
+
+## What's new beyond parity
+
+The socket bridge discarded `message_update.delta`, tool progress, turn
+boundaries, compaction and retries. Those now arrive as first-class events
+(`message.delta`, `tool.start`/`delta`/`end`, `turn.start`/`end`,
+`agent.start`/`end`, `job.status`, `notice`), forwarded additively by
+`StreamingClient`. Nothing requires them; a consumer can opt in to true
+incremental text (`message.delta`) and stop re-rendering a whole message per
+frame.
+
+A second channel kind is available: `GET /v1/sse/jobs/{job_id}` is openable the
+instant the async chat call returns, before any record id exists — removing the
+race where the client polled job status until a record id appeared and relied
+on cumulative frames to catch up. `StreamingClient` takes `channelKind: "job"`.
+
+## Backend to develop against
+
+- Repo: `~/local-operator`, branch `feat/harness-rewrite` (commit `27cebcc`).
+- Serve: `local-operator serve --port 1111` (default `0.0.0.0:1111`).
+- Discovery: `GET /v1/sse/capabilities`.
+- Streams: `GET /v1/sse/messages/{message_id}`, `GET /v1/sse/jobs/{job_id}`.
+  Resume via the `Last-Event-ID` header or `?after_seq=<n>`.
+
+## Pointing the UI at it
+
+The `dev` script greps `.env`, and none ships, so create one:
+
+```env
+VITE_LOCAL_OPERATOR_API_URL=http://localhost:1111
+VITE_DISABLE_BACKEND_MANAGER=true
+```
+
+`VITE_DISABLE_BACKEND_MANAGER=true` stops Electron from installing or killing
+your backend. Then `pnpm dev`. The CSP in `src/renderer/index.html` already
+permits `http://localhost:1111`.
+
+## Verifying without a backend
+
+`pnpm storybook`, then **Chat → SSE transport**. Four buttons:
+
+- *Stream over SSE* — transport `sse`, the message fills in, completes, one
+  stream URL with no cursor.
+- *Drop mid-stream, then resume* — the connection drops and reports
+  `CONNECTING`, and the client reconnects.
+- *Old backend, no SSE* — the probe 404s and transport is `websocket`, with no
+  stream URL opened.
+- *SSE advertised but silent* — opens, produces nothing, and the stall detector
+  switches to `websocket`.
+
+## Verified against a live backend
+
+- The probe selects `sse` when the route exists.
+- A real turn streams records that carry the answer and the legacy socket keys,
+  then closes on `stream.terminal`.
+- A backend without the route falls back to the socket.
+- A stream that opens and dies falls back too.
+
+The backend's own evidence (resume across a real disconnect, late-attach
+snapshot recovery, concurrent-listener fan-out, WebSocket/SSE record parity)
+is in `~/local-operator/docs/VERIFICATION.md`.

--- a/node_modules
+++ b/node_modules
@@ -1,1 +1,0 @@
-/Users/damian/local-operator-ui/node_modules

--- a/node_modules
+++ b/node_modules
@@ -1,0 +1,1 @@
+/Users/damian/local-operator-ui/node_modules

--- a/src/renderer/src/features/chat/components/sse-transport.stories.tsx
+++ b/src/renderer/src/features/chat/components/sse-transport.stories.tsx
@@ -1,0 +1,458 @@
+import type { Meta, StoryObj } from "@storybook/react";
+import { useCallback, useEffect, useRef, useState } from "react";
+import {
+	StreamingClient,
+	type StreamingTransportKind,
+	resetTransportCache,
+} from "../../../shared/api/local-operator/streaming-transport";
+import "../../../styles/index.css";
+
+/**
+ * Transport fixture — SSE, resume, and the WebSocket fallback, no backend.
+ *
+ * Only the network is fake. A scripted `EventSource` stand-in replays the exact
+ * frames the backend emits (`stream.open` with a folded snapshot, `record.*`,
+ * `message.delta`, `stream.terminal`) through the real `StreamingClient`, so
+ * what these buttons prove is what the app does.
+ *
+ * Three behaviours are visible here, and each is something the socket could not
+ * do:
+ *
+ * - **Stream over SSE.** Records arrive under `update:<id>` in the legacy socket
+ *   shape, so every consumer above the transport is unchanged.
+ * - **Resume after a drop.** The reconnect carries `after_seq`, and the reopened
+ *   stream continues at the next sequence rather than replaying the turn. The
+ *   socket had no sequence at all and simply lost whatever arrived while away.
+ * - **Fall back.** With no `/v1/sse/capabilities` (an older backend) or a stream
+ *   that opens and then goes silent (a buffering proxy), the client switches to
+ *   the WebSocket and the consumer never learns it happened.
+ */
+
+const MESSAGE_ID = "fixture-sse-message";
+const BASE_URL = "http://fixture.invalid";
+
+type Frame = { name: string; id?: number; data: unknown };
+
+/** The frame script, in the shape and order the backend actually emits. */
+const buildFrames = (): Frame[] => {
+	const record = (message: string, complete: boolean) => ({
+		id: MESSAGE_ID,
+		message,
+		code: "",
+		stdout: "",
+		stderr: "",
+		logging: "",
+		content: "",
+		formatted_print: "",
+		role: "assistant",
+		status: complete ? "success" : "in_progress",
+		timestamp: new Date().toISOString(),
+		files: [],
+		execution_type: "response",
+		task_classification: "conversation",
+		is_complete: complete,
+		is_streamable: true,
+		message_id: MESSAGE_ID,
+		connection_type: "message",
+	});
+
+	const words = ["Streaming", " over", " SSE", " with", " resume."];
+	const frames: Frame[] = [
+		{
+			name: "stream.open",
+			data: {
+				type: "stream.open",
+				channel: `message:${MESSAGE_ID}`,
+				transport: "sse",
+				last_seq: 0,
+				resumed: false,
+				snapshot: [],
+				snapshot_count: 0,
+			},
+		},
+	];
+	let text = "";
+	let seq = 0;
+	for (const word of words) {
+		text += word;
+		seq += 1;
+		frames.push({
+			name: "message.delta",
+			id: seq,
+			data: { type: "message.delta", seq, delta: word, message_id: MESSAGE_ID },
+		});
+		seq += 1;
+		frames.push({
+			name: "record.update",
+			id: seq,
+			data: {
+				type: "record.update",
+				seq,
+				record: record(text, false),
+				message_id: MESSAGE_ID,
+			},
+		});
+	}
+	seq += 1;
+	frames.push({
+		name: "record.complete",
+		id: seq,
+		data: {
+			type: "record.complete",
+			seq,
+			record: record(text, true),
+			message_id: MESSAGE_ID,
+		},
+	});
+	seq += 1;
+	frames.push({
+		name: "stream.terminal",
+		id: seq,
+		data: { type: "stream.terminal", seq, status: "complete" },
+	});
+	return frames;
+};
+
+type FakeMode = "stream" | "drop-midway" | "silent";
+
+/**
+ * Scripted `EventSource`. Faithful about the parts the client depends on:
+ * named events, `lastEventId`, `readyState`, `onopen`/`onerror`, and the
+ * `CONNECTING` state that distinguishes a deliberate close from a failure.
+ */
+class FakeEventSource {
+	static CONNECTING = 0;
+	static OPEN = 1;
+	static CLOSED = 2;
+	static mode: FakeMode = "stream";
+	static urls: string[] = [];
+
+	readyState = FakeEventSource.CONNECTING;
+	onopen: (() => void) | null = null;
+	onerror: (() => void) | null = null;
+	private readonly listeners = new Map<
+		string,
+		Array<(event: { data: string; lastEventId: string }) => void>
+	>();
+	private timers: number[] = [];
+	private closed = false;
+
+	constructor(readonly url: string) {
+		FakeEventSource.urls.push(url);
+		this.timers.push(
+			window.setTimeout(() => {
+				if (this.closed) return;
+				this.readyState = FakeEventSource.OPEN;
+				this.onopen?.();
+				if (FakeEventSource.mode !== "silent") this.play();
+			}, 10),
+		);
+	}
+
+	addEventListener(
+		name: string,
+		fn: (event: { data: string; lastEventId: string }) => void,
+	): void {
+		const existing = this.listeners.get(name);
+		if (existing) existing.push(fn);
+		else this.listeners.set(name, [fn]);
+	}
+
+	private play(): void {
+		// A reconnect carries `after_seq`; honouring it is what makes the resume
+		// visible - the reopened stream sends only what follows the cursor.
+		const cursor = Number.parseInt(
+			new URL(this.url, "http://x").searchParams.get("after_seq") ?? "0",
+			10,
+		);
+		const frames = buildFrames().filter(
+			(frame) => frame.id === undefined || frame.id > cursor,
+		);
+		const cut =
+			FakeEventSource.mode === "drop-midway"
+				? Math.ceil(frames.length / 2)
+				: frames.length;
+
+		frames.slice(0, cut).forEach((frame, index) => {
+			this.timers.push(
+				window.setTimeout(
+					() => {
+						if (this.closed) return;
+						for (const fn of this.listeners.get(frame.name) ?? []) {
+							fn({
+								data: JSON.stringify(frame.data),
+								lastEventId: frame.id ? String(frame.id) : "",
+							});
+						}
+					},
+					60 + index * 70,
+				),
+			);
+		});
+
+		if (FakeEventSource.mode === "drop-midway") {
+			this.timers.push(
+				window.setTimeout(
+					() => {
+						if (this.closed) return;
+						// Spec behaviour for a dropped connection: stay CONNECTING so
+						// the client treats it as retryable.
+						this.readyState = FakeEventSource.CONNECTING;
+						this.onerror?.();
+					},
+					60 + cut * 70,
+				),
+			);
+		}
+	}
+
+	close(): void {
+		this.closed = true;
+		this.readyState = FakeEventSource.CLOSED;
+		for (const timer of this.timers) window.clearTimeout(timer);
+		this.timers = [];
+	}
+}
+
+/** Minimal socket stand-in, so the fallback path has something to land on. */
+class FakeSocket {
+	static instances: FakeSocket[] = [];
+	readyState = 1;
+	onopen: (() => void) | null = null;
+	onmessage: ((event: { data: string }) => void) | null = null;
+	onclose: (() => void) | null = null;
+	onerror: (() => void) | null = null;
+
+	constructor(readonly url: string) {
+		FakeSocket.instances.push(this);
+		window.setTimeout(() => this.onopen?.(), 5);
+	}
+	send(): void {}
+	close(): void {
+		this.readyState = 3;
+		this.onclose?.();
+	}
+}
+
+/**
+ * Swap the network globals. `EventSource` and `WebSocket` are read-only per
+ * their DOM types, so they go through `defineProperty`; `fetch` decides what the
+ * capability probe sees, which is what selects the transport.
+ */
+const installFakes = (sseAvailable: boolean): (() => void) => {
+	const originalEventSource = window.EventSource;
+	const originalSocket = window.WebSocket;
+	const originalFetch = window.fetch;
+
+	Object.defineProperty(window, "EventSource", {
+		value: FakeEventSource,
+		configurable: true,
+	});
+	Object.defineProperty(window, "WebSocket", {
+		value: FakeSocket,
+		configurable: true,
+	});
+	window.fetch = (async (input: RequestInfo | URL) => {
+		const url = String(input);
+		if (url.includes("/v1/sse/capabilities")) {
+			// A backend without the SSE surface answers 404 - that 404 is the
+			// entire fallback signal, not an error to report.
+			if (!sseAvailable) return new Response("", { status: 404 });
+			return new Response(
+				JSON.stringify({
+					transports: ["sse", "websocket"],
+					preferred: "sse",
+					sse: {
+						version: 1,
+						channels: {},
+						resume: {
+							last_event_id: true,
+							query_param: "after_seq",
+							replay_buffer: 256,
+						},
+						heartbeat_interval_s: 15,
+						retry_hint_ms: 1000,
+						events: [],
+						legacy_record_frames: true,
+					},
+					websocket: { channels: {}, deprecated: true },
+				}),
+				{ status: 200, headers: { "content-type": "application/json" } },
+			);
+		}
+		return new Response("{}", { status: 200 });
+	}) as typeof window.fetch;
+
+	return () => {
+		Object.defineProperty(window, "EventSource", {
+			value: originalEventSource,
+			configurable: true,
+		});
+		Object.defineProperty(window, "WebSocket", {
+			value: originalSocket,
+			configurable: true,
+		});
+		window.fetch = originalFetch;
+	};
+};
+
+type Observed = {
+	transport: StreamingTransportKind | null;
+	text: string;
+	complete: boolean;
+	events: string[];
+	urls: string[];
+};
+
+const TransportFixture = () => {
+	const [observed, setObserved] = useState<Observed>({
+		transport: null,
+		text: "",
+		complete: false,
+		events: [],
+		urls: [],
+	});
+	const clientRef = useRef<StreamingClient | null>(null);
+
+	const stop = useCallback(() => {
+		clientRef.current?.disconnect();
+		clientRef.current = null;
+	}, []);
+
+	useEffect(() => stop, [stop]);
+
+	const run = useCallback(
+		async (mode: FakeMode, sseAvailable: boolean) => {
+			stop();
+			const restore = installFakes(sseAvailable);
+			FakeEventSource.mode = mode;
+			FakeEventSource.urls = [];
+			resetTransportCache();
+			setObserved({
+				transport: null,
+				text: "",
+				complete: false,
+				events: [],
+				urls: [],
+			});
+
+			const client = new StreamingClient(BASE_URL, MESSAGE_ID, {
+				sse: { stallTimeout: 600, maxReconnectAttempts: 1 },
+			});
+			clientRef.current = client;
+
+			const seen: string[] = [];
+			client.on("status", (status) => {
+				seen.push(`status:${String(status)}`);
+			});
+			client.on("message.delta", () => seen.push("message.delta"));
+			client.on("terminal", () => seen.push("terminal"));
+			client.on(`update:${MESSAGE_ID}`, (update) => {
+				const record = update as { message?: string; is_complete?: boolean };
+				setObserved((previous) => ({
+					...previous,
+					text: record.message ?? previous.text,
+					complete: record.is_complete ?? previous.complete,
+				}));
+			});
+
+			await client.connect();
+			setObserved((previous) => ({
+				...previous,
+				transport: client.getTransport(),
+			}));
+
+			window.setTimeout(() => {
+				setObserved((previous) => ({
+					...previous,
+					events: [...seen],
+					urls: [...FakeEventSource.urls],
+					transport: client.getTransport(),
+				}));
+				restore();
+			}, 2200);
+		},
+		[stop],
+	);
+
+	return (
+		<div className="flex flex-col gap-4 p-6 text-sm">
+			<div className="flex flex-wrap gap-2">
+				<button
+					type="button"
+					className="rounded border px-3 py-1"
+					onClick={() => void run("stream", true)}
+				>
+					Stream over SSE
+				</button>
+				<button
+					type="button"
+					className="rounded border px-3 py-1"
+					onClick={() => void run("drop-midway", true)}
+				>
+					Drop mid-stream, then resume
+				</button>
+				<button
+					type="button"
+					className="rounded border px-3 py-1"
+					onClick={() => void run("stream", false)}
+				>
+					Old backend, no SSE
+				</button>
+				<button
+					type="button"
+					className="rounded border px-3 py-1"
+					onClick={() => void run("silent", true)}
+				>
+					SSE advertised but silent
+				</button>
+			</div>
+
+			<dl className="grid grid-cols-[10rem_1fr] gap-1">
+				<dt>transport</dt>
+				<dd data-testid="transport">{observed.transport ?? "—"}</dd>
+				<dt>complete</dt>
+				<dd data-testid="complete">{String(observed.complete)}</dd>
+				<dt>message</dt>
+				<dd data-testid="message">{observed.text || "—"}</dd>
+				<dt>stream urls</dt>
+				<dd data-testid="urls">
+					{observed.urls.length ? (
+						<ul>
+							{observed.urls.map((url) => (
+								<li key={url}>{url.replace(BASE_URL, "")}</li>
+							))}
+						</ul>
+					) : (
+						"—"
+					)}
+				</dd>
+				<dt>events</dt>
+				<dd data-testid="events">{observed.events.join(", ") || "—"}</dd>
+			</dl>
+		</div>
+	);
+};
+
+const meta = {
+	title: "Chat/SSE transport",
+	component: TransportFixture,
+	parameters: { layout: "fullscreen" },
+} satisfies Meta<typeof TransportFixture>;
+
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+/**
+ * Press each button in turn.
+ *
+ * - *Stream over SSE* — transport `sse`, the message fills in, `complete` true,
+ *   one stream URL with no cursor.
+ * - *Drop mid-stream, then resume* — two stream URLs, the second carrying
+ *   `?after_seq=<n>`, and the message still completes.
+ * - *Old backend, no SSE* — transport `websocket`, no stream URL at all.
+ * - *SSE advertised but silent* — opens, produces nothing, and the stall
+ *   detector switches to `websocket`.
+ */
+export const Fixture: Story = {};

--- a/src/renderer/src/shared/api/local-operator/sse-api.ts
+++ b/src/renderer/src/shared/api/local-operator/sse-api.ts
@@ -1,0 +1,422 @@
+/**
+ * Server-Sent Events transport for streaming message updates.
+ *
+ * ## Why this exists
+ *
+ * Everything the renderer needs from a running turn is server-to-client. The
+ * only frame the socket client ever sent upstream was a keepalive `ping`;
+ * cancellation is already an HTTP call (`JobsApi.cancelJob`). So SSE costs no
+ * capability and buys three things the socket cannot:
+ *
+ * - **Resume with a cursor.** `EventSource` reconnects on its own and replays
+ *   `Last-Event-ID`, so a dropped connection continues at the exact event
+ *   instead of restarting the render. The socket had no sequence at all.
+ * - **Plain HTTP.** No upgrade handshake, so proxies, the Vite dev server and
+ *   ordinary HTTP tooling all work without special handling.
+ * - **A server-driven keepalive.** The backend sends a comment every 15s, so
+ *   there is no client ping timer to get wrong.
+ *
+ * ## Why it is shaped like `WebSocketClient`
+ *
+ * This class deliberately mirrors `WebSocketClient`'s emitter surface -
+ * `status`, `update:<messageId>`, `error`, plus `connect`/`disconnect`/
+ * `getStatus` - so {@link useWebSocketMessage} can hold either one behind the
+ * same reference and nothing above it changes. The rAF coalescing, the equality
+ * gate, the global registry and the store all keep working untouched, which is
+ * what makes the fallback in `streaming-transport.ts` transparent rather than a
+ * second rendering path to maintain.
+ *
+ * ## Compatibility
+ *
+ * `record.update` and `record.complete` carry the legacy `CodeExecutionResult`
+ * dump verbatim, including the `message_id` and `connection_type` keys the
+ * socket injected. This client republishes that object unchanged as
+ * `update:<messageId>`, so the consumer cannot tell which transport delivered
+ * it. The richer events the socket bridge discarded (`message.delta`,
+ * `tool.*`, `turn.*`) are emitted separately for anything that wants them, and
+ * ignoring them costs nothing.
+ */
+
+import type { AgentExecutionRecord } from "./types";
+
+/** Trailing slashes on a configured base URL would double up in every path. */
+const TRAILING_SLASHES = /\/+$/;
+import { EventEmitter, type WebSocketConnectionStatus } from "./websocket-api";
+
+/**
+ * The event names the backend publishes. Mirrors `EventName` in
+ * `local_operator/server/utils/sse.py`; the SSE `event:` name and the inner
+ * `data.type` always agree, so switching on either is valid.
+ */
+export const SseEventName = {
+	Open: "stream.open",
+	Gap: "stream.gap",
+	Terminal: "stream.terminal",
+	Error: "error",
+	RecordUpdate: "record.update",
+	RecordComplete: "record.complete",
+	MessageDelta: "message.delta",
+	ToolStart: "tool.start",
+	ToolDelta: "tool.delta",
+	ToolEnd: "tool.end",
+	TurnStart: "turn.start",
+	TurnEnd: "turn.end",
+	AgentStart: "agent.start",
+	AgentEnd: "agent.end",
+	Notice: "notice",
+	JobStatus: "job.status",
+} as const;
+
+/** Body of `stream.open`: what you attached to, and the state as of attach. */
+export type SseOpenPayload = {
+	type: string;
+	seq?: number;
+	channel: string;
+	transport: string;
+	last_seq: number;
+	resumed: boolean;
+	snapshot: AgentExecutionRecord[];
+	snapshot_count: number;
+};
+
+/** Body of a record frame. `record` is the legacy socket data frame verbatim. */
+export type SseRecordPayload = {
+	type: string;
+	seq: number;
+	channel: string;
+	record: AgentExecutionRecord & {
+		message_id: string;
+		connection_type: string;
+	};
+	message_id: string;
+	job_id?: string;
+};
+
+/** Body of `stream.gap`: frames were lost and the client must reconcile. */
+export type SseGapPayload = {
+	type: string;
+	reason: "overflow" | "evicted" | string;
+	reconcile: boolean;
+	dropped?: number;
+	expected_seq?: number;
+};
+
+export type SseClientOptions = {
+	/** Reconnect hint passed through to the URL; the server also sends `retry:`. */
+	autoReconnect?: boolean;
+	/** Give up after this many consecutive failed opens. */
+	maxReconnectAttempts?: number;
+	/**
+	 * Milliseconds of silence tolerated before the stream is treated as dead.
+	 * The server heartbeats every 15s, so anything comfortably above that
+	 * distinguishes "quiet turn" from "connection black-holed" - a case the
+	 * socket client could not detect at all.
+	 */
+	stallTimeout?: number;
+};
+
+const DEFAULT_OPTIONS: Required<SseClientOptions> = {
+	autoReconnect: true,
+	maxReconnectAttempts: 5,
+	stallTimeout: 45000,
+};
+
+/** Channel kinds. Prefer `job` for new work; see the note on `messageId`. */
+export type SseChannelKind = "message" | "job";
+
+/**
+ * Streams one channel over SSE, presenting the same surface as
+ * `WebSocketClient`.
+ */
+export class SseClient extends EventEmitter {
+	private source: EventSource | null = null;
+	private readonly baseUrl: string;
+	private readonly channelId: string;
+	private readonly channelKind: SseChannelKind;
+	private readonly options: Required<SseClientOptions>;
+	private status: WebSocketConnectionStatus = "disconnected";
+	private failedOpens = 0;
+	/**
+	 * Highest sequence seen. `EventSource` sends `Last-Event-ID` itself, so this
+	 * is only needed when a *manual* reconnect has to rebuild the URL - and as
+	 * the signal that the stream produced something before it broke, which is
+	 * what distinguishes "SSE is unusable here" from "the connection blipped".
+	 */
+	private lastSeq: number | null = null;
+	private stallTimerId: number | null = null;
+	private closedByServer = false;
+
+	/**
+	 * @param baseUrl - Base URL of the Local Operator API.
+	 * @param channelId - Record id for a `message` channel, job id for a `job`
+	 *   channel. The record id is only knowable after the turn starts producing,
+	 *   which is the race the job channel exists to remove.
+	 * @param options - Connection options.
+	 * @param channelKind - Which channel namespace `channelId` belongs to.
+	 */
+	constructor(
+		baseUrl: string,
+		channelId: string,
+		options: SseClientOptions = {},
+		channelKind: SseChannelKind = "message",
+	) {
+		super();
+		this.baseUrl = baseUrl.replace(TRAILING_SLASHES, "");
+		this.channelId = channelId;
+		this.channelKind = channelKind;
+		this.options = { ...DEFAULT_OPTIONS, ...options };
+	}
+
+	public getStatus(): WebSocketConnectionStatus {
+		return this.status;
+	}
+
+	/**
+	 * Highest sequence observed, or null if nothing arrived yet. A non-null
+	 * value is the proof the transport selector needs that SSE demonstrably
+	 * works on this connection, so a later failure is a blip to retry rather
+	 * than a reason to fall back to the socket.
+	 */
+	public getLastSequence(): number | null {
+		return this.lastSeq;
+	}
+
+	private url(): string {
+		const path =
+			this.channelKind === "job"
+				? `/v1/sse/jobs/${encodeURIComponent(this.channelId)}`
+				: `/v1/sse/messages/${encodeURIComponent(this.channelId)}`;
+		// A manual reopen cannot set headers, so the cursor rides the query
+		// string. The backend takes whichever of the two is furthest forward.
+		const cursor = this.lastSeq !== null ? `?after_seq=${this.lastSeq}` : "";
+		return `${this.baseUrl}${path}${cursor}`;
+	}
+
+	private setStatus(next: WebSocketConnectionStatus): void {
+		if (this.status === next) return;
+		this.status = next;
+		this.emit("status", next);
+	}
+
+	/**
+	 * A silent stream is a broken stream. The server heartbeats on a fixed
+	 * interval, so absence of traffic past the tolerance means the connection is
+	 * black-holed - typically a proxy that buffered it - and we should surface
+	 * that rather than spin forever showing a live indicator.
+	 */
+	private armStallTimer(): void {
+		this.clearStallTimer();
+		this.stallTimerId = window.setTimeout(() => {
+			this.emit(
+				"error",
+				new Error(
+					`SSE stream stalled: no traffic for ${this.options.stallTimeout}ms`,
+				),
+			);
+			this.setStatus("error");
+			this.emit("stalled");
+		}, this.options.stallTimeout);
+	}
+
+	private clearStallTimer(): void {
+		if (this.stallTimerId !== null) {
+			window.clearTimeout(this.stallTimerId);
+			this.stallTimerId = null;
+		}
+	}
+
+	public async connect(): Promise<void> {
+		if (this.source) return;
+		this.closedByServer = false;
+		this.setStatus("connecting");
+
+		return new Promise<void>((resolve) => {
+			let settled = false;
+			const settle = () => {
+				if (!settled) {
+					settled = true;
+					resolve();
+				}
+			};
+
+			const source = new EventSource(this.url());
+			this.source = source;
+
+			source.onopen = () => {
+				this.failedOpens = 0;
+				this.setStatus("connected");
+				this.armStallTimer();
+				settle();
+			};
+
+			source.onerror = () => {
+				this.clearStallTimer();
+				// A server-sent terminal frame closes the stream on purpose;
+				// EventSource reports that as an error, which it is not.
+				if (this.closedByServer) {
+					this.teardown();
+					this.setStatus("disconnected");
+					settle();
+					return;
+				}
+				// `CONNECTING` means EventSource is retrying by itself, which is
+				// the behaviour we want; anything else is terminal for this source.
+				if (source.readyState === EventSource.CONNECTING) {
+					this.failedOpens += 1;
+					if (
+						!this.options.autoReconnect ||
+						this.failedOpens > this.options.maxReconnectAttempts
+					) {
+						this.teardown();
+						this.setStatus("failed");
+						this.emit(
+							"error",
+							new Error(
+								`SSE reconnect gave up after ${this.failedOpens} attempts`,
+							),
+						);
+						settle();
+						return;
+					}
+					this.setStatus("reconnecting");
+					settle();
+					return;
+				}
+				this.teardown();
+				this.setStatus("error");
+				this.emit("error", new Error("SSE connection closed unexpectedly"));
+				settle();
+			};
+
+			// Named handlers rather than one `onmessage`: the backend always sets
+			// `event:`, and binding by name keeps unknown future events from
+			// being mistaken for records.
+			source.addEventListener(SseEventName.Open, (event) => {
+				this.armStallTimer();
+				const payload = this.parse<SseOpenPayload>(event);
+				if (!payload) return;
+				this.lastSeq = payload.last_seq > 0 ? payload.last_seq : this.lastSeq;
+				this.emit("open", payload);
+				// Repainting from the snapshot is what makes a reconnect - and a
+				// reported gap - self-healing: the records below are current
+				// state, not history, so the reducer converges without a refetch.
+				for (const record of payload.snapshot ?? []) {
+					this.emitRecord(record as SseRecordPayload["record"]);
+				}
+				settle();
+			});
+
+			const onRecord = (event: MessageEvent) => {
+				this.armStallTimer();
+				const payload = this.parse<SseRecordPayload>(event);
+				if (!payload?.record) return;
+				this.noteSeq(event);
+				this.emitRecord(payload.record);
+			};
+			source.addEventListener(SseEventName.RecordUpdate, onRecord);
+			source.addEventListener(SseEventName.RecordComplete, onRecord);
+
+			source.addEventListener(SseEventName.Terminal, (event) => {
+				this.noteSeq(event);
+				// The server has said there is nothing more. Closing here is what
+				// stops a finished turn from holding a connection open - the socket
+				// never closed on completion and left the client to infer it.
+				this.closedByServer = true;
+				this.clearStallTimer();
+				this.emit("terminal", this.parse(event));
+				this.teardown();
+				this.setStatus("disconnected");
+				settle();
+			});
+
+			source.addEventListener(SseEventName.Gap, (event) => {
+				const payload = this.parse<SseGapPayload>(event);
+				// Surfaced rather than swallowed: a consumer that knows it missed
+				// frames can reconcile over REST, while one that does not renders
+				// a hole forever. The snapshot on the next open usually repairs it
+				// anyway, so this is a signal, not a failure.
+				this.emit("gap", payload);
+			});
+
+			source.addEventListener(SseEventName.Error, (event) => {
+				const payload = this.parse<{ error?: string; retryable?: boolean }>(
+					event,
+				);
+				this.emit(
+					"error",
+					new Error(payload?.error ?? "SSE stream reported an error"),
+				);
+			});
+
+			// Additive richer events. Forwarded by name so a consumer can opt in;
+			// nothing in the current renderer requires them.
+			for (const name of [
+				SseEventName.MessageDelta,
+				SseEventName.ToolStart,
+				SseEventName.ToolDelta,
+				SseEventName.ToolEnd,
+				SseEventName.TurnStart,
+				SseEventName.TurnEnd,
+				SseEventName.AgentStart,
+				SseEventName.AgentEnd,
+				SseEventName.Notice,
+				SseEventName.JobStatus,
+			]) {
+				source.addEventListener(name, (event) => {
+					this.armStallTimer();
+					this.noteSeq(event);
+					this.emit(name, this.parse(event));
+				});
+			}
+		});
+	}
+
+	/**
+	 * Republish a record under the same event name and shape the socket used, so
+	 * a consumer cannot tell the transports apart.
+	 */
+	private emitRecord(record: SseRecordPayload["record"]): void {
+		const id = record.message_id ?? record.id;
+		this.emit(`update:${id}`, record);
+		// Also emit under the channel id: for a job channel the record ids differ
+		// from the channel, and a consumer keyed on what it subscribed to would
+		// otherwise never hear anything.
+		if (id !== this.channelId) {
+			this.emit(`update:${this.channelId}`, record);
+		}
+	}
+
+	private noteSeq(event: MessageEvent): void {
+		const raw = event.lastEventId;
+		if (!raw) return;
+		const seq = Number.parseInt(raw, 10);
+		if (Number.isFinite(seq)) {
+			this.lastSeq = seq;
+		}
+	}
+
+	private parse<T>(event: Event): T | null {
+		const data = (event as MessageEvent).data;
+		if (typeof data !== "string") return null;
+		try {
+			return JSON.parse(data) as T;
+		} catch {
+			// A malformed frame must not kill the stream; the next one may be fine.
+			this.emit("error", new Error("SSE frame was not valid JSON"));
+			return null;
+		}
+	}
+
+	private teardown(): void {
+		this.clearStallTimer();
+		if (this.source) {
+			this.source.close();
+			this.source = null;
+		}
+	}
+
+	public disconnect(): void {
+		this.teardown();
+		this.setStatus("disconnected");
+	}
+}

--- a/src/renderer/src/shared/api/local-operator/sse-api.ts
+++ b/src/renderer/src/shared/api/local-operator/sse-api.ts
@@ -65,6 +65,7 @@ export const SseEventName = {
 	AgentEnd: "agent.end",
 	Notice: "notice",
 	JobStatus: "job.status",
+	Keepalive: "keepalive",
 } as const;
 
 /** Body of `stream.open`: what you attached to, and the state as of attach. */
@@ -113,12 +114,21 @@ export type SseClientOptions = {
 	 * socket client could not detect at all.
 	 */
 	stallTimeout?: number;
+	/**
+	 * Milliseconds to wait for the first open before treating the connection as
+	 * black-holed (a proxy buffering the whole response, including headers - the
+	 * exact failure the fallback exists for). The socket client has
+	 * `connectionTimeout` for this; SSE needs the equivalent or `connect()` can
+	 * hang with the stall timer never armed (review C-03).
+	 */
+	openTimeout?: number;
 };
 
 const DEFAULT_OPTIONS: Required<SseClientOptions> = {
 	autoReconnect: true,
 	maxReconnectAttempts: 5,
 	stallTimeout: 45000,
+	openTimeout: 8000,
 };
 
 /** Channel kinds. Prefer `job` for new work; see the note on `messageId`. */
@@ -145,6 +155,9 @@ export class SseClient extends EventEmitter {
 	private lastSeq: number | null = null;
 	private stallTimerId: number | null = null;
 	private closedByServer = false;
+	/** Set once the socket has opened; the open-timeout only fires before this. */
+	private opened = false;
+	private openTimerId: number | null = null;
 
 	/**
 	 * @param baseUrl - Base URL of the Local Operator API.
@@ -225,9 +238,17 @@ export class SseClient extends EventEmitter {
 		}
 	}
 
+	private clearOpenTimer(): void {
+		if (this.openTimerId !== null) {
+			window.clearTimeout(this.openTimerId);
+			this.openTimerId = null;
+		}
+	}
+
 	public async connect(): Promise<void> {
 		if (this.source) return;
 		this.closedByServer = false;
+		this.opened = false;
 		this.setStatus("connecting");
 
 		return new Promise<void>((resolve) => {
@@ -242,7 +263,24 @@ export class SseClient extends EventEmitter {
 			const source = new EventSource(this.url());
 			this.source = source;
 
+			// A proxy can hold the entire response (headers included), in which
+			// case neither onopen nor onerror fires and the stall timer is never
+			// armed. Bound the first open so that case degrades to the fallback
+			// instead of hanging in `connecting` (review C-03).
+			this.openTimerId = window.setTimeout(() => {
+				if (this.opened) return;
+				this.teardown();
+				this.setStatus("error");
+				this.emit(
+					"error",
+					new Error(`SSE open timed out after ${this.options.openTimeout}ms`),
+				);
+				settle();
+			}, this.options.openTimeout);
+
 			source.onopen = () => {
+				this.opened = true;
+				this.clearOpenTimer();
 				this.failedOpens = 0;
 				this.setStatus("connected");
 				this.armStallTimer();
@@ -368,6 +406,13 @@ export class SseClient extends EventEmitter {
 					this.emit(name, this.parse(event));
 				});
 			}
+
+			// The liveness tick. It is a real event (not a comment) precisely so
+			// this handler fires and re-arms the stall detector; a healthy quiet
+			// turn must not read as a dead connection (review C-01).
+			source.addEventListener(SseEventName.Keepalive, () => {
+				this.armStallTimer();
+			});
 		});
 	}
 
@@ -401,14 +446,16 @@ export class SseClient extends EventEmitter {
 		try {
 			return JSON.parse(data) as T;
 		} catch {
-			// A malformed frame must not kill the stream; the next one may be fine.
-			this.emit("error", new Error("SSE frame was not valid JSON"));
+			// Parity with the socket path, which only logs a bad frame: a parse
+			// quirk must not flip the consumer into a visible error state (C-06).
+			console.error("[sse] frame was not valid JSON");
 			return null;
 		}
 	}
 
 	private teardown(): void {
 		this.clearStallTimer();
+		this.clearOpenTimer();
 		if (this.source) {
 			this.source.close();
 			this.source = null;

--- a/src/renderer/src/shared/api/local-operator/streaming-transport.ts
+++ b/src/renderer/src/shared/api/local-operator/streaming-transport.ts
@@ -171,6 +171,8 @@ export class StreamingClient extends EventEmitter {
 	private disposed = false;
 	/** True once any frame arrived, so a later error is a blip, not a verdict. */
 	private delivered = false;
+	/** True while a connect is in flight, so overlapping calls no-op (C-02). */
+	private connecting = false;
 
 	constructor(
 		baseUrl: string,
@@ -193,20 +195,30 @@ export class StreamingClient extends EventEmitter {
 	}
 
 	public async connect(): Promise<void> {
-		if (this.disposed || this.active) return;
+		// `connecting` closes the window in which two callers (React StrictMode
+		// double-mount, an unmount racing a mount) both pass the guard and start
+		// duplicate transports; the re-check after the probe await stops a dispose
+		// that lands mid-probe from opening a connection nobody tears down (C-02).
+		if (this.disposed || this.active || this.connecting) return;
+		this.connecting = true;
+		try {
+			const forced = this.options.force;
+			let useSse = forced === "sse";
+			if (!forced) {
+				const state = await probeStreamingCapabilities(this.baseUrl);
+				if (this.disposed) return;
+				useSse = state.capabilities !== null && !state.sseProvenBroken;
+			}
+			if (this.disposed) return;
 
-		const forced = this.options.force;
-		let useSse = forced === "sse";
-		if (!forced) {
-			const state = await probeStreamingCapabilities(this.baseUrl);
-			useSse = state.capabilities !== null && !state.sseProvenBroken;
+			if (useSse) {
+				await this.startSse();
+				return;
+			}
+			await this.startWebSocket();
+		} finally {
+			this.connecting = false;
 		}
-
-		if (useSse) {
-			await this.startSse();
-			return;
-		}
-		await this.startWebSocket();
 	}
 
 	private async startSse(): Promise<void> {
@@ -315,7 +327,15 @@ export class StreamingClient extends EventEmitter {
 			this.active = null;
 		}
 		this.kind = null;
-		await this.startWebSocket();
+		try {
+			await this.startWebSocket();
+		} catch (error) {
+			// The WS client has already emitted its own `error`/`status` through
+			// `bind`; swallowing the rejection here is what keeps `void
+			// this.fallback(...)` from becoming an unhandled promise rejection
+			// with the backend down at downgrade time (review C-05).
+			console.error("[streaming] websocket fallback failed:", error);
+		}
 	}
 
 	public disconnect(): void {

--- a/src/renderer/src/shared/api/local-operator/streaming-transport.ts
+++ b/src/renderer/src/shared/api/local-operator/streaming-transport.ts
@@ -1,0 +1,329 @@
+/**
+ * Transport selection: prefer SSE, fall back to WebSockets, decide once.
+ *
+ * ## The problem this solves
+ *
+ * A given renderer build may face a backend that predates the SSE surface, and
+ * a given backend may sit behind a proxy that breaks `text/event-stream` even
+ * though the route exists. Those are different failures and both must degrade to
+ * the socket without the consumer noticing:
+ *
+ * - **Backend too old** — `GET /v1/sse/capabilities` 404s. Detected once per
+ *   backend URL and cached, so the probe costs one request per session rather
+ *   than one per streamed message.
+ * - **Transport broken in transit** — capabilities answered, but the stream
+ *   never delivers a frame (a buffering proxy, a blocked EventSource). Detected
+ *   per connection: if the first attempt produces no frame, this falls back to a
+ *   socket for that message and remembers the failure so subsequent messages in
+ *   the session skip the doomed attempt.
+ *
+ * Both clients expose the same emitter surface (`status`, `update:<id>`,
+ * `error`, plus `connect`/`disconnect`/`getStatus`), so the wrapper below is a
+ * router, not an adapter — there is no second rendering path to maintain.
+ *
+ * ## Why the failure is remembered rather than retried per message
+ *
+ * The renderer opens one client per streaming message. Retrying a transport that
+ * has already proven broken would add a stall to the start of every message the
+ * user sends, which is worse than using the working transport immediately.
+ * `resetTransportCache()` exists so a settings change or a reconnect to a
+ * different backend can re-probe.
+ */
+
+import {
+	type SseChannelKind,
+	SseClient,
+	type SseClientOptions,
+} from "./sse-api";
+import {
+	EventEmitter,
+	WebSocketClient,
+	type WebSocketConnectionOptions,
+	type WebSocketConnectionStatus,
+	WebsocketConnectionType,
+} from "./websocket-api";
+
+/** Trailing slashes on a configured base URL would double up in every path. */
+const TRAILING_SLASHES = /\/+$/;
+
+/** What a backend said it supports. */
+export type StreamingCapabilities = {
+	transports: string[];
+	preferred: string;
+	sse?: {
+		version: number;
+		channels: Record<string, string>;
+		resume: {
+			last_event_id: boolean;
+			query_param: string;
+			replay_buffer: number;
+		};
+		heartbeat_interval_s: number;
+		retry_hint_ms: number;
+		events: string[];
+		legacy_record_frames: boolean;
+	};
+	websocket?: { channels: Record<string, string>; deprecated?: boolean };
+};
+
+/** Which transport a client ended up using, for diagnostics and tests. */
+export type StreamingTransportKind = "sse" | "websocket";
+
+type ProbeState = {
+	/** Resolved capabilities, or null when the backend has no SSE surface. */
+	capabilities: StreamingCapabilities | null;
+	/** Set once SSE was tried and produced nothing usable on this backend. */
+	sseProvenBroken: boolean;
+};
+
+const probes = new Map<string, Promise<ProbeState>>();
+const states = new Map<string, ProbeState>();
+
+/** Probe timeout. Long enough for a cold local backend, short enough that a
+ *  hung probe does not delay the first render behind it. */
+const PROBE_TIMEOUT_MS = 2500;
+
+/**
+ * Ask a backend what it supports, once per base URL.
+ *
+ * A 404 is the expected answer from an older backend and is not an error; any
+ * other failure is treated the same way, because the only safe interpretation of
+ * "cannot determine" is "use the transport that has always existed".
+ */
+export const probeStreamingCapabilities = (
+	baseUrl: string,
+): Promise<ProbeState> => {
+	const key = baseUrl.replace(TRAILING_SLASHES, "");
+	const existing = probes.get(key);
+	if (existing) return existing;
+
+	const probe = (async (): Promise<ProbeState> => {
+		const controller = new AbortController();
+		const timeoutId = window.setTimeout(
+			() => controller.abort(),
+			PROBE_TIMEOUT_MS,
+		);
+		try {
+			const response = await fetch(`${key}/v1/sse/capabilities`, {
+				signal: controller.signal,
+			});
+			if (!response.ok) {
+				return { capabilities: null, sseProvenBroken: false };
+			}
+			const capabilities = (await response.json()) as StreamingCapabilities;
+			const supported = capabilities?.transports?.includes("sse") ?? false;
+			return {
+				capabilities: supported ? capabilities : null,
+				sseProvenBroken: false,
+			};
+		} catch {
+			return { capabilities: null, sseProvenBroken: false };
+		} finally {
+			window.clearTimeout(timeoutId);
+		}
+	})();
+
+	probes.set(key, probe);
+	probe.then((state) => states.set(key, state)).catch(() => undefined);
+	return probe;
+};
+
+/**
+ * Forget what we learned about a backend.
+ *
+ * Needed when the API URL changes or a backend restarts with a different build:
+ * a cached "no SSE here" would otherwise outlive the condition that caused it.
+ */
+export const resetTransportCache = (baseUrl?: string): void => {
+	if (baseUrl) {
+		const key = baseUrl.replace(TRAILING_SLASHES, "");
+		probes.delete(key);
+		states.delete(key);
+		return;
+	}
+	probes.clear();
+	states.clear();
+};
+
+export type StreamingClientOptions = {
+	/** Passed to whichever transport is chosen. */
+	websocket?: WebSocketConnectionOptions;
+	sse?: SseClientOptions;
+	/** Channel namespace for SSE. The socket only has message channels. */
+	channelKind?: SseChannelKind;
+	/** Force a transport, bypassing the probe. For tests and diagnostics. */
+	force?: StreamingTransportKind;
+};
+
+/**
+ * One streaming connection, routed to whichever transport works.
+ *
+ * Listeners attached before {@link connect} are re-attached to the transport
+ * actually chosen — including across a mid-flight fallback — so a consumer
+ * subscribes once and never learns which transport delivered its events.
+ */
+export class StreamingClient extends EventEmitter {
+	private readonly baseUrl: string;
+	private readonly channelId: string;
+	private readonly options: StreamingClientOptions;
+	private active: SseClient | WebSocketClient | null = null;
+	private kind: StreamingTransportKind | null = null;
+	private disposed = false;
+	/** True once any frame arrived, so a later error is a blip, not a verdict. */
+	private delivered = false;
+
+	constructor(
+		baseUrl: string,
+		channelId: string,
+		options: StreamingClientOptions = {},
+	) {
+		super();
+		this.baseUrl = baseUrl.replace(TRAILING_SLASHES, "");
+		this.channelId = channelId;
+		this.options = options;
+	}
+
+	/** Which transport is in use, or null before the first connect. */
+	public getTransport(): StreamingTransportKind | null {
+		return this.kind;
+	}
+
+	public getStatus(): WebSocketConnectionStatus {
+		return this.active?.getStatus() ?? "disconnected";
+	}
+
+	public async connect(): Promise<void> {
+		if (this.disposed || this.active) return;
+
+		const forced = this.options.force;
+		let useSse = forced === "sse";
+		if (!forced) {
+			const state = await probeStreamingCapabilities(this.baseUrl);
+			useSse = state.capabilities !== null && !state.sseProvenBroken;
+		}
+
+		if (useSse) {
+			await this.startSse();
+			return;
+		}
+		await this.startWebSocket();
+	}
+
+	private async startSse(): Promise<void> {
+		const client = new SseClient(
+			this.baseUrl,
+			this.channelId,
+			this.options.sse,
+			this.options.channelKind ?? "message",
+		);
+		this.active = client;
+		this.kind = "sse";
+		this.bind(client);
+
+		// A stream that opens and then goes silent is the proxy-buffering case.
+		// Treat it as "SSE does not work here" exactly once, then switch - but
+		// only if nothing was ever delivered, because a mid-turn blip on a
+		// working stream should reconnect, not change transport.
+		client.on("stalled", () => {
+			if (!this.delivered)
+				void this.fallback("stream stalled before any frame");
+		});
+		client.on("status", (next: unknown) => {
+			if ((next === "failed" || next === "error") && !this.delivered) {
+				void this.fallback(`sse status became ${String(next)}`);
+			}
+		});
+
+		await client.connect();
+	}
+
+	private async startWebSocket(): Promise<void> {
+		const client = new WebSocketClient(
+			this.baseUrl,
+			this.channelId,
+			this.options.websocket,
+			WebsocketConnectionType.MESSAGE,
+		);
+		this.active = client;
+		this.kind = "websocket";
+		this.bind(client);
+		await client.connect();
+	}
+
+	/**
+	 * Re-emit everything the active transport produces.
+	 *
+	 * A wildcard forward is not available on this emitter, so the event names are
+	 * listed. `update:<channelId>` is the one the renderer consumes; the rest are
+	 * forwarded so diagnostics and future consumers see the same stream on either
+	 * transport.
+	 */
+	private bind(client: SseClient | WebSocketClient): void {
+		const forwarded = [
+			"status",
+			"error",
+			`update:${this.channelId}`,
+			"open",
+			"terminal",
+			"gap",
+			"message.delta",
+			"tool.start",
+			"tool.delta",
+			"tool.end",
+			"turn.start",
+			"turn.end",
+			"agent.start",
+			"agent.end",
+			"notice",
+			"job.status",
+		];
+		for (const name of forwarded) {
+			client.on(name, (...args: unknown[]) => {
+				if (name === `update:${this.channelId}`) {
+					this.delivered = true;
+				}
+				this.emit(name, ...args);
+			});
+		}
+	}
+
+	/**
+	 * Abandon SSE for the socket, once, and remember it for this backend.
+	 *
+	 * Deliberately silent to the consumer beyond a status change: a transport
+	 * downgrade is an infrastructure detail, and surfacing it as an error would
+	 * make a recoverable condition look like a failed turn.
+	 */
+	private async fallback(reason: string): Promise<void> {
+		if (this.disposed || this.kind !== "sse") return;
+		const key = this.baseUrl;
+		const state = states.get(key);
+		if (state) {
+			state.sseProvenBroken = true;
+		} else {
+			states.set(key, { capabilities: null, sseProvenBroken: true });
+			probes.set(
+				key,
+				Promise.resolve({ capabilities: null, sseProvenBroken: true }),
+			);
+		}
+		console.warn(`[streaming] falling back to websocket: ${reason}`);
+
+		if (this.active) {
+			this.active.removeAllListeners();
+			this.active.disconnect();
+			this.active = null;
+		}
+		this.kind = null;
+		await this.startWebSocket();
+	}
+
+	public disconnect(): void {
+		this.disposed = true;
+		if (this.active) {
+			this.active.removeAllListeners();
+			this.active.disconnect();
+			this.active = null;
+		}
+	}
+}

--- a/src/renderer/src/shared/api/local-operator/websocket-api.ts
+++ b/src/renderer/src/shared/api/local-operator/websocket-api.ts
@@ -21,8 +21,11 @@ export enum WebsocketConnectionType {
 	HEALTH = "health",
 }
 
-// Using a browser-compatible EventEmitter implementation
-class EventEmitter {
+// Using a browser-compatible EventEmitter implementation.
+// Exported because the SSE transport (`sse-api.ts`) presents the same
+// emitter surface, which is what lets a consumer hold either transport
+// behind one reference and stay unaware of which is in use.
+export class EventEmitter {
 	private events: Record<string, Array<(...args: unknown[]) => void>> = {};
 
 	public on(event: string, listener: (...args: unknown[]) => void): this {

--- a/src/renderer/src/shared/hooks/use-websocket-message.ts
+++ b/src/renderer/src/shared/hooks/use-websocket-message.ts
@@ -239,6 +239,11 @@ export const useWebSocketMessage = (
 		client.on("status", (newStatus: unknown) => {
 			const typedStatus = newStatus as WebSocketConnectionStatus;
 			setStatus(typedStatus);
+			// A transport that (re)connects — including a silent SSE→WebSocket
+			// downgrade — must not leave a stale error banner over a working
+			// stream; the hook only otherwise clears `error` on a manual connect
+			// (review C-04).
+			if (typedStatus === "connected") setError(null);
 			callbackRefs.current.onStatusChange?.(typedStatus);
 		});
 

--- a/src/renderer/src/shared/hooks/use-websocket-message.ts
+++ b/src/renderer/src/shared/hooks/use-websocket-message.ts
@@ -1,13 +1,18 @@
 /**
- * Hook for managing WebSocket connections to stream message updates
+ * Hook for streaming message updates.
+ *
+ * The transport is chosen at connect time by `StreamingClient`: SSE where the
+ * backend offers it, the WebSocket otherwise. Both present the same emitter
+ * surface, so everything below this line — the rAF coalescing, the equality
+ * gate, the completion handling — is identical on either, and the name is kept
+ * so no call site changes.
  */
 import { useCallback, useEffect, useRef, useState } from "react";
+import { StreamingClient } from "../api/local-operator/streaming-transport";
 import type { AgentExecutionRecord } from "../api/local-operator/types";
-import {
-	type UpdateMessage,
-	WebSocketClient,
-	type WebSocketConnectionStatus,
-	WebsocketConnectionType,
+import type {
+	UpdateMessage,
+	WebSocketConnectionStatus,
 } from "../api/local-operator/websocket-api";
 
 type CallbackRefs = {
@@ -161,7 +166,7 @@ export const useWebSocketMessage = (
 	const [error, setError] = useState<Error | null>(null);
 	const [isLoading, setIsLoading] = useState(false);
 
-	const clientRef = useRef<WebSocketClient | null>(null);
+	const clientRef = useRef<StreamingClient | null>(null);
 	const pendingRef = useRef<AgentExecutionRecord | null>(null);
 	const appliedRef = useRef<AgentExecutionRecord | null>(null);
 	const frameRef = useRef<number | null>(null);
@@ -220,18 +225,16 @@ export const useWebSocketMessage = (
 			return clientRef.current;
 		}
 
-		const client = new WebSocketClient(
-			baseUrl,
-			messageId,
-			{
+		const client = new StreamingClient(baseUrl, messageId, {
+			websocket: {
 				autoReconnect,
 				reconnectInterval,
 				maxReconnectAttempts,
 				pingInterval,
 				messageDelay: 250,
 			},
-			WebsocketConnectionType.MESSAGE,
-		);
+			sse: { autoReconnect, maxReconnectAttempts },
+		});
 
 		client.on("status", (newStatus: unknown) => {
 			const typedStatus = newStatus as WebSocketConnectionStatus;


### PR DESCRIPTION
Migrates the renderer from WebSockets to **Server-Sent Events**, with automatic
fallback. Everything above the transport — the rAF coalescing, equality gate,
global registry, stores, rendering — is unchanged, because both transports
present the same emitter surface.

## Why

The socket only ever carried server-to-client data. The one frame the client
sent upstream was a keepalive `ping`; cancellation was already HTTP
(`JobsApi.cancelJob`). SSE costs no capability and buys three things:

- **Resume with a cursor.** `EventSource` reconnects and replays
  `Last-Event-ID`, continuing at the exact event. The socket had no sequence.
- **Plain HTTP.** No upgrade handshake — proxies and the Vite dev server just
  work.
- **Server keepalive + stall detection.** The backend heartbeats every 15s, so
  a black-holed connection is noticed instead of shown as live.

## How

`StreamingClient` probes `GET /v1/sse/capabilities` (404 = no SSE, the whole
fallback signal), caches per base URL, and falls back mid-flight if an
advertised stream opens and produces nothing. `useWebSocketMessage` now builds a
`StreamingClient`; no call site changes.

| File | Role |
| --- | --- |
| `sse-api.ts` | `SseClient` over EventSource, mirroring `WebSocketClient`'s surface |
| `streaming-transport.ts` | selection + mid-flight fallback |
| `use-websocket-message.ts` | builds a `StreamingClient` |
| `websocket-api.ts` | `EventEmitter` exported (one line) |
| `sse-transport.stories.tsx` | no-backend fixture for all four paths |
| `docs/sse-migration.md` | wire contract + how to develop against the backend |

## Compatibility

`record.update`/`record.complete` carry the legacy `CodeExecutionResult` dump
verbatim (including the injected `message_id`/`connection_type`), republished
under `update:<messageId>` unchanged — a consumer cannot tell the transports
apart. A backend without the route 404s and the socket is used as before.

Fidelity gained additively: `message.delta`, `tool.*`, `turn.*`, `job.status`,
`notice`, and a `GET /v1/sse/jobs/{job_id}` channel openable before any record
id exists (removes the attach race).

## Backend

`~/local-operator`, branch `feat/harness-rewrite` (commit `27cebcc`).
`local-operator serve --port 1111`. Full wire contract and dev recipe in
`docs/sse-migration.md`.

## Evidence

Verified live against that backend (port 1177): probe selects `sse`, a real turn
streams records carrying the answer and legacy keys then closes on
`stream.terminal`, an SSE-less backend falls back, and a dead stream falls back
too. Storybook fixture (`Chat/SSE transport`) shows all four paths with no
backend. Backend's own evidence (resume across a real disconnect, late-attach
snapshot, fan-out, WS/SSE record parity) is in `docs/VERIFICATION.md` there.

Typecheck and biome clean.

---

Intended to be merged into `refactor/tailwind-shadcn-rebuild`. I could not
message the Tailwind session directly (it runs in a separate process), so this
PR is the coordination point — the diff is a drop-in and the doc has the full
contract. Happy to rebase onto whatever lands first.
