### PR TITLE
fix(ci): keep the signing keychain unlocked for the whole macOS build

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -152,6 +152,11 @@ jobs:
     runs-on: macos-latest
     needs: [validate-release, preflight-macos, npm-publish]
     if: ${{ needs.validate-release.result == 'success' && needs.preflight-macos.result == 'success' && needs.npm-publish.result == 'success' }}
+    # A hung codesign (run 33948569170 sat at "signing file=...app" for 5h50m
+    # until cancelled) must fail bounded rather than burn the 6h job default.
+    # Windows takes ~13 min and Linux ~8 min; universal mac packaging, signing
+    # and notarization realistically take 20-40 min, so 60 leaves headroom.
+    timeout-minutes: 60
 
     steps:
       - name: Checkout code
@@ -190,6 +195,14 @@ jobs:
           security create-keychain -p "$KEYCHAIN_PASSWORD" "$CSC_KEYCHAIN"
           security default-keychain -s "$CSC_KEYCHAIN"
           security unlock-keychain -p "$KEYCHAIN_PASSWORD" "$CSC_KEYCHAIN"
+          # A fresh keychain defaults to lock-on-sleep with a 300s timeout. It
+          # relocked partway through signing the universal app and codesign
+          # blocked on a GUI unlock prompt for ~6h (run 33948569170). Without
+          # -t/-l this removes both the timeout and lock-on-sleep, mirroring
+          # electron-builder's own createKeychain. show-keychain-info prints
+          # only the resulting "no-timeout" line, never the password.
+          security set-keychain-settings "$CSC_KEYCHAIN"
+          security show-keychain-info "$CSC_KEYCHAIN"
           security import "$CERTIFICATE" -k "$CSC_KEYCHAIN" -P "$CSC_KEY_PASSWORD" -T /usr/bin/codesign
           security set-key-partition-list -S apple-tool:,apple:,codesign:,notarize: -s -k "$KEYCHAIN_PASSWORD" "$CSC_KEYCHAIN"
 

--- a/scripts/test-publish-workflow.mjs
+++ b/scripts/test-publish-workflow.mjs
@@ -144,7 +144,7 @@ const args = process.argv.slice(2);
 const command = args[0];
 const flag = command === 'set-key-partition-list' ? '-k' : '-p';
 const password = ['create-keychain', 'unlock-keychain', 'set-key-partition-list'].includes(command) ? args[args.indexOf(flag) + 1] : undefined;
-appendFileSync(process.env.CALLS_FILE, JSON.stringify({ command, keychain: args.at(-1), passwordShape: password ? /^[a-f0-9]{64}$/.test(password) : null, digest: password ? createHash('sha256').update(password).digest('hex') : null }) + '\\n');
+appendFileSync(process.env.CALLS_FILE, JSON.stringify({ command, keychain: args.at(-1), flags: args.slice(1, -1).filter((a) => a.startsWith('-')), passwordShape: password ? /^[a-f0-9]{64}$/.test(password) : null, digest: password ? createHash('sha256').update(password).digest('hex') : null }) + '\\n');
 console.log('SECURITY_CALLED');
 `, { mode: 0o755 });
     const result = shell(step("build-macos", "Setup code signing").run, {
@@ -160,19 +160,27 @@ console.log('SECURITY_CALLED');
     const password = lines[0].slice("::add-mask::".length);
     const digest = createHash("sha256").update(password).digest("hex");
     assert.ok(!result.stderr.includes(password));
-    assert.deepEqual(lines.slice(1), Array(5).fill("SECURITY_CALLED"));
+    assert.deepEqual(lines.slice(1), Array(7).fill("SECURITY_CALLED"));
     const calls = readFileSync(join(dir, "calls"), "utf8").trim().split("\n").map((line) => JSON.parse(line));
-    assert.deepEqual(calls.map((c) => c.command), ["create-keychain", "default-keychain", "unlock-keychain", "import", "set-key-partition-list"]);
+    assert.deepEqual(calls.map((c) => c.command), ["create-keychain", "default-keychain", "unlock-keychain", "set-keychain-settings", "show-keychain-info", "import", "set-key-partition-list"]);
+    // Regression for run 33948569170: a fresh keychain auto-locks after 300s and
+    // codesign then hangs on a GUI prompt. The settings call must follow unlock,
+    // precede import/partition-list, and carry no -t timeout or -l lock flag.
+    const settings = calls.find((c) => c.command === "set-keychain-settings");
+    assert.equal(settings.keychain, join(dir, "build.keychain-db"));
+    assert.deepEqual(settings.flags, [], "set-keychain-settings must remove the timeout, not set one");
+    assert.ok(!settings.passwordShape, "keychain settings do not take the password");
     const passwordCalls = calls.filter((c) => c.digest);
     assert.equal(passwordCalls.length, 3);
     assert.ok(passwordCalls.every((c) => c.passwordShape && c.digest === digest), "create/unlock/partition must share the generated 32-byte password");
     assert.ok(calls.filter((c) => c.command !== "import").every((c) => c.keychain === join(dir, "build.keychain-db")));
+    assert.equal(calls.findIndex((c) => c.command === "set-keychain-settings") - calls.findIndex((c) => c.command === "unlock-keychain"), 1, "settings must be applied immediately after unlock");
     assert.equal(readFileSync(join(dir, "env"), "utf8"), `CSC_KEYCHAIN=${join(dir, "build.keychain-db")}\n`);
     assert.ok(!existsSync(join(dir, "certificate.p12")), "temporary certificate must be removed");
     return digest;
   }));
   assert.notEqual(digests[0], digests[1], "each job must generate a fresh password");
-  console.log("SIGNING_SHELL: 2 fresh 32-byte passwords; mask before use; create/unlock/partition equal; only keychain path persisted");
+  console.log("SIGNING_SHELL: 2 fresh 32-byte passwords; mask before use; create/unlock/partition equal; set-keychain-settings after unlock with no timeout; only keychain path persisted");
 });
 test("failed random generation stops before keychain setup", () => sandbox((dir) => {
   writeFileSync(join(dir, "openssl"), "#!/bin/sh\nexit 1\n", { mode: 0o755 });


### PR DESCRIPTION
## Summary

**Change class: C2 (CI-only).** No app source, version, or tag changes. Two files: `.github/workflows/publish.yml` and `scripts/test-publish-workflow.mjs`.

The v0.14.1 macOS recovery build (run 33948569170, job 101259014212) never produced a signed app. The job log shows it entered signing at 06:08:52Z and sat there until the run was cancelled at 11:59:16Z (5h50m), with an orphan `codesign` process terminated on cancel:

```
• signing file=dist/mac-universal/Local Operator.app ...
```

It never reached notarization. Windows (~13 min) and Linux (~8 min) completed normally in the same run.

### Root cause

The "Setup code signing" step runs `security create-keychain`, `default-keychain`, `unlock-keychain`, `import` and `set-key-partition-list`, but never `security set-keychain-settings`. A freshly created keychain defaults to lock-on-sleep with a 300 s inactivity timeout (confirmed locally with `security show-keychain-info` on a fresh keychain). Signing a universal app takes longer than five minutes, so the keychain relocked mid-signing and `codesign` blocked forever on a GUI unlock prompt that no one on a headless runner can answer.

electron-builder's own keychain path (app-builder-lib 26.0.12, `out/codeSign/macCodeSign.js` `createKeychain`) runs `["set-keychain-settings", keychainFile]` immediately after `unlock-keychain` for exactly this reason; our hand-rolled setup step skipped it.

### What changed

1. **`security set-keychain-settings "$CSC_KEYCHAIN"`** (no `-t`/`-l`, i.e. no timeout and no lock-on-sleep) right after `unlock-keychain`, followed by `security show-keychain-info "$CSC_KEYCHAIN"` so the job log proves the setting took (`... no-timeout`). `show-keychain-info` prints only the keychain path and lock settings, never the password.
2. **`timeout-minutes: 60`** on `build-macos`. Windows takes ~13 min, Linux ~8 min; universal mac packaging + signing + notarization realistically takes 20-40 min. A future hang now fails bounded instead of consuming the 6 h job default.
3. **Regression test** in `scripts/test-publish-workflow.mjs`: the existing test executes the checked-in setup shell with a stub `security` and now also asserts `set-keychain-settings` is invoked on the keychain path, immediately after `unlock-keychain`, before `import`/`set-key-partition-list`, and with no flags (so no `-t` timeout can sneak back in).

## Delivery contract

- Fresh worktree on `dev-signing-keychain-lock` cut from `origin/main` (`e080adffc`).
- Single commit `595f297c3`, conventional message, `git diff --check` clean.
- No secrets in the diff, the tests, or this body.

## Testing evidence

All commands run from the worktree against the committed head.

```
$ node scripts/test-validate-release.mjs
...
23 passed, 0 failed
All validation tests passed

$ NODE_PATH="$HOME/local-operator-ui/node_modules" node --test scripts/test-release-safety.mjs scripts/test-publish-workflow.mjs
SIGNING_SHELL: 2 fresh 32-byte passwords; mask before use; create/unlock/partition equal; set-keychain-settings after unlock with no timeout; only keychain path persisted
ℹ tests 116
ℹ pass 116
ℹ fail 0

$ actionlint .github/workflows/publish.yml   # exit 0, no findings

$ git diff --check                            # exit 0
```

Negative check, to prove the new assertion guards the fix rather than passing vacuously: temporarily rewriting the workflow line to `security set-keychain-settings -t 300 "$CSC_KEYCHAIN"` makes `test-publish-workflow.mjs` fail with:

```
ℹ pass 83
ℹ fail 1
  AssertionError [ERR_ASSERTION]: set-keychain-settings must remove the timeout, not set one
```

The workflow was restored before committing.

## What this does not prove

Native macOS signing and notarization only run on the GitHub macOS runner with the repository's certificate secrets. Nothing here exercises `codesign` or `notarytool` locally; the stub `security` in the test only verifies the shell invokes the right commands in the right order. Whether the fix actually gets v0.14.1 through signing and notarization is unproven until the recovery workflow is dispatched again after this merges. The new `show-keychain-info` line in that run's log is the first thing to check (`no-timeout`), and the job should either finish signing or fail within 60 minutes rather than hanging.
