### PR TITLE
fix(ci): recover signed installers from immutable release tags

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -60,6 +60,11 @@ jobs:
       - name: Check CodeMirror insertion previews
         run: pnpm check-edit-diffs
 
+      - name: Check immutable release recovery contracts
+        run: |
+          node scripts/test-validate-release.mjs
+          node --test scripts/test-release-safety.mjs scripts/test-publish-workflow.mjs
+
   audit:
     name: Security Audit
     runs-on: ubuntu-latest

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -11,8 +11,16 @@ on:
         type: string
       expected_source_sha:
         description: 'Full 40-char commit SHA the tag must point to (required for manual dispatch)'
-        required: false
+        required: true
         type: string
+
+# Serialize normal publishing and manual repairs for the same release tag.
+concurrency:
+  group: publish-${{ github.event.release.tag_name || inputs.release_tag }}
+  cancel-in-progress: false
+
+env:
+  NOTARIZE: 'true'
 
 permissions:
   contents: write
@@ -32,6 +40,9 @@ jobs:
       - name: Checkout workflow scripts
         uses: actions/checkout@v4
         with:
+          # Recovery payloads predate these helpers. Use the workflow's reviewed
+          # commit for tooling, never the old app tag or a moving branch name.
+          ref: ${{ github.workflow_sha }}
           sparse-checkout: scripts/validate-release.mjs
           sparse-checkout-cone-mode: false
 
@@ -41,6 +52,7 @@ jobs:
           RELEASE_TAG: ${{ github.event_name == 'workflow_dispatch' && inputs.release_tag || github.event.release.tag_name }}
           EXPECTED_SOURCE_SHA: ${{ github.event_name == 'workflow_dispatch' && inputs.expected_source_sha || '' }}
           IS_MANUAL_DISPATCH: ${{ github.event_name == 'workflow_dispatch' }}
+          EXPECTED_RELEASE_ID: ${{ github.event_name == 'release' && github.event.release.id || '' }}
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: node scripts/validate-release.mjs
 
@@ -59,6 +71,10 @@ jobs:
           CSC_KEY_PASSWORD: ${{ secrets.CSC_KEY_PASSWORD }}
           KEYCHAIN_PASSWORD: ${{ secrets.KEYCHAIN_PASSWORD }}
         run: |
+          if [ "$NOTARIZE" != true ]; then
+            echo 'NOTARIZE must be true'
+            exit 1
+          fi
           for var in APPLE_ID APPLE_ID_PASSWORD APPLE_TEAM_ID CSC_CONTENT CSC_KEY_PASSWORD KEYCHAIN_PASSWORD; do
             if [ -z "${!var}" ]; then
               echo "Missing required secret: $var"
@@ -71,7 +87,7 @@ jobs:
     name: Build and Publish to NPM
     runs-on: ubuntu-latest
     needs: validate-release
-    if: ${{ needs.validate-release.result == 'success' && github.event_name == 'release' && github.event.release.prerelease == false }}
+    if: ${{ needs.validate-release.result == 'success' }}
     permissions:
       id-token: write
       contents: read
@@ -95,29 +111,36 @@ jobs:
           registry-url: 'https://registry.npmjs.org'
 
       - name: Ensure npm supports trusted publishing
+        if: github.event_name == 'release'
         run: |
           npm install -g npm@^11.5.1
           npm --version
 
       - name: Install dependencies
+        if: github.event_name == 'release'
         run: pnpm install --frozen-lockfile
 
       - name: Check if version already published
         id: check_version
+        env:
+          IS_MANUAL_DISPATCH: ${{ github.event_name == 'workflow_dispatch' }}
         run: |
           PKG_NAME=$(jq -r .name package.json)
           PKG_VERSION=$(jq -r .version package.json)
           echo "Package: $PKG_NAME, Version: $PKG_VERSION"
-          if npm view "$PKG_NAME@$PKG_VERSION" > /dev/null 2>&1; then
+          if PUBLISHED_VERSION=$(npm view "$PKG_NAME@$PKG_VERSION" version 2>/dev/null) && [ "$PUBLISHED_VERSION" = "$PKG_VERSION" ]; then
             echo "Version $PKG_VERSION already published."
-            echo "published=true" >> $GITHUB_OUTPUT
+            echo "published=true" >> "$GITHUB_OUTPUT"
+          elif [ "$IS_MANUAL_DISPATCH" = true ]; then
+            echo 'Manual repair requires the matching npm version to already exist; refusing publish.'
+            exit 1
           else
             echo "Version $PKG_VERSION not published yet."
-            echo "published=false" >> $GITHUB_OUTPUT
+            echo "published=false" >> "$GITHUB_OUTPUT"
           fi
 
       - name: Publish to npm
-        if: steps.check_version.outputs.published == 'false'
+        if: github.event_name == 'release' && steps.check_version.outputs.published == 'false'
         run: npm publish --provenance
         env:
           VITE_GOOGLE_CLIENT_ID: ${{ secrets.GOOGLE_CLIENT_ID }}
@@ -152,29 +175,35 @@ jobs:
         run: pnpm install --frozen-lockfile
 
       - name: Setup code signing
+        env:
+          CSC_CONTENT: ${{ secrets.CSC_CONTENT }}
+          CSC_KEY_PASSWORD: ${{ secrets.CSC_KEY_PASSWORD }}
+          KEYCHAIN_PASSWORD: ${{ secrets.KEYCHAIN_PASSWORD }}
         run: |
-          echo "${{ secrets.CSC_CONTENT }}" | base64 --decode > certificate.p12
-          security create-keychain -p "${{ secrets.KEYCHAIN_PASSWORD }}" build.keychain
-          security default-keychain -s build.keychain
-          security unlock-keychain -p "${{ secrets.KEYCHAIN_PASSWORD }}" build.keychain
-          security import certificate.p12 -k build.keychain -P "${{ secrets.CSC_KEY_PASSWORD }}" -T /usr/bin/codesign
-          security set-key-partition-list -S apple-tool:,apple:,codesign:,notarize: -s -k "${{ secrets.KEYCHAIN_PASSWORD }}" build.keychain
-          rm certificate.p12
+          CSC_KEYCHAIN="$RUNNER_TEMP/build.keychain-db"
+          echo "CSC_KEYCHAIN=$CSC_KEYCHAIN" >> "$GITHUB_ENV"
+          CERTIFICATE="$RUNNER_TEMP/certificate.p12"
+          trap 'rm -f "$CERTIFICATE"' EXIT
+          printf '%s' "$CSC_CONTENT" | base64 --decode > "$CERTIFICATE"
+          security create-keychain -p "$KEYCHAIN_PASSWORD" "$CSC_KEYCHAIN"
+          security default-keychain -s "$CSC_KEYCHAIN"
+          security unlock-keychain -p "$KEYCHAIN_PASSWORD" "$CSC_KEYCHAIN"
+          security import "$CERTIFICATE" -k "$CSC_KEYCHAIN" -P "$CSC_KEY_PASSWORD" -T /usr/bin/codesign
+          security set-key-partition-list -S apple-tool:,apple:,codesign:,notarize: -s -k "$KEYCHAIN_PASSWORD" "$CSC_KEYCHAIN"
 
       - name: Setup python distributable
         run: |
           pnpm setup-python
 
       - name: Build macOS app
-        run: pnpm dist:mac -- -c.forceCodeSigning=true
+        # pnpm forwards a literal -- to electron-builder; the config must precede it.
+        run: pnpm dist:mac -c.forceCodeSigning=true
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          CSC_KEYCHAIN: build.keychain
           CSC_KEY_PASSWORD: ${{ secrets.CSC_KEY_PASSWORD }}
           APPLE_ID: ${{ secrets.APPLE_ID }}
           APPLE_ID_PASSWORD: ${{ secrets.APPLE_ID_PASSWORD }}
           APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
-          NOTARIZE: true
           VITE_GOOGLE_CLIENT_ID: ${{ secrets.GOOGLE_CLIENT_ID }}
           VITE_GOOGLE_CLIENT_SECRET: ${{ secrets.GOOGLE_CLIENT_SECRET }}
           VITE_MICROSOFT_CLIENT_ID: ${{ secrets.MICROSOFT_CLIENT_ID }}
@@ -188,6 +217,7 @@ jobs:
             dist/*.dmg
             dist/*.zip
             dist/latest*.yml
+          if-no-files-found: error
           retention-days: 5
 
   build-windows:
@@ -240,6 +270,7 @@ jobs:
             dist/*.exe
             dist/*.msi
             dist/latest*.yml
+          if-no-files-found: error
           retention-days: 5
 
   build-linux:
@@ -286,6 +317,7 @@ jobs:
             dist/*.AppImage
             dist/*.rpm
             dist/latest*.yml
+          if-no-files-found: error
           retention-days: 5
 
   attach-to-release:
@@ -295,43 +327,27 @@ jobs:
     if: ${{ needs.validate-release.result == 'success' && needs.build-macos.result == 'success' && needs.build-windows.result == 'success' && needs.build-linux.result == 'success' }}
 
     steps:
+      - name: Checkout workflow scripts
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.workflow_sha }}
+          path: workflow
+          sparse-checkout: |
+            scripts/validate-release.mjs
+            scripts/upload-release.mjs
+          sparse-checkout-cone-mode: false
+
       - name: Download all artifacts
         uses: actions/download-artifact@v4
         with:
           path: artifacts
 
-      - name: Revalidate release target
-        id: revalidate
+      # POST only to the pinned ID: release actions may create releases, update
+      # metadata, or replace assets. A repair must do none of those things.
+      - name: Revalidate and attach artifacts to existing release
         env:
           RELEASE_TAG: ${{ needs.validate-release.outputs.release_tag }}
           EXPECTED_SOURCE_SHA: ${{ needs.validate-release.outputs.source_sha }}
+          EXPECTED_RELEASE_ID: ${{ needs.validate-release.outputs.release_id }}
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: node scripts/validate-release.mjs
-
-      - name: Check asset collisions
-        run: |
-          TAG="${{ needs.validate-release.outputs.release_tag }}"
-          EXISTING=$(gh api "repos/${{ github.repository }}/releases/tags/$TAG" --jq '.assets[].name')
-          NEW=$(find artifacts -type f -exec basename {} \; | sort -u)
-          COLLISIONS=$(comm -12 <(echo "$EXISTING" | sort) <(echo "$NEW" | sort))
-          if [ -n "$COLLISIONS" ]; then
-            echo "Asset filename collisions detected:"
-            echo "$COLLISIONS"
-            exit 1
-          fi
-          echo "No asset collisions"
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Attach artifacts to release
-        uses: softprops/action-gh-release@v1
-        with:
-          files: |
-            artifacts/macos-artifacts/*
-            artifacts/windows-artifacts/*
-            artifacts/linux-artifacts/*
-          tag_name: ${{ needs.validate-release.outputs.release_tag }}
-          draft: false
-          prerelease: ${{ needs.validate-release.outputs.prerelease == 'true' }}
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: node workflow/scripts/upload-release.mjs

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -5,23 +5,73 @@ on:
     types: [published]
   workflow_dispatch:
     inputs:
-      release_type:
-        description: 'Release Type'
+      release_tag:
+        description: 'Published release tag (vX.Y.Z)'
         required: true
-        default: 'draft'
-        type: choice
-        options:
-          - draft
-          - prerelease
-          - release
+        type: string
+      expected_source_sha:
+        description: 'Full 40-char commit SHA the tag must point to (required for manual dispatch)'
+        required: false
+        type: string
 
 permissions:
   contents: write
 
 jobs:
+  validate-release:
+    name: Validate release target
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    outputs:
+      source_sha: ${{ steps.validate.outputs.source_sha }}
+      release_tag: ${{ steps.validate.outputs.release_tag }}
+      release_id: ${{ steps.validate.outputs.release_id }}
+      prerelease: ${{ steps.validate.outputs.prerelease }}
+    steps:
+      - name: Checkout workflow scripts
+        uses: actions/checkout@v4
+        with:
+          sparse-checkout: scripts/validate-release.mjs
+          sparse-checkout-cone-mode: false
+
+      - name: Validate release target
+        id: validate
+        env:
+          RELEASE_TAG: ${{ github.event_name == 'workflow_dispatch' && inputs.release_tag || github.event.release.tag_name }}
+          EXPECTED_SOURCE_SHA: ${{ github.event_name == 'workflow_dispatch' && inputs.expected_source_sha || '' }}
+          IS_MANUAL_DISPATCH: ${{ github.event_name == 'workflow_dispatch' }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: node scripts/validate-release.mjs
+
+  preflight-macos:
+    name: Preflight macOS signing
+    runs-on: ubuntu-latest
+    needs: validate-release
+    if: ${{ needs.validate-release.result == 'success' }}
+    steps:
+      - name: Check required secrets
+        env:
+          APPLE_ID: ${{ secrets.APPLE_ID }}
+          APPLE_ID_PASSWORD: ${{ secrets.APPLE_ID_PASSWORD }}
+          APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
+          CSC_CONTENT: ${{ secrets.CSC_CONTENT }}
+          CSC_KEY_PASSWORD: ${{ secrets.CSC_KEY_PASSWORD }}
+          KEYCHAIN_PASSWORD: ${{ secrets.KEYCHAIN_PASSWORD }}
+        run: |
+          for var in APPLE_ID APPLE_ID_PASSWORD APPLE_TEAM_ID CSC_CONTENT CSC_KEY_PASSWORD KEYCHAIN_PASSWORD; do
+            if [ -z "${!var}" ]; then
+              echo "Missing required secret: $var"
+              exit 1
+            fi
+          done
+          echo "All macOS signing secrets present"
+
   npm-publish:
     name: Build and Publish to NPM
     runs-on: ubuntu-latest
+    needs: validate-release
+    if: ${{ needs.validate-release.result == 'success' && github.event_name == 'release' && github.event.release.prerelease == false }}
     permissions:
       id-token: write
       contents: read
@@ -29,6 +79,8 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
+        with:
+          ref: ${{ needs.validate-release.outputs.source_sha }}
 
       - name: Install pnpm
         uses: pnpm/action-setup@v4
@@ -76,11 +128,14 @@ jobs:
   build-macos:
     name: Build macOS App
     runs-on: macos-latest
-    needs: npm-publish
+    needs: [validate-release, preflight-macos, npm-publish]
+    if: ${{ needs.validate-release.result == 'success' && needs.preflight-macos.result == 'success' && needs.npm-publish.result == 'success' }}
 
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
+        with:
+          ref: ${{ needs.validate-release.outputs.source_sha }}
 
       - name: Install pnpm
         uses: pnpm/action-setup@v4
@@ -104,16 +159,16 @@ jobs:
           security unlock-keychain -p "${{ secrets.KEYCHAIN_PASSWORD }}" build.keychain
           security import certificate.p12 -k build.keychain -P "${{ secrets.CSC_KEY_PASSWORD }}" -T /usr/bin/codesign
           security set-key-partition-list -S apple-tool:,apple:,codesign:,notarize: -s -k "${{ secrets.KEYCHAIN_PASSWORD }}" build.keychain
+          rm certificate.p12
 
       - name: Setup python distributable
         run: |
           pnpm setup-python
 
       - name: Build macOS app
-        run: pnpm dist:mac
+        run: pnpm dist:mac -- -c.forceCodeSigning=true
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          CSC_LINK: ./certificate.p12
           CSC_KEYCHAIN: build.keychain
           CSC_KEY_PASSWORD: ${{ secrets.CSC_KEY_PASSWORD }}
           APPLE_ID: ${{ secrets.APPLE_ID }}
@@ -138,11 +193,14 @@ jobs:
   build-windows:
     name: Build Windows App
     runs-on: windows-latest
-    needs: npm-publish
+    needs: [validate-release, npm-publish]
+    if: ${{ needs.validate-release.result == 'success' && needs.npm-publish.result == 'success' }}
 
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
+        with:
+          ref: ${{ needs.validate-release.outputs.source_sha }}
 
       - name: Install pnpm
         uses: pnpm/action-setup@v4
@@ -187,11 +245,14 @@ jobs:
   build-linux:
     name: Build Linux App
     runs-on: ubuntu-latest
-    needs: npm-publish
+    needs: [validate-release, npm-publish]
+    if: ${{ needs.validate-release.result == 'success' && needs.npm-publish.result == 'success' }}
 
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
+        with:
+          ref: ${{ needs.validate-release.outputs.source_sha }}
 
       - name: Install pnpm
         uses: pnpm/action-setup@v4
@@ -230,31 +291,37 @@ jobs:
   attach-to-release:
     name: Attach Artifacts to Release
     runs-on: ubuntu-latest
-    needs: [build-macos, build-windows, build-linux]
+    needs: [validate-release, build-macos, build-windows, build-linux]
+    if: ${{ needs.validate-release.result == 'success' && needs.build-macos.result == 'success' && needs.build-windows.result == 'success' && needs.build-linux.result == 'success' }}
 
     steps:
-      - name: Checkout code
-        uses: actions/checkout@v4
-
       - name: Download all artifacts
         uses: actions/download-artifact@v4
         with:
           path: artifacts
 
-      - name: Set release type from event
-        id: release_type
+      - name: Revalidate release target
+        id: revalidate
+        env:
+          RELEASE_TAG: ${{ needs.validate-release.outputs.release_tag }}
+          EXPECTED_SOURCE_SHA: ${{ needs.validate-release.outputs.source_sha }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: node scripts/validate-release.mjs
+
+      - name: Check asset collisions
         run: |
-          if [ "${{ github.event_name }}" == "release" ]; then
-            if [ "${{ github.event.release.draft }}" == "true" ]; then
-              echo "type=draft" >> $GITHUB_OUTPUT
-            elif [ "${{ github.event.release.prerelease }}" == "true" ]; then
-              echo "type=prerelease" >> $GITHUB_OUTPUT
-            else
-              echo "type=release" >> $GITHUB_OUTPUT
-            fi
-          else
-            echo "type=${{ github.event.inputs.release_type }}" >> $GITHUB_OUTPUT
+          TAG="${{ needs.validate-release.outputs.release_tag }}"
+          EXISTING=$(gh api "repos/${{ github.repository }}/releases/tags/$TAG" --jq '.assets[].name')
+          NEW=$(find artifacts -type f -exec basename {} \; | sort -u)
+          COLLISIONS=$(comm -12 <(echo "$EXISTING" | sort) <(echo "$NEW" | sort))
+          if [ -n "$COLLISIONS" ]; then
+            echo "Asset filename collisions detected:"
+            echo "$COLLISIONS"
+            exit 1
           fi
+          echo "No asset collisions"
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Attach artifacts to release
         uses: softprops/action-gh-release@v1
@@ -263,7 +330,8 @@ jobs:
             artifacts/macos-artifacts/*
             artifacts/windows-artifacts/*
             artifacts/linux-artifacts/*
-          draft: ${{ steps.release_type.outputs.type == 'draft' }}
-          prerelease: ${{ steps.release_type.outputs.type == 'prerelease' }}
+          tag_name: ${{ needs.validate-release.outputs.release_tag }}
+          draft: false
+          prerelease: ${{ needs.validate-release.outputs.prerelease == 'true' }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/scripts/test-publish-workflow.mjs
+++ b/scripts/test-publish-workflow.mjs
@@ -1,0 +1,148 @@
+#!/usr/bin/env node
+/**
+ * Test the actual YAML graph, inline shell gates and pnpm argument forwarding.
+ * Packaging/signing are not executed here. Existing builder dependencies supply
+ * the YAML and CLI parsers; no second parser or dependency install is needed.
+ */
+import assert from "node:assert/strict";
+import { test } from "node:test";
+import { createRequire } from "node:module";
+import { readFileSync, writeFileSync, mkdtempSync, mkdirSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { spawnSync } from "node:child_process";
+
+const require = createRequire(import.meta.url);
+const builderRequire = createRequire(require.resolve("electron-builder/package.json"));
+const appRequire = createRequire(builderRequire.resolve("app-builder-lib"));
+const { load } = appRequire("js-yaml");
+const builder = require("electron-builder/out/builder");
+const workflow = load(readFileSync(new URL("../.github/workflows/publish.yml", import.meta.url), "utf8"));
+const pkg = JSON.parse(readFileSync(new URL("../package.json", import.meta.url), "utf8"));
+const jobs = workflow.jobs;
+const steps = (job) => jobs[job].steps;
+const step = (job, name) => steps(job).find((s) => s.name === name);
+const needsOf = (job) => [].concat(jobs[job].needs || []);
+function condition(expression, context) {
+  if (!expression) return true;
+  const code = expression.replace(/^\$\{\{\s*|\s*\}\}$/g, "").replace(/needs\.([\w-]+)\.result/g, 'needs["$1"].result');
+  // Expressions come only from the checked-in workflow, not user input. Status
+  // functions are deliberately unsupported: they can bypass GitHub's skip gate.
+  return Boolean(Function(...Object.keys(context), `return (${code})`)(...Object.values(context)));
+}
+function graph(event, prerelease = false, forced = {}) {
+  const result = {};
+  for (const job of Object.keys(jobs)) {
+    const needs = Object.fromEntries(needsOf(job).map((n) => [n, { result: result[n] }]));
+    const success = Object.values(needs).every((n) => n.result === "success");
+    const eligible = success && condition(jobs[job].if, { needs, github: { event_name: event, event: { release: { prerelease } } } });
+    result[job] = eligible ? forced[job] || "success" : "skipped";
+  }
+  return result;
+}
+function sandbox(fn) {
+  const dir = mkdtempSync(join(tmpdir(), "publish-contract-"));
+  try { return fn(dir); } finally { rmSync(dir, { recursive: true, force: true }); }
+}
+const cleanEnv = { PATH: process.env.PATH, HOME: process.env.HOME, NODE_PATH: process.env.NODE_PATH || "" };
+function shell(script, env, cwd) {
+  return spawnSync("bash", ["--noprofile", "--norc", "-e", "-o", "pipefail", "-c", script], { encoding: "utf8", cwd, env: { ...cleanEnv, ...env } });
+}
+
+for (const [event, prerelease] of [["workflow_dispatch", false], ["release", false], ["release", true]]) {
+  test(`${event} prerelease=${prerelease}: every required job reaches upload`, () => {
+    const result = graph(event, prerelease);
+    assert.ok(Object.values(result).every((r) => r === "success"), JSON.stringify(result));
+    console.log(`REACHABLE ${event} prerelease=${prerelease}: ${Object.keys(result).join(" -> ")}`);
+  });
+  for (const failed of ["validate-release", "preflight-macos", "npm-publish", "build-macos", "build-windows", "build-linux"]) {
+    for (const status of ["failure", "cancelled", "skipped"]) {
+      test(`${event} prerelease=${prerelease}: ${failed} ${status} blocks upload`, () => {
+        assert.equal(graph(event, prerelease, { [failed]: status })["attach-to-release"], "skipped");
+      });
+    }
+  }
+}
+test("upload requires all platform jobs; no status-function bypass", () => {
+  assert.deepEqual(needsOf("attach-to-release").sort(), ["build-linux", "build-macos", "build-windows", "validate-release"]);
+  for (const job of Object.values(jobs)) assert.doesNotMatch(job.if || "", /always\(|failure\(|cancelled\(/);
+});
+test("payload checkouts use validated source, helper checkouts use workflow SHA", () => {
+  for (const job of ["npm-publish", "build-macos", "build-windows", "build-linux"]) {
+    assert.equal(step(job, "Checkout code").with.ref, "${{ needs.validate-release.outputs.source_sha }}");
+  }
+  for (const job of ["validate-release", "attach-to-release"]) {
+    assert.equal(step(job, "Checkout workflow scripts").with.ref, "${{ github.workflow_sha }}");
+  }
+  const upload = step("attach-to-release", "Revalidate and attach artifacts to existing release");
+  assert.equal(upload.run, "node workflow/scripts/upload-release.mjs");
+  assert.equal(upload.env.EXPECTED_SOURCE_SHA, "${{ needs.validate-release.outputs.source_sha }}");
+  assert.equal(upload.env.EXPECTED_RELEASE_ID, "${{ needs.validate-release.outputs.release_id }}");
+  assert.match(step("attach-to-release", "Checkout workflow scripts").with["sparse-checkout"], /scripts\/upload-release.mjs/);
+  assert.equal(step("attach-to-release", "Checkout workflow scripts").with.path, "workflow");
+});
+for (const event of ["release", "workflow_dispatch"]) {
+  for (const published of ["true", "false"]) {
+    test(`npm publish guard event=${event}, published=${published}`, () => {
+      assert.equal(condition(step("npm-publish", "Publish to npm").if, { github: { event_name: event }, steps: { check_version: { outputs: { published } } } }), event === "release" && published === "false");
+    });
+  }
+}
+for (const [label, output, exitCode] of [["exists", "0.14.1", 0], ["absent", "", 1], ["registry unavailable", "", 42], ["wrong version", "0.14.0", 0]]) {
+  for (const manual of [true, false]) {
+    test(`npm registry ${label}, manual=${manual}: actual shell gate`, () => sandbox((dir) => {
+      writeFileSync(join(dir, "package.json"), JSON.stringify({ name: "local-operator-ui", version: "0.14.1" }));
+      writeFileSync(join(dir, "npm"), `#!/bin/sh\nprintf '%s\\n' '${output}'\nexit ${exitCode}\n`, { mode: 0o755 });
+      const result = shell(step("npm-publish", "Check if version already published").run, { PATH: `${dir}:${process.env.PATH}`, IS_MANUAL_DISPATCH: String(manual), GITHUB_OUTPUT: join(dir, "outputs") }, dir);
+      assert.equal(result.status, manual && label !== "exists" ? 1 : 0, result.stderr);
+      if (result.status === 0) assert.equal(readFileSync(join(dir, "outputs"), "utf8").trim(), `published=${label === "exists"}`);
+    }));
+  }
+}
+const preflight = step("preflight-macos", "Check required secrets");
+const signingEnv = { NOTARIZE: workflow.env.NOTARIZE, ...Object.fromEntries(Object.keys(preflight.env).map((k) => [k, "fixture-secret-value-never-log"])) };
+test("signing preflight accepts complete credentials", () => assert.equal(shell(preflight.run, signingEnv).status, 0));
+for (const name of Object.keys(signingEnv)) {
+  test(`signing preflight rejects missing ${name} without exposing values`, () => {
+    const result = shell(preflight.run, { ...signingEnv, [name]: "" });
+    assert.equal(result.status, 1);
+    assert.match(result.stdout, new RegExp(name));
+    assert.doesNotMatch(result.stdout + result.stderr, /fixture-secret-value/);
+  });
+}
+test("NOTARIZE=false is rejected", () => assert.equal(shell(preflight.run, { ...signingEnv, NOTARIZE: "false" }).status, 1));
+test("mac signing uses imported keychain without CSC_LINK, keeps notarization", () => {
+  assert.equal(workflow.env.NOTARIZE, "true");
+  const mac = step("build-macos", "Build macOS app");
+  assert.ok(!("NOTARIZE" in mac.env));
+  assert.ok(!("CSC_LINK" in mac.env));
+  for (const key of ["APPLE_ID", "APPLE_ID_PASSWORD", "APPLE_TEAM_ID"]) assert.equal(mac.env[key], preflight.env[key]);
+  const setup = step("build-macos", "Setup code signing").run;
+  assert.match(setup, /CSC_KEYCHAIN=\"\$RUNNER_TEMP\/build.keychain-db\"/);
+  assert.match(setup, /echo "CSC_KEYCHAIN=\$CSC_KEYCHAIN" >> "\$GITHUB_ENV"/);
+  assert.match(setup, /set-key-partition-list .* -k "\$KEYCHAIN_PASSWORD" "\$CSC_KEYCHAIN"/);
+  for (const job of ["build-windows", "build-linux"]) assert.ok(!JSON.stringify(jobs[job]).includes("forceCodeSigning"));
+});
+test("actual pnpm forwarding and electron-builder parser enforce signing", async () => {
+  const captures = sandbox((dir) => {
+  // Preserve the real dist script. Only its expensive build and packaging
+  // executables are replaced at the process boundary to capture actual argv.
+  writeFileSync(join(dir, "package.json"), JSON.stringify({ scripts: { build: "node -e ''", "dist:mac": pkg.scripts["dist:mac"] } }));
+  mkdirSync(join(dir, "bin"));
+  writeFileSync(join(dir, "bin", "electron-builder"), '#!/usr/bin/env node\nconsole.log("BUILDER_ARGV="+JSON.stringify(process.argv.slice(2)));\n', { mode: 0o755 });
+  return [["pnpm dist:mac -- -c.forceCodeSigning=true", false], [step("build-macos", "Build macOS app").run, true]].map(([command, shouldForce]) => {
+    const result = shell(command, { PATH: `${join(dir, "bin")}:${process.env.PATH}` }, dir);
+    assert.equal(result.status, 0, result.stderr);
+    const args = JSON.parse(result.stdout.split("\n").find((line) => line.startsWith("BUILDER_ARGV=")).slice(13));
+    const parsed = builder.configureBuildCommand(builder.createYargs()).parse(args);
+    const options = builder.normalizeOptions(parsed);
+    return { command, shouldForce, args, options };
+  });
+  });
+  for (const { command, shouldForce, args, options } of captures) {
+    // AJV performs boolean coercion after yargs and normalizeOptions.
+    await appRequire("./util/config/config").validateConfiguration(options.config || {}, { add() {} });
+    assert.equal(options.config?.forceCodeSigning === true, shouldForce, JSON.stringify({ args, options }));
+    console.log(`ACTUAL ${command}: argv=${JSON.stringify(args)} forceCodeSigning=${options.config?.forceCodeSigning}`);
+  }
+});

--- a/scripts/test-release-safety.mjs
+++ b/scripts/test-release-safety.mjs
@@ -1,0 +1,111 @@
+#!/usr/bin/env node
+/** Metadata tests use explicit fixtures, not live-release evidence. No network. */
+import assert from "node:assert/strict";
+import { test } from "node:test";
+import { mkdtempSync, mkdirSync, writeFileSync, rmSync, symlinkSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { validateInputs, validateRelease, resolveTagSha } from "./validate-release.mjs";
+import { artifactFiles, checkAssetCollisions, uploadRelease } from "./upload-release.mjs";
+
+const SHA = "3becfb9c462f6adb1f47f9815767f5522755f849";
+const TAG = "v0.14.1";
+const ID = 383131955;
+function fixture({ tag = TAG, sha = SHA, ref = `refs/tags/${tag}`, release = {}, pkg = {}, missing = "", assets = [] } = {}) {
+  return (path) => {
+    if (path === missing) throw new Error("GitHub HTTP 404");
+    if (path === `/git/ref/tags/${tag}`) return { ref, object: { type: "commit", sha } };
+    if (path === `/releases/tags/${tag}`) return { id: ID, tag_name: tag, draft: false, prerelease: false, published_at: "2026-09-05T00:00:00Z", ...release };
+    if (path === `/contents/package.json?ref=${sha}`) return { content: Buffer.from(JSON.stringify({ name: "local-operator-ui", version: tag.slice(1), ...pkg })).toString("base64") };
+    if (path.startsWith(`/releases/${ID}/assets?`)) return assets;
+    throw new Error(`Unexpected API path: ${path}`);
+  };
+}
+
+for (const manual of [true, false]) {
+  test(`matching published release validates (manual=${manual})`, () => {
+    assert.deepEqual(validateRelease(fixture(), TAG, SHA, manual, ID), { source_sha: SHA, release_id: ID, release_tag: TAG, prerelease: false });
+  });
+  test(`moved source rejected (manual=${manual})`, () => {
+    assert.throws(() => validateRelease(fixture(), TAG, "0".repeat(40), manual, ID), /Tag SHA.*does not match/);
+  });
+  test(`recreated release rejected (manual=${manual})`, () => {
+    assert.throws(() => validateRelease(fixture({ release: { id: ID + 1 } }), TAG, SHA, manual, ID), /Release ID.*does not match/);
+  });
+}
+for (const [name, options, error] of [
+  ["missing tag", { missing: `/git/ref/tags/${TAG}` }, /404/],
+  ["missing release", { missing: `/releases/tags/${TAG}` }, /404/],
+  ["wrong package", { pkg: { name: "other" } }, /name mismatch/],
+  ["wrong version", { pkg: { version: "0.14.2" } }, /version mismatch/],
+  ["draft", { release: { draft: true } }, /draft/],
+  ["unpublished", { release: { published_at: null } }, /not published/],
+  ["wrong release tag", { release: { tag_name: "v0.14.0" } }, /tag_name/],
+  ["missing release ID", { release: { id: undefined } }, /valid release ID/],
+]) {
+  test(`${name} rejected`, () => assert.throws(() => validateRelease(fixture(options), TAG, SHA, true, ID), error));
+}
+test("suffix-matching but nonexact ref rejected", () => {
+  assert.throws(() => resolveTagSha(fixture({ ref: `refs/heads/tags/${TAG}` }), TAG), /Unexpected ref/);
+});
+test("published prerelease is supported without changing its metadata", () => {
+  const tag = "v0.15.0-beta.1";
+  validateInputs(tag, SHA, true, "fixture-token");
+  assert.equal(validateRelease(fixture({ tag, release: { prerelease: true } }), tag, SHA, true, ID).prerelease, true);
+});
+test("missing API token fails by name only", () => {
+  assert.throws(() => validateInputs(TAG, SHA, true, ""), { message: "GH_TOKEN required for read-only API calls" });
+});
+test("duplicate artifact filenames fail before upload", () => {
+  assert.throws(() => checkAssetCollisions(fixture(), ID, ["mac/latest.yml", "win/latest.yml"]), /Duplicate/);
+});
+test("existing filename collision rejected", () => {
+  assert.throws(() => checkAssetCollisions(fixture({ assets: [{ name: "app.dmg" }] }), ID, ["app.dmg"]), /collisions/);
+});
+test("collisions on paginated assets rejected", () => {
+  const api = (path) => path.endsWith("page=1") ? Array.from({ length: 100 }, (_, i) => ({ name: `old-${i}` })) : [{ name: "app.dmg" }];
+  assert.throws(() => checkAssetCollisions(api, ID, ["app.dmg"]), /collisions/);
+});
+test("empty artifact set rejected", () => assert.throws(() => checkAssetCollisions(fixture(), ID, []), /No artifacts/));
+for (const [name, overrides, error] of [
+  ["missing SHA", { expectedSha: "" }, /EXPECTED_SOURCE_SHA/],
+  ["missing ID", { expectedReleaseId: "" }, /EXPECTED_RELEASE_ID/],
+  ["moved SHA", { expectedSha: "0".repeat(40) }, /Tag SHA/],
+  ["changed ID", { expectedReleaseId: ID + 1 }, /Release ID/],
+  ["collision", { api: fixture({ assets: [{ name: "app.dmg" }] }) }, /collisions/],
+]) {
+  test(`upload rejects ${name} without writes`, () => {
+    let writes = 0;
+    assert.throws(() => uploadRelease({ api: fixture(), tag: TAG, expectedSha: SHA, expectedReleaseId: ID, files: ["app.dmg"], upload: () => writes++, ...overrides }), error);
+    assert.equal(writes, 0);
+  });
+}
+test("upload addresses validated ID and does not mutate release metadata", () => {
+  const writes = [];
+  uploadRelease({ api: fixture(), tag: TAG, expectedSha: SHA, expectedReleaseId: ID, files: ["app.dmg", "app.exe"], upload: (...args) => writes.push(args) });
+  assert.deepEqual(writes, [[ID, "app.dmg"], [ID, "app.exe"]]);
+});
+for (const mode of ["complete", "missing-linux", "metadata-only", "symlink"]) {
+  test(`artifact collection ${mode}`, () => {
+    const root = mkdtempSync(join(tmpdir(), "release-artifact-test-"));
+    try {
+      for (const [platform, file] of [["macos", "app.dmg"], ["windows", "app.exe"], ["linux", "app.deb"]]) {
+        if (mode === "missing-linux" && platform === "linux") continue;
+        const dir = join(root, `${platform}-artifacts`);
+        mkdirSync(dir);
+        writeFileSync(join(dir, mode === "metadata-only" ? "latest.yml" : file), "fixture");
+        if (mode === "symlink") symlinkSync(join(dir, file), join(dir, "linked-installer"));
+      }
+      if (mode === "complete") assert.equal(artifactFiles(root).length, 3);
+      else assert.throws(() => artifactFiles(root), mode === "missing-linux" ? /ENOENT/ : mode === "symlink" ? /non-file/ : /Missing macos installer/);
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+}
+
+test("a failed upload stops instead of replacing or retrying assets", () => {
+  let writes = 0;
+  assert.throws(() => uploadRelease({ api: fixture(), tag: TAG, expectedSha: SHA, expectedReleaseId: ID, files: ["app.dmg", "app.exe"], upload: () => { writes++; throw new Error("HTTP 422 duplicate"); } }), /422/);
+  assert.equal(writes, 1);
+});

--- a/scripts/test-validate-release.mjs
+++ b/scripts/test-validate-release.mjs
@@ -40,7 +40,7 @@ console.log("--- Input validation ---");
 expectThrow(() => validateInputs("", SHA, true, "t"), "empty tag", "vX.Y.Z");
 expectThrow(() => validateInputs("0.14.1", SHA, true, "t"), "tag without v", "vX.Y.Z");
 expectThrow(() => validateInputs("v0.14", SHA, true, "t"), "incomplete version", "vX.Y.Z");
-expectThrow(() => validateInputs("v0.14.1-beta", SHA, true, "t"), "prerelease suffix", "vX.Y.Z");
+try { validateInputs("v0.14.1-beta.1", SHA, true, "t"); ok("prerelease suffix supported"); } catch (e) { fail("prerelease suffix", e.message); }
 expectThrow(() => validateInputs(TAG, "abc", true, "t"), "short SHA", "40-char");
 expectThrow(() => validateInputs(TAG, "", true, "t"), "empty SHA manual", "40-char");
 try { validateInputs(TAG, "", false, "t"); ok("empty SHA release event valid"); } catch (e) { fail("empty SHA release event", e.message); }
@@ -76,7 +76,7 @@ try {
 // --- Release validation ---
 console.log("--- Release validation ---");
 
-const publishedRelease = { id: 383131955, tag_name: TAG, draft: false, prerelease: false };
+const publishedRelease = { id: 383131955, tag_name: TAG, draft: false, prerelease: false, published_at: "2026-09-05T00:00:00Z" };
 const draftRelease = { id: 123, tag_name: TAG, draft: true, prerelease: false };
 const wrongTagRelease = { id: 123, tag_name: "v0.14.0", draft: false, prerelease: false };
 const validPkg = { content: Buffer.from(JSON.stringify({ name: "local-operator-ui", version: "0.14.1" })).toString("base64") };

--- a/scripts/test-validate-release.mjs
+++ b/scripts/test-validate-release.mjs
@@ -1,0 +1,131 @@
+#!/usr/bin/env node
+/** Bounded unit tests for validate-release.mjs — dependency-injected API, no network. */
+import { validateInputs, validateRelease, resolveTagSha, ValidationError } from "./validate-release.mjs";
+
+const SHA = "3becfb9c462f6adb1f47f9815767f5522755f849";
+const TAG = "v0.14.1";
+let failures = 0;
+let passes = 0;
+
+function ok(name) { passes++; console.log(`PASS: ${name}`); }
+function fail(name, msg) { failures++; console.error(`FAIL: ${name}: ${msg}`); }
+
+function expectThrow(fn, name, pattern) {
+  try {
+    fn();
+    fail(name, "expected throw but succeeded");
+  } catch (e) {
+    if (!(e instanceof ValidationError)) {
+      fail(name, `expected ValidationError, got ${e.constructor.name}: ${e.message}`);
+    } else if (e.message.includes(pattern) || e.message.match(new RegExp(pattern))) {
+      ok(name);
+    } else {
+      fail(name, `wrong error: ${e.message}`);
+    }
+  }
+}
+
+function mockApi(responses) {
+  return (path) => {
+    for (const [key, val] of Object.entries(responses)) {
+      if (path === key || path.startsWith(key)) return val;
+    }
+    throw new Error(`unmocked path: ${path}`);
+  };
+}
+
+// --- Input validation ---
+console.log("--- Input validation ---");
+
+expectThrow(() => validateInputs("", SHA, true, "t"), "empty tag", "vX.Y.Z");
+expectThrow(() => validateInputs("0.14.1", SHA, true, "t"), "tag without v", "vX.Y.Z");
+expectThrow(() => validateInputs("v0.14", SHA, true, "t"), "incomplete version", "vX.Y.Z");
+expectThrow(() => validateInputs("v0.14.1-beta", SHA, true, "t"), "prerelease suffix", "vX.Y.Z");
+expectThrow(() => validateInputs(TAG, "abc", true, "t"), "short SHA", "40-char");
+expectThrow(() => validateInputs(TAG, "", true, "t"), "empty SHA manual", "40-char");
+try { validateInputs(TAG, "", false, "t"); ok("empty SHA release event valid"); } catch (e) { fail("empty SHA release event", e.message); }
+expectThrow(() => validateInputs(TAG, "abc", false, "t"), "invalid SHA release event", "40-char");
+expectThrow(() => validateInputs(TAG, SHA, true, ""), "missing token", "GH_TOKEN");
+expectThrow(() => validateInputs(TAG, SHA, false, ""), "missing token release", "GH_TOKEN");
+try { validateInputs(TAG, SHA, true, "t"); ok("valid manual inputs"); } catch (e) { fail("valid manual", e.message); }
+try { validateInputs(TAG, "", false, "t"); ok("valid release inputs"); } catch (e) { fail("valid release", e.message); }
+
+// --- Tag resolution ---
+console.log("--- Tag resolution ---");
+
+const lightweightRef = { ref: `refs/tags/${TAG}`, object: { sha: SHA, type: "commit" } };
+const annotatedRef = { ref: `refs/tags/${TAG}`, object: { sha: "annotated1234567890123456789012345678901234", type: "tag" } };
+const annotatedTagObj = { object: { sha: SHA, type: "commit" } };
+
+expectThrow(() => resolveTagSha(mockApi({ "/git/ref/tags/v0.14.1": { ref: "refs/heads/main", object: { sha: SHA, type: "commit" } } }), TAG), "wrong ref format", "Unexpected ref");
+expectThrow(() => resolveTagSha(mockApi({ "/git/ref/tags/v0.14.1": { ref: `refs/tags/${TAG}`, object: { sha: SHA, type: "blob" } } }), TAG), "non-commit ref", "expected commit");
+
+try {
+  const sha = resolveTagSha(mockApi({ "/git/ref/tags/v0.14.1": lightweightRef }), TAG);
+  if (sha === SHA) ok("lightweight tag resolution"); else fail("lightweight", `got ${sha}`);
+} catch (e) { fail("lightweight tag", e.message); }
+
+try {
+  const sha = resolveTagSha(mockApi({
+    "/git/ref/tags/v0.14.1": annotatedRef,
+    "/git/tags/annotated1234567890123456789012345678901234": annotatedTagObj,
+  }), TAG);
+  if (sha === SHA) ok("annotated tag peeling"); else fail("annotated", `got ${sha}`);
+} catch (e) { fail("annotated tag", e.message); }
+
+// --- Release validation ---
+console.log("--- Release validation ---");
+
+const publishedRelease = { id: 383131955, tag_name: TAG, draft: false, prerelease: false };
+const draftRelease = { id: 123, tag_name: TAG, draft: true, prerelease: false };
+const wrongTagRelease = { id: 123, tag_name: "v0.14.0", draft: false, prerelease: false };
+const validPkg = { content: Buffer.from(JSON.stringify({ name: "local-operator-ui", version: "0.14.1" })).toString("base64") };
+const wrongNamePkg = { content: Buffer.from(JSON.stringify({ name: "other", version: "0.14.1" })).toString("base64") };
+const wrongVersionPkg = { content: Buffer.from(JSON.stringify({ name: "local-operator-ui", version: "0.14.0" })).toString("base64") };
+
+const happyApi = mockApi({
+  "/git/ref/tags/v0.14.1": lightweightRef,
+  "/releases/tags/v0.14.1": publishedRelease,
+  "/contents/package.json?ref=": validPkg,
+});
+
+try {
+  const result = validateRelease(happyApi, TAG, SHA, true);
+  if (result.source_sha === SHA && result.release_id === 383131955) ok("happy path manual");
+  else fail("happy manual", JSON.stringify(result));
+} catch (e) { fail("happy manual", e.message); }
+
+try {
+  const result = validateRelease(happyApi, TAG, "", false);
+  if (result.source_sha === SHA) ok("happy path release event");
+  else fail("happy release", JSON.stringify(result));
+} catch (e) { fail("happy release", e.message); }
+
+expectThrow(() => validateRelease(mockApi({
+  "/git/ref/tags/v0.14.1": lightweightRef,
+  "/releases/tags/v0.14.1": draftRelease,
+}), TAG, SHA, true), "draft release rejected", "draft");
+
+expectThrow(() => validateRelease(mockApi({
+  "/git/ref/tags/v0.14.1": lightweightRef,
+  "/releases/tags/v0.14.1": wrongTagRelease,
+}), TAG, SHA, true), "tag_name mismatch rejected", "tag_name");
+
+expectThrow(() => validateRelease(mockApi({
+  "/git/ref/tags/v0.14.1": lightweightRef,
+  "/releases/tags/v0.14.1": publishedRelease,
+  "/contents/package.json?ref=": wrongNamePkg,
+}), TAG, SHA, true), "package name mismatch rejected", "name mismatch");
+
+expectThrow(() => validateRelease(mockApi({
+  "/git/ref/tags/v0.14.1": lightweightRef,
+  "/releases/tags/v0.14.1": publishedRelease,
+  "/contents/package.json?ref=": wrongVersionPkg,
+}), TAG, SHA, true), "package version mismatch rejected", "version mismatch");
+
+expectThrow(() => validateRelease(happyApi, TAG, "0".repeat(40), true), "SHA mismatch manual rejected", "does not match");
+
+// --- Summary ---
+console.log(`\n${passes} passed, ${failures} failed`);
+if (failures > 0) process.exit(1);
+console.log("All validation tests passed");

--- a/scripts/upload-release.mjs
+++ b/scripts/upload-release.mjs
@@ -1,0 +1,81 @@
+#!/usr/bin/env node
+/**
+ * Repair assets on a pinned, already-published release. Never create a release,
+ * replace an asset, change release metadata, or resolve an upload target by tag.
+ * GitHub rejects duplicate asset names; unlike a release action we never delete
+ * an existing asset to retry, including when another upload races our precheck.
+ */
+import { execFileSync } from "node:child_process";
+import { readdirSync } from "node:fs";
+import { basename, join } from "node:path";
+import { pathToFileURL } from "node:url";
+import { createApi, validateInputs, validateRelease, ValidationError } from "./validate-release.mjs";
+
+function artifactFiles(root) {
+  const platforms = { macos: /\.(dmg|zip)$/, windows: /\.(exe|msi)$/, linux: /\.(deb|AppImage|rpm)$/ };
+  return Object.entries(platforms).flatMap(([platform, installer]) => {
+    const dir = join(root, `${platform}-artifacts`);
+    const files = readdirSync(dir, { withFileTypes: true });
+    if (!files.some((f) => f.isFile() && installer.test(f.name))) {
+      throw new ValidationError(`Missing ${platform} installer artifacts`);
+    }
+    if (files.some((f) => !f.isFile())) throw new ValidationError(`Unexpected non-file in ${platform} artifacts`);
+    return files.map((f) => join(dir, f.name));
+  });
+}
+
+function checkAssetCollisions(api, releaseId, files) {
+  if (!files.length) throw new ValidationError("No artifacts to upload");
+  const names = files.map((file) => basename(file));
+  if (new Set(names).size !== names.length) throw new ValidationError("Duplicate artifact filenames across platforms");
+  // The release summary can truncate its assets; page the ID-addressed list.
+  const existing = new Set();
+  for (let page = 1; ; page++) {
+    const assets = api(`/releases/${releaseId}/assets?per_page=100&page=${page}`);
+    for (const asset of assets) existing.add(asset.name);
+    if (assets.length < 100) break;
+  }
+  const collisions = names.filter((name) => existing.has(name));
+  if (collisions.length) throw new ValidationError(`Asset filename collisions: ${collisions.join(", ")}`);
+}
+
+function uploadRelease({ api, tag, expectedSha, expectedReleaseId, files, upload }) {
+  // Both pins must survive the build, even for release events (not just repairs).
+  if (!/^[0-9a-f]{40}$/.test(expectedSha || "")) throw new ValidationError("EXPECTED_SOURCE_SHA required for upload");
+  if (!/^[1-9]\d*$/.test(String(expectedReleaseId || ""))) throw new ValidationError("EXPECTED_RELEASE_ID required for upload");
+  const release = validateRelease(api, tag, expectedSha, false, expectedReleaseId);
+  checkAssetCollisions(api, release.release_id, files);
+  for (const file of files) upload(release.release_id, file);
+  return release;
+}
+
+if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
+  try {
+    const { RELEASE_TAG: tag, EXPECTED_SOURCE_SHA: expectedSha, EXPECTED_RELEASE_ID: expectedReleaseId } = process.env;
+    const token = process.env.GH_TOKEN || process.env.GITHUB_TOKEN;
+    const repo = process.env.GITHUB_REPOSITORY;
+    validateInputs(tag, expectedSha, true, token);
+    if (!repo) throw new ValidationError("GITHUB_REPOSITORY required");
+    uploadRelease({
+      api: createApi(repo, token), tag, expectedSha, expectedReleaseId,
+      files: artifactFiles(process.env.ARTIFACTS_DIR || "artifacts"),
+      upload: (releaseId, file) => {
+        try {
+          execFileSync("gh", ["api", "--method", "POST",
+            `https://uploads.github.com/repos/${repo}/releases/${releaseId}/assets?name=${encodeURIComponent(basename(file))}`,
+            "-H", "Content-Type: application/octet-stream", "--input", file], {
+            env: { ...process.env, GH_TOKEN: token }, stdio: ["ignore", "pipe", "pipe"],
+          });
+          console.log(`Uploaded ${basename(file)} to release ${releaseId}`);
+        } catch {
+          throw new ValidationError(`Asset upload failed: ${basename(file)}; existing assets were not replaced`);
+        }
+      },
+    });
+  } catch (error) {
+    console.error(error instanceof ValidationError ? error.message : "Release upload failed; inspect artifact inputs");
+    process.exitCode = 1;
+  }
+}
+
+export { artifactFiles, checkAssetCollisions, uploadRelease };

--- a/scripts/validate-release.mjs
+++ b/scripts/validate-release.mjs
@@ -3,13 +3,18 @@
  * Validate that a release targets an existing, published, immutable release.
  * Read-only: no secrets printed, no mutations, no publish.
  *
- * Env: RELEASE_TAG, EXPECTED_SOURCE_SHA (required for manual dispatch), IS_MANUAL_DISPATCH, GH_TOKEN
+ * Env: RELEASE_TAG, EXPECTED_SOURCE_SHA (required for manual dispatch),
+ * EXPECTED_RELEASE_ID (required by upload), IS_MANUAL_DISPATCH, GH_TOKEN
+ * These pins are independent of the event: upload must detect a moved tag or
+ * a deleted/recreated release even when it runs after a normal release event.
  * Output: GITHUB_OUTPUT lines source_sha, release_tag, release_id, prerelease
  */
 import { execFileSync } from "node:child_process";
 import { writeFileSync } from "node:fs";
+import { pathToFileURL } from "node:url";
 
-const TAG_RE = /^v\d+\.\d+\.\d+$/;
+// Published prereleases use the same pipeline as stable releases.
+const TAG_RE = /^v(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)(?:-(?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*)(?:\.(?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*))*)?(?:\+[0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*)?$/;
 const SHA_RE = /^[0-9a-f]{40}$/;
 
 class ValidationError extends Error {}
@@ -30,19 +35,26 @@ function validateInputs(tag, expectedSha, isManual, token) {
 }
 
 function createApi(repo, token) {
-  return (path) => JSON.parse(
-    execFileSync("gh", ["api", `repos/${repo}${path}`, "--jq", "."], {
-      env: { ...process.env, GH_TOKEN: token },
-      encoding: "utf8",
-    }),
-  );
+  return (path) => {
+    try {
+      return JSON.parse(execFileSync("gh", ["api", `repos/${repo}${path}`], {
+        env: { ...process.env, GH_TOKEN: token },
+        encoding: "utf8",
+        stdio: ["ignore", "pipe", "pipe"],
+      }));
+    } catch {
+      // Do not echo subprocess output: it can include authentication details.
+      fail(`GitHub metadata lookup failed: ${path}`);
+    }
+  };
 }
 
 function resolveTagSha(api, tag) {
-  const ref = api(`/git/ref/tags/${tag}`);
-  if (!ref.ref || !ref.ref.endsWith(`/tags/${tag}`)) {
-    fail(`Unexpected ref format: ${ref.ref}, expected .../tags/${tag}`);
+  const ref = api(`/git/ref/tags/${encodeURIComponent(tag)}`);
+  if (ref?.ref !== `refs/tags/${tag}`) {
+    fail(`Unexpected ref format: expected refs/tags/${tag}`);
   }
+  if (!ref.object) fail("Missing tag object");
   let sha = ref.object.sha;
   if (ref.object.type === "tag") {
     const tagObj = api(`/git/tags/${sha}`);
@@ -51,19 +63,26 @@ function resolveTagSha(api, tag) {
   } else if (ref.object.type !== "commit") {
     fail(`Tag ref points to ${ref.object.type}, expected commit`);
   }
+  if (!SHA_RE.test(sha)) fail("Tag must resolve to a full 40-char commit SHA");
   return sha;
 }
 
-function validateRelease(api, tag, expectedSha, isManual) {
+function validateRelease(api, tag, expectedSha, isManual, expectedReleaseId = "") {
   const tagSha = resolveTagSha(api, tag);
   console.log(`Tag ${tag} resolves to commit ${tagSha}`);
 
-  const release = api(`/releases/tags/${tag}`);
+  const release = api(`/releases/tags/${encodeURIComponent(tag)}`);
+  if (!release) fail(`Missing release ${tag}`);
   if (release.tag_name !== tag) fail(`Release tag_name ${release.tag_name} does not match requested ${tag}`);
-  if (release.draft) fail(`Release ${tag} is a draft; refusing dispatch`);
+  if (release.draft !== false || !release.published_at) fail(`Release ${tag} is a draft or not published`);
+  if (!Number.isSafeInteger(release.id) || release.id <= 0) fail("Missing valid release ID");
+  if (expectedReleaseId && String(release.id) !== String(expectedReleaseId)) {
+    fail(`Release ID ${release.id} does not match expected release ID ${expectedReleaseId}`);
+  }
   console.log(`Release ${tag} (id ${release.id}) state: published, prerelease: ${release.prerelease}`);
 
-  if (isManual && tagSha !== expectedSha) {
+  if (isManual && !expectedSha) fail("EXPECTED_SOURCE_SHA required for manual dispatch");
+  if (expectedSha && tagSha !== expectedSha) {
     fail(`Tag SHA ${tagSha} does not match expected source SHA ${expectedSha}`);
   }
 
@@ -91,7 +110,7 @@ function emitOutputs(result) {
 }
 
 // Main execution (skip when imported for testing)
-if (import.meta.url === `file://${process.argv[1]}`) {
+if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
   const tag = process.env.RELEASE_TAG;
   const expectedSha = process.env.EXPECTED_SOURCE_SHA || "";
   const isManual = process.env.IS_MANUAL_DISPATCH === "true";
@@ -101,7 +120,7 @@ if (import.meta.url === `file://${process.argv[1]}`) {
   try {
     validateInputs(tag, expectedSha, isManual, token);
     const api = createApi(repo, token);
-    const result = validateRelease(api, tag, expectedSha, isManual);
+    const result = validateRelease(api, tag, expectedSha, isManual, process.env.EXPECTED_RELEASE_ID);
     emitOutputs(result);
     console.log("Validation passed");
   } catch (e) {
@@ -114,4 +133,4 @@ if (import.meta.url === `file://${process.argv[1]}`) {
 }
 
 // Export for testing
-export { validateInputs, validateRelease, resolveTagSha, ValidationError };
+export { validateInputs, validateRelease, resolveTagSha, createApi, ValidationError };

--- a/scripts/validate-release.mjs
+++ b/scripts/validate-release.mjs
@@ -1,0 +1,117 @@
+#!/usr/bin/env node
+/**
+ * Validate that a release targets an existing, published, immutable release.
+ * Read-only: no secrets printed, no mutations, no publish.
+ *
+ * Env: RELEASE_TAG, EXPECTED_SOURCE_SHA (required for manual dispatch), IS_MANUAL_DISPATCH, GH_TOKEN
+ * Output: GITHUB_OUTPUT lines source_sha, release_tag, release_id, prerelease
+ */
+import { execFileSync } from "node:child_process";
+import { writeFileSync } from "node:fs";
+
+const TAG_RE = /^v\d+\.\d+\.\d+$/;
+const SHA_RE = /^[0-9a-f]{40}$/;
+
+class ValidationError extends Error {}
+
+function fail(msg) {
+  throw new ValidationError(msg);
+}
+
+function validateInputs(tag, expectedSha, isManual, token) {
+  if (!tag || !TAG_RE.test(tag)) fail(`RELEASE_TAG must match vX.Y.Z, got: ${tag}`);
+  if (!token) fail("GH_TOKEN required for read-only API calls");
+  if (isManual && (!expectedSha || !SHA_RE.test(expectedSha))) {
+    fail(`EXPECTED_SOURCE_SHA must be a full 40-char hex SHA for manual dispatch, got: ${expectedSha || "(empty)"}`);
+  }
+  if (!isManual && expectedSha && !SHA_RE.test(expectedSha)) {
+    fail(`EXPECTED_SOURCE_SHA must be a full 40-char hex SHA or empty for release event, got: ${expectedSha}`);
+  }
+}
+
+function createApi(repo, token) {
+  return (path) => JSON.parse(
+    execFileSync("gh", ["api", `repos/${repo}${path}`, "--jq", "."], {
+      env: { ...process.env, GH_TOKEN: token },
+      encoding: "utf8",
+    }),
+  );
+}
+
+function resolveTagSha(api, tag) {
+  const ref = api(`/git/ref/tags/${tag}`);
+  if (!ref.ref || !ref.ref.endsWith(`/tags/${tag}`)) {
+    fail(`Unexpected ref format: ${ref.ref}, expected .../tags/${tag}`);
+  }
+  let sha = ref.object.sha;
+  if (ref.object.type === "tag") {
+    const tagObj = api(`/git/tags/${sha}`);
+    if (tagObj.object.type !== "commit") fail(`Annotated tag points to ${tagObj.object.type}, expected commit`);
+    sha = tagObj.object.sha;
+  } else if (ref.object.type !== "commit") {
+    fail(`Tag ref points to ${ref.object.type}, expected commit`);
+  }
+  return sha;
+}
+
+function validateRelease(api, tag, expectedSha, isManual) {
+  const tagSha = resolveTagSha(api, tag);
+  console.log(`Tag ${tag} resolves to commit ${tagSha}`);
+
+  const release = api(`/releases/tags/${tag}`);
+  if (release.tag_name !== tag) fail(`Release tag_name ${release.tag_name} does not match requested ${tag}`);
+  if (release.draft) fail(`Release ${tag} is a draft; refusing dispatch`);
+  console.log(`Release ${tag} (id ${release.id}) state: published, prerelease: ${release.prerelease}`);
+
+  if (isManual && tagSha !== expectedSha) {
+    fail(`Tag SHA ${tagSha} does not match expected source SHA ${expectedSha}`);
+  }
+
+  const pkg = JSON.parse(Buffer.from(api(`/contents/package.json?ref=${tagSha}`).content, "base64").toString());
+  if (pkg.name !== "local-operator-ui") fail(`package.json name mismatch: expected local-operator-ui, got ${pkg.name}`);
+  const expectedVersion = tag.slice(1);
+  if (pkg.version !== expectedVersion) fail(`package.json version mismatch: expected ${expectedVersion}, got ${pkg.version}`);
+  console.log(`package.json name=${pkg.name} version=${pkg.version} OK`);
+
+  return { source_sha: tagSha, release_tag: tag, release_id: release.id, prerelease: release.prerelease };
+}
+
+function emitOutputs(result) {
+  const outFile = process.env.GITHUB_OUTPUT;
+  if (outFile) {
+    writeFileSync(outFile, [
+      `source_sha=${result.source_sha}`,
+      `release_tag=${result.release_tag}`,
+      `release_id=${result.release_id}`,
+      `prerelease=${result.prerelease}`,
+    ].join("\n") + "\n", { flag: "a" });
+  } else {
+    console.log(JSON.stringify(result));
+  }
+}
+
+// Main execution (skip when imported for testing)
+if (import.meta.url === `file://${process.argv[1]}`) {
+  const tag = process.env.RELEASE_TAG;
+  const expectedSha = process.env.EXPECTED_SOURCE_SHA || "";
+  const isManual = process.env.IS_MANUAL_DISPATCH === "true";
+  const token = process.env.GH_TOKEN || process.env.GITHUB_TOKEN;
+  const repo = process.env.GITHUB_REPOSITORY || "damianvtran/local-operator-ui";
+
+  try {
+    validateInputs(tag, expectedSha, isManual, token);
+    const api = createApi(repo, token);
+    const result = validateRelease(api, tag, expectedSha, isManual);
+    emitOutputs(result);
+    console.log("Validation passed");
+  } catch (e) {
+    if (e instanceof ValidationError) {
+      console.error(e.message);
+      process.exit(1);
+    }
+    throw e;
+  }
+}
+
+// Export for testing
+export { validateInputs, validateRelease, resolveTagSha, ValidationError };


### PR DESCRIPTION
## Summary / change class

**C2 — standard/pre-authorized, CI-only installer recovery.** No application code, dependency, package version, or tag changes. No RFC or tracker required; this PR is the change record. No rendered product surface changes, so a new design round is not applicable.

The reviewed application is v0.14.1 at `3becfb9c462f6adb1f47f9815767f5522755f849`. npm already contains that version. macOS signing failed in [run 33944365983](https://github.com/damianvtran/local-operator-ui/actions/runs/33944365983); signed/notarized installers are **not yet proven repaired**.

## Delivery contract

- Manual dispatch repairs assets on an **existing published release**, building its validated immutable application SHA. It must never publish npm, create another release, alter release metadata, overwrite assets, or move a tag.
- Normal `release.published` events continue to publish npm when absent and build all platforms, including prereleases (the pre-PR behavior).
- macOS uses the already-imported signing keychain, requires signing, and retains the existing notarization hook and all Apple credentials.
- Upload requires every platform job to succeed, complete platform artifact directories, stable source SHA/release ID, and no filename collisions.
- Non-goals: app changes, version bumps, new releases, Windows signing-policy changes, backend PR643, or a local/cloud publication during implementation.

## Implementation

Correction commit: `5b8f8989d` on `dev-signing-keychain`, following (not replacing) predecessor `7e30c26bf`.

- Remove macOS `CSC_LINK`; export an absolute `CSC_KEYCHAIN` via `GITHUB_ENV` after creating/importing the CI keychain. The installed app-builder-lib 26.0.12 source confirms `MacPackager.codeSigningInfo` uses `CSC_KEYCHAIN` when no `CSC_LINK` exists, avoiding its second import path. That path's `importCerts` passes the P12 password to `set-key-partition-list`, not the generated keychain password.
- Run `pnpm dist:mac -c.forceCodeSigning=true` (no forwarding `--`). The flag is macOS-only. Shared `NOTARIZE='true'` and names-only credential preflight fail closed; the app's existing `afterSign: scripts/notarize.js` remains untouched.
- Both events run `npm-publish`. Manual recovery performs an exact npm-version read and fails on absent/mismatched version or registry error; its dependency install and npm-publish steps cannot execute. Normal stable/prerelease events retain publish-if-absent behavior.
- `validate-release` checks exact `refs/tags/<tag>` equality, peels annotated tags, verifies published release identity and package name/version at the resolved SHA. Any supplied expected SHA is enforced regardless of event. Release events also pin the event's release ID.
- Application/npm checkouts use `needs.validate-release.outputs.source_sha`. Validation/upload tooling uses `github.workflow_sha`, including its own sparse checkout in the upload job, so old app tags need not contain new helpers.
- `upload-release.mjs` requires both original pins and revalidates them before uploading. It enumerates every platform directory, requires installers, rejects duplicate filenames and collisions against the paginated release assets list, then POSTs only to the validated release ID. No release-create/update/delete API, no `--clobber`, no overwrite retry. Same-tag workflow runs are serialized.
- Required-job success gates remain strict; no `always()` bypass. Missing artifact uploads fail instead of warning. New regression scripts run in the existing PR CI lint job using existing builder dependencies; no new install/dependency/job.

## Exact workflow reachability

For manual dispatch, stable published releases, and published prereleases:

```text
validate-release -> preflight-macos
validate-release -> npm-publish
(validate-release + preflight-macos + npm-publish) -> build-macos
(validate-release + npm-publish) -> build-windows, build-linux
(validate-release + build-macos + build-windows + build-linux) -> attach-to-release
```

Manual npm success means **verification only**, not publication. Any required job failure, cancellation, or skip blocks attachment. Artifact upload is not transactionally atomic across files: a network failure after a successful POST can leave a partial set; the job fails and the next attempt refuses collisions rather than deleting/replacing existing assets. GitHub duplicate-name rejection also protects the race after the precheck.

## Verification (actually executed)

- `node scripts/test-validate-release.mjs`: **23 passed, 0 failed**.
- `NODE_PATH="$HOME/local-operator-ui/node_modules" node --test scripts/test-release-safety.mjs scripts/test-publish-workflow.mjs`: **114 passed, 0 failed**. Existing shared dependencies were used read-only; no installs/repo copies. Covers metadata success/failure, missing tags/releases, SHA/ID changes, wrong package/version, drafts/prereleases, paginated collisions, missing artifacts, all required-job failure/skip/cancel states, real inline npm/preflight shell execution, and names-only missing credentials.
- Actual pnpm 10.30.3 process forwarding, followed by electron-builder 26.0.12's actual yargs/parser/schema validation (build/packaging executables stubbed, **not** a signed build):
  - Before: `pnpm dist:mac -- -c.forceCodeSigning=true` -> argv `["--mac","--publish","never","--","-c.forceCodeSigning=true"]`, effective `forceCodeSigning=undefined`.
  - After: `pnpm dist:mac -c.forceCodeSigning=true` -> argv `["--mac","--publish","never","-c.forceCodeSigning=true"]`, effective `forceCodeSigning=true`.
- Reproduced predecessor `7e30c26` accepting a suffix-matching nonexact ref and an upload SHA mismatch despite its original 23 passing tests; regression tests now reject both and exercise the previously broken manual skip chain.
- `actionlint .github/workflows/publish.yml`: clean, including shellcheck.
- `actionlint -shellcheck= .github/workflows/publish.yml .github/workflows/ci.yml`: clean. Full shellcheck on `ci.yml` still reports the pre-existing unrelated audit-job SC2126 (`grep | wc -l`); left outside this slice, not presented as fixed.
- `git diff --check`: clean. `package.json` remains `0.14.1` and unchanged.

### Live read-only GitHub/npm evidence (not fixtures)

Ran `node scripts/validate-release.mjs` with a `gh auth token` loaded directly into the subprocess environment (never printed), `GITHUB_REPOSITORY=damianvtran/local-operator-ui`, `RELEASE_TAG=v0.14.1`, `EXPECTED_SOURCE_SHA=3becfb9c462f6adb1f47f9815767f5522755f849`, `EXPECTED_RELEASE_ID=383131955`:

```text
IS_MANUAL_DISPATCH=true: exit 0
Tag v0.14.1 resolves to commit 3becfb9c462f6adb1f47f9815767f5522755f849
Release v0.14.1 (id 383131955) state: published, prerelease: false
package.json name=local-operator-ui version=0.14.1 OK
Validation passed
IS_MANUAL_DISPATCH=false with same pins: exit 0, Validation passed
false + EXPECTED_SOURCE_SHA=0000000000000000000000000000000000000000:
  exit 1, Tag SHA ... does not match expected source SHA ...
false + EXPECTED_RELEASE_ID=1:
  exit 1, Release ID 383131955 does not match expected release ID 1
RELEASE_TAG=v999999.0.0: exit 1, GitHub metadata lookup failed
invalid auth token: exit 1, GitHub metadata lookup failed
npm view local-operator-ui@0.14.1 version: exit 0, 0.14.1
GET /repos/damianvtran/local-operator-ui/releases/383131955/assets: exit 0, []
```

Local evidence: `signing-validator-tests.txt`, `signing-contract-tests.txt`, `signing-live-readonly.txt`, and `signing-before-workflow.txt` under `/tmp/lop-security-evidence`. The last file evaluates predecessor YAML and records manual `npm-publish` plus all builds/attachment skipped. `git ls-remote --tags origin refs/tags/v0.14.1` separately returned the original `3becfb9c462f6adb1f47f9815767f5522755f849`.

## Pending cloud proof / rollout / rollback

Real cloud signing, notarization, all-platform builds, and actual GitHub upload have **not** run for this correction. They require the CI-held signing/Apple credentials and an authorized workflow dispatch. Local tests and read-only metadata checks do not prove that cloud path.

After independent agent review/QA and the parent's reviewed merge, the parent may authorize `publish.yml` on the reviewed workflow ref with `release_tag=v0.14.1`, `expected_source_sha=3becfb9c462f6adb1f47f9815767f5522755f849`. It must verify all jobs, macOS signature/notarization, and uploaded installers before calling recovery complete. This builds/uploads all platform artifacts onto existing release ID383131955, not only macOS. npm/tag/app version remain unchanged.

Rollback before dispatch: revert this CI-only change through a reviewed PR. If an upload partially succeeds, stop and inspect; this workflow intentionally refuses overwrite/replacement on retry. Any deletion or replacement needs separate authorization. No push, PR creation, merge, dispatch, publication, tag movement, or user-checkout changes were performed by the implementing coder.
