### PR TITLE
fix(ci): generate disposable macOS signing keychain passwords

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -69,13 +69,12 @@ jobs:
           APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
           CSC_CONTENT: ${{ secrets.CSC_CONTENT }}
           CSC_KEY_PASSWORD: ${{ secrets.CSC_KEY_PASSWORD }}
-          KEYCHAIN_PASSWORD: ${{ secrets.KEYCHAIN_PASSWORD }}
         run: |
           if [ "$NOTARIZE" != true ]; then
             echo 'NOTARIZE must be true'
             exit 1
           fi
-          for var in APPLE_ID APPLE_ID_PASSWORD APPLE_TEAM_ID CSC_CONTENT CSC_KEY_PASSWORD KEYCHAIN_PASSWORD; do
+          for var in APPLE_ID APPLE_ID_PASSWORD APPLE_TEAM_ID CSC_CONTENT CSC_KEY_PASSWORD; do
             if [ -z "${!var}" ]; then
               echo "Missing required secret: $var"
               exit 1
@@ -178,8 +177,11 @@ jobs:
         env:
           CSC_CONTENT: ${{ secrets.CSC_CONTENT }}
           CSC_KEY_PASSWORD: ${{ secrets.CSC_KEY_PASSWORD }}
-          KEYCHAIN_PASSWORD: ${{ secrets.KEYCHAIN_PASSWORD }}
         run: |
+          # This runner-local keychain has no lifetime beyond the job. Generate
+          # its password here rather than requiring a persistent repository secret.
+          KEYCHAIN_PASSWORD="$(openssl rand -hex 32)"
+          echo "::add-mask::$KEYCHAIN_PASSWORD"
           CSC_KEYCHAIN="$RUNNER_TEMP/build.keychain-db"
           echo "CSC_KEYCHAIN=$CSC_KEYCHAIN" >> "$GITHUB_ENV"
           CERTIFICATE="$RUNNER_TEMP/certificate.p12"

--- a/scripts/test-publish-workflow.mjs
+++ b/scripts/test-publish-workflow.mjs
@@ -7,7 +7,8 @@
 import assert from "node:assert/strict";
 import { test } from "node:test";
 import { createRequire } from "node:module";
-import { readFileSync, writeFileSync, mkdtempSync, mkdirSync, rmSync } from "node:fs";
+import { readFileSync, writeFileSync, mkdtempSync, mkdirSync, rmSync, existsSync } from "node:fs";
+import { createHash } from "node:crypto";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { spawnSync } from "node:child_process";
@@ -123,6 +124,64 @@ test("mac signing uses imported keychain without CSC_LINK, keeps notarization", 
   assert.match(setup, /set-key-partition-list .* -k "\$KEYCHAIN_PASSWORD" "\$CSC_KEYCHAIN"/);
   for (const job of ["build-windows", "build-linux"]) assert.ok(!JSON.stringify(jobs[job]).includes("forceCodeSigning"));
 });
+test("keychain password is generated per job, masked, and never a repository dependency", () => {
+  assert.ok(!("KEYCHAIN_PASSWORD" in preflight.env));
+  assert.doesNotMatch(preflight.run, /KEYCHAIN_PASSWORD/);
+  assert.doesNotMatch(JSON.stringify(workflow), /secrets\.KEYCHAIN_PASSWORD/);
+  assert.deepEqual(Object.keys(preflight.env).sort(), ["APPLE_ID", "APPLE_ID_PASSWORD", "APPLE_TEAM_ID", "CSC_CONTENT", "CSC_KEY_PASSWORD"]);
+  const setup = step("build-macos", "Setup code signing");
+  assert.ok(!("KEYCHAIN_PASSWORD" in setup.env));
+  assert.match(setup.run, /KEYCHAIN_PASSWORD="\$\(openssl rand -hex 32\)"/);
+});
+test("actual signing setup masks one random password and passes it consistently", () => {
+  const digests = [0, 1].map(() => sandbox((dir) => {
+    // Only security is stubbed: execute the checked-in shell, real OpenSSL
+    // generation, base64 decoding and cleanup. Persist hashes, never passwords.
+    writeFileSync(join(dir, "security"), `#!/usr/bin/env node
+const { appendFileSync } = require('node:fs');
+const { createHash } = require('node:crypto');
+const args = process.argv.slice(2);
+const command = args[0];
+const flag = command === 'set-key-partition-list' ? '-k' : '-p';
+const password = ['create-keychain', 'unlock-keychain', 'set-key-partition-list'].includes(command) ? args[args.indexOf(flag) + 1] : undefined;
+appendFileSync(process.env.CALLS_FILE, JSON.stringify({ command, keychain: args.at(-1), passwordShape: password ? /^[a-f0-9]{64}$/.test(password) : null, digest: password ? createHash('sha256').update(password).digest('hex') : null }) + '\\n');
+console.log('SECURITY_CALLED');
+`, { mode: 0o755 });
+    const result = shell(step("build-macos", "Setup code signing").run, {
+      PATH: `${dir}:${process.env.PATH}`, RUNNER_TEMP: dir,
+      GITHUB_ENV: join(dir, "env"), CALLS_FILE: join(dir, "calls"),
+      CSC_CONTENT: Buffer.from("fixture-p12").toString("base64"), CSC_KEY_PASSWORD: "fixture-p12-password",
+    }, dir);
+    // Avoid including captured stdout in assertion errors: the Actions mask
+    // command necessarily contains the value, but no test output may reveal it.
+    assert.equal(result.status, 0, "signing setup shell must succeed");
+    const lines = result.stdout.trim().split("\n");
+    assert.ok(/^::add-mask::[a-f0-9]{64}$/.test(lines[0]), "mask must precede every security invocation");
+    const password = lines[0].slice("::add-mask::".length);
+    const digest = createHash("sha256").update(password).digest("hex");
+    assert.ok(!result.stderr.includes(password));
+    assert.deepEqual(lines.slice(1), Array(5).fill("SECURITY_CALLED"));
+    const calls = readFileSync(join(dir, "calls"), "utf8").trim().split("\n").map((line) => JSON.parse(line));
+    assert.deepEqual(calls.map((c) => c.command), ["create-keychain", "default-keychain", "unlock-keychain", "import", "set-key-partition-list"]);
+    const passwordCalls = calls.filter((c) => c.digest);
+    assert.equal(passwordCalls.length, 3);
+    assert.ok(passwordCalls.every((c) => c.passwordShape && c.digest === digest), "create/unlock/partition must share the generated 32-byte password");
+    assert.ok(calls.filter((c) => c.command !== "import").every((c) => c.keychain === join(dir, "build.keychain-db")));
+    assert.equal(readFileSync(join(dir, "env"), "utf8"), `CSC_KEYCHAIN=${join(dir, "build.keychain-db")}\n`);
+    assert.ok(!existsSync(join(dir, "certificate.p12")), "temporary certificate must be removed");
+    return digest;
+  }));
+  assert.notEqual(digests[0], digests[1], "each job must generate a fresh password");
+  console.log("SIGNING_SHELL: 2 fresh 32-byte passwords; mask before use; create/unlock/partition equal; only keychain path persisted");
+});
+test("failed random generation stops before keychain setup", () => sandbox((dir) => {
+  writeFileSync(join(dir, "openssl"), "#!/bin/sh\nexit 1\n", { mode: 0o755 });
+  writeFileSync(join(dir, "security"), "#!/bin/sh\necho SECURITY_CALLED\n", { mode: 0o755 });
+  const result = shell(step("build-macos", "Setup code signing").run, { PATH: `${dir}:${process.env.PATH}`, RUNNER_TEMP: dir, GITHUB_ENV: join(dir, "env") }, dir);
+  assert.equal(result.status, 1);
+  assert.equal(result.stdout, "");
+  assert.ok(!existsSync(join(dir, "env")));
+}));
 test("actual pnpm forwarding and electron-builder parser enforce signing", async () => {
   const captures = sandbox((dir) => {
   // Preserve the real dist script. Only its expensive build and packaging


### PR DESCRIPTION
## Summary / change class

**C2 standard/pre-authorized, CI-only follow-up to #80.** Generate the temporary macOS build keychain's own password instead of treating it as a persistent repository secret. No app/package version, tag, dependency, notarization-hook or rendered surface changes.

Base: `3ed0dc1e0` (merged #80). Head: `680aeb9cf2a439aa6c45dcf0d89564c18c657dc6` on `dev-signing-ephemeral`.

## Reproduction and scope

Actual immutable v0.14.1 recovery [run33947172969](https://github.com/damianvtran/local-operator-ui/actions/runs/33947172969) stopped at preflight with `Missing required secret: KEYCHAIN_PASSWORD`. The earlier Apple/P12 fields were present. This password protects only a runner-local disposable keychain; provisioning an enduring GitHub secret is unnecessary. The genuine certificate/P12 and Apple notarization credentials remain required.

Only two files change:
- `.github/workflows/publish.yml`: remove `secrets.KEYCHAIN_PASSWORD` from preflight/setup. In the macOS setup shell, generate 32 cryptographically random bytes using `openssl rand -hex 32`, register `::add-mask::` before use, and reuse that same shell variable for create/unlock/partition-list. Persist only `CSC_KEYCHAIN` path through `GITHUB_ENV`, not its password.
- `scripts/test-publish-workflow.mjs`: preserve all genuine missing-secret/NOTARIZE negatives and add regression coverage for the absent persistent-secret dependency, generation/masking/wiring, different per-job passwords, and failed entropy generation stopping setup.

Non-goals: no installer publication, source/version/tag changes, persistent secret provisioning, Windows signing-policy changes, or alteration of #80's immutable source/release-ID/asset protections. `forceCodeSigning`, explicit imported keychain use, NOTARIZE=true and the existing notarization hook remain intact.

## Actual validation

- `node scripts/test-validate-release.mjs`: **23 passed, 0 failed**.
- `NODE_PATH="$HOME/local-operator-ui/node_modules" node --test scripts/test-release-safety.mjs scripts/test-publish-workflow.mjs`: **116 passed, 0 failed** using existing dependencies without a repository copy/install.
- Executed the exact checked-in Setup code signing shell twice with real OpenSSL/base64 and a disposable `security` executable stub. Captured only password hashes and boolean shape/equality in temporary evidence, never plaintext values in test output. Both runs generated fresh 64-hex-character values representing 32 random bytes; masking preceded all five security calls; create/unlock/partition received the same generated value; only the keychain path reached GITHUB_ENV; the temporary certificate was removed. Failed OpenSSL exited1 before mask/keychain setup.
- Real pnpm/builder argument parsing regression still proves effective `forceCodeSigning=true`; every genuine missing Apple/P12 secret and NOTARIZE=false still fails closed by name.
- `actionlint .github/workflows/publish.yml`: exit0, including shellcheck.
- `git diff --check`: clean. App/package/lockfile/notarization hook diff against merged #80: empty.
- Tests run in the existing normal PR CI job from #80. Evidence: `/tmp/lop-security-evidence/ephemeral-{validator,contract}-tests.txt`; prior actual failed preflight log: `signing-preflight-live.log`.

## Remaining cloud proof / rollout

The shell proof uses stubbed `security`; it is **not** proof of native keychain mutation, real certificate signing, Apple notarization or artifact upload. Those remain pending a reviewed merge and separately parent-authorized retry of the immutable v0.14.1 recovery. No signing secrets/keychains, npm versions, release assets/metadata or tags were mutated by implementation. No dispatch/publication performed.

After clean independent review/QA, the parent may merge and dispatch with original app SHA `3becfb9c462f6adb1f47f9815767f5522755f849`, then verify all required jobs, signature/notarization and complete release assets before declaring recovery complete. Existing no-overwrite/no-delete guards remain binding. Rollback is a reviewed CI revert; do not manufacture a persistent secret to bypass this correction.
