### PR TITLE
feat(chat): mark a completion read only when it is actually viewed

### DIFF
--- a/scripts/desktop-contract.test.mjs
+++ b/scripts/desktop-contract.test.mjs
@@ -188,6 +188,16 @@ test("canonical session operations preserve identity, arguments and main-owned a
 			"POST",
 			{ subscription_id: "a".repeat(32), visible: false, can_notify: true },
 		],
+		[
+			{
+				op: "sessions.seen",
+				sessionId,
+				completionToken: "bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb",
+			},
+			`/${sessionId}/seen`,
+			"POST",
+			{ completion_token: "bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb" },
+		],
 	]) {
 		assert.equal((await requestDesktop(operation, url, token)).status, 200);
 		const actual = seen.at(-1);
@@ -209,6 +219,21 @@ test("canonical session operations preserve identity, arguments and main-owned a
 			text: "hello",
 		},
 		{ op: "sessions.command", sessionId, requestId, command: "goal extra" },
+		// A receipt carries a completion token and nothing else: a timestamp or a
+		// bodyless call is what let a background tab acknowledge an unseen result.
+		{ op: "sessions.seen", sessionId },
+		{ op: "sessions.seen", sessionId, completionToken: "now" },
+		{
+			op: "sessions.seen",
+			sessionId: "../config",
+			completionToken: "bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb",
+		},
+		{
+			op: "sessions.seen",
+			sessionId,
+			completionToken: "bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb",
+			seenAt: 123,
+		},
 		{
 			op: "sessions.watch",
 			sessionId,
@@ -724,4 +749,135 @@ test("IPC rejects other frames and opens only backend-returned authorization onc
 	await assert.rejects(() => open(event, "https://evil.example"));
 	frame.url = "https://evil.example";
 	assert.throws(() => invoke(event, { op: "settings.list" }));
+});
+
+test("a read receipt is admitted only by an actually foreground native window", async () => {
+	// Renderer visibility cannot prove native foreground: an occluded, hidden or
+	// minimized window still reports `visibilityState === "visible"` and can
+	// still hold document focus. Main owns the real BrowserWindow, so this is
+	// the only place the claim can be checked -- and it is enforced on the
+	// shared typed request door so no alternate caller can route around it.
+	globalThis.__desktopHandlers = new Map();
+	const frame = { url: "file:///app/index.html" };
+	const contents = { mainFrame: frame };
+	const state = {
+		destroyed: false,
+		visible: true,
+		minimized: false,
+		focused: true,
+	};
+	const owner = {
+		webContents: contents,
+		isDestroyed: () => state.destroyed,
+		isVisible: () => state.visible,
+		isMinimized: () => state.minimized,
+		isFocused: () => state.focused,
+	};
+	const calls = [];
+	registerDesktopIPC(
+		() => owner,
+		"file:///app/index.html",
+		async (request) => {
+			calls.push(request);
+			return { status: 200, body: { result: { unseen: false } } };
+		},
+	);
+	const invoke = globalThis.__desktopHandlers.get("desktop-request");
+	const event = { sender: contents, senderFrame: frame };
+	const receipt = {
+		op: "sessions.seen",
+		sessionId: "123456abcdef",
+		completionToken: "bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb",
+	};
+
+	await invoke(event, receipt);
+	assert.equal(calls.length, 1, "a focused, visible window may acknowledge");
+
+	// Every individual negative must refuse on its own: a background window is
+	// unfocused, an occluded/hidden one is not visible, and a minimized one can
+	// report both while showing the user nothing.
+	for (const background of [
+		{ focused: false },
+		{ visible: false },
+		{ minimized: true },
+	]) {
+		Object.assign(state, { visible: true, minimized: false, focused: true });
+		Object.assign(state, background);
+		assert.throws(
+			() => invoke(event, receipt),
+			/foreground/,
+			JSON.stringify(background),
+		);
+	}
+	assert.equal(calls.length, 1, "no background state reached the backend");
+
+	// The gate is specific to receipts. Ordinary control traffic from a
+	// background window is legitimate and must not be broken by it.
+	Object.assign(state, { visible: false, minimized: true, focused: false });
+	await invoke(event, { op: "settings.list" });
+	assert.equal(calls.at(-1).op, "settings.list");
+
+	Object.assign(state, { visible: true, minimized: false, focused: true });
+	await invoke(event, receipt);
+	assert.equal(
+		calls.length,
+		3,
+		"the receipt is admitted again once foreground",
+	);
+});
+
+test("receipt revisions converge monotonically across reconnects and reordering", async () => {
+	// Owner epochs restart; the receipt clock does not. Frames arrive reordered
+	// after a reconnect, and a snapshot captured before an acknowledgement can
+	// land after it -- so applying whatever arrived last would resurrect an
+	// already-read result or, worse, hide a newer unread one.
+	const contract = await build({
+		stdin: {
+			contents: 'export * from "./src/shared/desktop-session-contract";',
+			resolveDir: process.cwd(),
+		},
+		bundle: true,
+		format: "esm",
+		platform: "node",
+		write: false,
+	});
+	const { mergeCompletionAttention } = await import(
+		`data:text/javascript;base64,${Buffer.from(contract.outputFiles[0].text).toString("base64")}`
+	);
+	const sessionId = "123456abcdef";
+	const at = (published, acknowledged, extra = {}) => ({
+		conversation_id: `session/${sessionId}`,
+		completion_token: "bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb",
+		anchor_id: "result-1",
+		kind: "complete",
+		unseen: published > acknowledged,
+		revision: [published, acknowledged],
+		supported: true,
+		...extra,
+	});
+	const merge = (current, incoming) =>
+		mergeCompletionAttention(current, incoming, sessionId)?.revision;
+
+	assert.deepEqual(merge(undefined, at(2, 1)), [2, 1]);
+	assert.deepEqual(merge(at(1, 1), at(2, 1)), [2, 1]);
+	assert.deepEqual(merge(at(2, 1), at(2, 2)), [2, 2]);
+	// Neither clock may run backwards, whichever direction the staleness is in.
+	assert.deepEqual(merge(at(2, 2), at(1, 1)), [2, 2]);
+	assert.deepEqual(merge(at(2, 2), at(2, 1)), [2, 2]);
+	// Identity is namespaced: a persistent agent conversation and an unrelated
+	// session are different authorities even when the trailing id matches.
+	for (const foreign of [
+		{ conversation_id: "session/ffffffffffff" },
+		{ conversation_id: `agent/${sessionId}` },
+		{ revision: ["x", 1] },
+		{ revision: [-1, 0] },
+		{ revision: [3] },
+	]) {
+		assert.deepEqual(
+			merge(at(2, 2), at(9, 9, foreign)),
+			[2, 2],
+			JSON.stringify(foreign),
+		);
+	}
+	assert.deepEqual(merge(at(2, 2), undefined), [2, 2]);
 });

--- a/src/main/desktop-ipc.ts
+++ b/src/main/desktop-ipc.ts
@@ -38,6 +38,28 @@ export function registerDesktopIPC(
 	}
 	ipcMain.handle("desktop-request", (event, input: unknown) => {
 		authorize(event);
+		if (
+			input !== null &&
+			typeof input === "object" &&
+			"op" in input &&
+			input.op === "sessions.seen"
+		) {
+			// Renderer visibility is necessary but cannot prove native foreground.
+			// Enforce this on the shared typed request entry so no alternate IPC
+			// caller can bypass it. Watch leases remain notification routing only.
+			const owner = window();
+			if (
+				!owner ||
+				owner.isDestroyed() ||
+				!owner.isVisible() ||
+				owner.isMinimized() ||
+				!owner.isFocused()
+			) {
+				throw new Error(
+					"View this completion in the foreground before marking it read.",
+				);
+			}
+		}
 		return request(input);
 	});
 	// `/exit`: the window closes through the ordinary close path, so the

--- a/src/renderer/src/features/chat/canonical/canonical-transcript.tsx
+++ b/src/renderer/src/features/chat/canonical/canonical-transcript.tsx
@@ -31,6 +31,7 @@
 
 import { Spinner } from "@shared/components/common/spinner";
 import { Button } from "@shared/components/ui/button";
+import { useCompletionView } from "@shared/hooks/use-completion-view";
 import { cn } from "@shared/lib/utils";
 import {
 	CircleAlert,
@@ -48,7 +49,10 @@ import {
 	useRef,
 	useState,
 } from "react";
-import type { PendingDesktopGate } from "../../../../../shared/desktop-session-contract";
+import type {
+	CanonicalFrontendState,
+	PendingDesktopGate,
+} from "../../../../../shared/desktop-session-contract";
 import { MarkdownRenderer } from "../components/markdown-renderer";
 import { ErrorBlock } from "../components/message-item/error-block";
 import {
@@ -67,6 +71,7 @@ const WINDOW = 60;
 const WINDOW_STEP = 60;
 
 export type CanonicalTranscriptProps = {
+	frontend?: CanonicalFrontendState | null;
 	transcript: TranscriptState;
 	gate: PendingDesktopGate | null;
 	/** The owner is generating and nothing has painted yet for this turn. */
@@ -441,6 +446,15 @@ const TranscriptRow = memo(function TranscriptRow({
 	return (
 		<div
 			data-record-id={record.id}
+			data-completion-anchor={record.id}
+			data-completion-complete={
+				"complete" in record &&
+				record.complete === true &&
+				(record.kind !== "assistant" ||
+					(!record.streaming && Boolean(record.text)))
+					? "true"
+					: "false"
+			}
 			className={cn(GAP[row.gap][isSmallView ? 1 : 0])}
 		>
 			{body}
@@ -449,6 +463,7 @@ const TranscriptRow = memo(function TranscriptRow({
 });
 
 export const CanonicalTranscript: FC<CanonicalTranscriptProps> = ({
+	frontend,
 	transcript,
 	gate,
 	waiting,
@@ -459,6 +474,11 @@ export const CanonicalTranscript: FC<CanonicalTranscriptProps> = ({
 	status,
 	error,
 }) => {
+	useCompletionView(
+		frontend,
+		status === "live" && !waiting && !loadingOlder,
+		containerRef,
+	);
 	const previousRows = useRef<Row[]>([]);
 	const rows = useMemo(() => {
 		const next = buildRows(transcript.records, previousRows.current);

--- a/src/renderer/src/features/chat/canonical/transcript-reducer.ts
+++ b/src/renderer/src/features/chat/canonical/transcript-reducer.ts
@@ -43,6 +43,8 @@ export type TranscriptRecord =
 	  }
 	| {
 			kind: "assistant";
+			/** Only a full durable history read certifies the actual ending. */
+			complete?: boolean;
 			id: string;
 			ts: number;
 			text: string;
@@ -70,6 +72,8 @@ export type TranscriptRecord =
 	  }
 	| {
 			kind: "notice";
+			/** A durable completion marker, not an arbitrary renderer notice. */
+			complete?: boolean;
 			id: string;
 			ts: number;
 			text: string;
@@ -193,6 +197,28 @@ function durableRecord(
 	if (entry.type === "compaction") {
 		return { kind: "compaction", id: entry.id, ts, text: "Context compacted" };
 	}
+	if (
+		entry.type === "custom" &&
+		payload.custom_type === "completion_attention"
+	) {
+		const details = (payload.details ?? {}) as Record<string, unknown>;
+		if (
+			typeof details.anchor === "string" &&
+			(details.kind === "error" || details.kind === "interrupted")
+		) {
+			// Preserve the marker's durable position. Appending an old failure at
+			// the current retry tail would misrepresent which outcome was viewed.
+			return {
+				kind: "notice",
+				id: details.anchor,
+				ts,
+				complete: true,
+				text:
+					details.kind === "error" ? "Stopped with an error" : "Interrupted",
+				level: details.kind === "error" ? "error" : "warning",
+			};
+		}
+	}
 	if (entry.type !== "message") return null;
 	const kind = String(payload.kind ?? "message");
 	if (kind === "custom") {
@@ -251,6 +277,7 @@ function durableRecord(
 			id: entry.id,
 			ts,
 			text,
+			complete: true,
 			streaming: false,
 			stopReason: (payload.stop_reason as string | null) ?? null,
 			error: Boolean(payload.is_error),

--- a/src/renderer/src/features/chat/components/chat-content.tsx
+++ b/src/renderer/src/features/chat/components/chat-content.tsx
@@ -279,6 +279,7 @@ export const ChatContent: FC<ChatContentProps> = React.memo(
 									/* Messages container */
 									canonical ? (
 										<CanonicalTranscript
+											frontend={canonical.view.frontend}
 											transcript={canonical.view.transcript}
 											gate={canonical.view.frontend?.pending_gate ?? null}
 											waiting={canonical.busy}

--- a/src/renderer/src/shared/hooks/use-canonical-session.ts
+++ b/src/renderer/src/shared/hooks/use-canonical-session.ts
@@ -40,6 +40,7 @@ import {
 	subscribeDesktopStream,
 } from "@shared/api/local-operator/desktop-api";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { mergeCompletionAttention } from "../../../../shared/desktop-session-contract";
 import type {
 	CanonicalFrontendState,
 	DesktopHistoryPage,
@@ -146,9 +147,12 @@ export function useCanonicalSessionStream(
 			// tail is fetched once per snapshot and merged durable-wins.
 			const needsReconcile = frames.some(
 				(frame) =>
-					frame.type === "snapshot" &&
-					(frame.payload.history.cursor_missing ||
-						frame.payload.history.entries.length === 0),
+					frame.type === "attention" ||
+					(frame.type === "snapshot" &&
+						(frame.payload.frontend.snapshot.attention?.completion_token !=
+							null ||
+							frame.payload.history.cursor_missing ||
+							frame.payload.history.entries.length === 0)),
 			);
 			performance.mark("lop:transcript:flush:start");
 
@@ -234,7 +238,14 @@ export function useCanonicalSessionStream(
 							next = {
 								...next,
 								status: "live",
-								frontend: snapshot.frontend.snapshot,
+								frontend: {
+									...snapshot.frontend.snapshot,
+									attention: mergeCompletionAttention(
+										next.frontend?.attention,
+										snapshot.frontend.snapshot.attention,
+										sessionId,
+									),
+								},
 								history: snapshot.history,
 								cold: snapshot.cold,
 								ownerEpoch: snapshot.frontend.epoch,
@@ -245,6 +256,21 @@ export function useCanonicalSessionStream(
 							replayQueue.length = 0;
 							replayTranscript = null;
 						}
+						continue;
+					}
+					if (frame.type === "attention") {
+						if (next.frontend)
+							next = {
+								...next,
+								frontend: {
+									...next.frontend,
+									attention: mergeCompletionAttention(
+										next.frontend.attention,
+										frame.payload,
+										sessionId,
+									),
+								},
+							};
 						continue;
 					}
 					if (frame.type === "frontend.update") {
@@ -271,6 +297,11 @@ export function useCanonicalSessionStream(
 								frontend: {
 									...next.frontend,
 									...update.changes,
+									attention: mergeCompletionAttention(
+										next.frontend.attention,
+										update.changes.attention,
+										sessionId,
+									),
 									sequence: update.sequence,
 								},
 							};

--- a/src/renderer/src/shared/hooks/use-completion-view.ts
+++ b/src/renderer/src/shared/hooks/use-completion-view.ts
@@ -1,0 +1,96 @@
+import { desktopResult } from "@shared/api/local-operator/desktop-api";
+import { useCanonicalSessionsStore } from "@shared/store/canonical-sessions-store";
+import { type RefObject, useEffect } from "react";
+import type { CanonicalFrontendState } from "../../../../shared/desktop-session-contract";
+
+/** A stream, mount, watch lease or offscreen row is never evidence of reading.
+ * Capture canonical identity and completion together; navigation retires this
+ * attempt, and main independently checks the actual BrowserWindow at admission.
+ */
+export function useCompletionView(
+	frontend: CanonicalFrontendState | null | undefined,
+	ready: boolean,
+	root: RefObject<HTMLDivElement>,
+) {
+	const selected = useCanonicalSessionsStore((state) => state.activeSessionId);
+	const attention = frontend?.attention;
+	const sessionId = frontend?.session_id;
+	useEffect(() => {
+		if (
+			!ready ||
+			frontend?.streaming ||
+			!sessionId ||
+			selected !== sessionId ||
+			!attention?.unseen ||
+			attention.supported !== true ||
+			!attention.completion_token ||
+			!attention.anchor_id ||
+			attention.conversation_id !== `session/${sessionId}`
+		)
+			return;
+		const completionToken = attention.completion_token;
+		const anchorId = attention.anchor_id;
+		let cancelled = false;
+		let pending = false;
+		let acknowledged = false;
+		const check = () => {
+			if (
+				cancelled ||
+				pending ||
+				acknowledged ||
+				document.visibilityState !== "visible" ||
+				!document.hasFocus() ||
+				useCanonicalSessionsStore.getState().activeSessionId !== sessionId
+			)
+				return;
+			const element = root.current?.querySelector<HTMLElement>(
+				`[data-completion-anchor="${CSS.escape(anchorId)}"][data-completion-complete="true"]`,
+			);
+			if (!element) return;
+			const rect = element.getBoundingClientRect();
+			const x = rect.left + rect.width / 2;
+			const y = rect.bottom - 2;
+			if (
+				rect.width <= 0 ||
+				rect.height <= 0 ||
+				x < 0 ||
+				x >= innerWidth ||
+				y < 0 ||
+				y >= innerHeight
+			)
+				return;
+			const top = document.elementFromPoint(x, y);
+			if (!top || !element.contains(top)) return;
+			pending = true;
+			void desktopResult({ op: "sessions.seen", sessionId, completionToken })
+				.then(() => {
+					acknowledged = true;
+				})
+				.catch(() => {
+					// No optimistic clear. A rejected native-focus check or stale
+					// token leaves authoritative state intact and permits a retry.
+				})
+				.finally(() => {
+					pending = false;
+				});
+		};
+		const frame = requestAnimationFrame(check);
+		const timer = window.setInterval(check, 500);
+		return () => {
+			cancelled = true;
+			cancelAnimationFrame(frame);
+			clearInterval(timer);
+		};
+	}, [
+		ready,
+		frontend?.streaming,
+		sessionId,
+		selected,
+		attention?.conversation_id,
+		attention?.completion_token,
+		attention?.anchor_id,
+		attention?.unseen,
+		attention?.supported,
+		root,
+	]);
+}

--- a/src/shared/desktop-contract.ts
+++ b/src/shared/desktop-contract.ts
@@ -121,6 +121,13 @@ export const desktopRequestSchema = z.discriminatedUnion("op", [
 		.strict(),
 	z
 		.object({
+			op: z.literal("sessions.seen"),
+			sessionId,
+			completionToken: z.string().uuid(),
+		})
+		.strict(),
+	z
+		.object({
 			op: z.literal("sessions.watch"),
 			sessionId,
 			subscriptionId: z.string().regex(/^[a-f0-9]{32}$/),
@@ -750,6 +757,12 @@ export function desktopEndpoint(request: DesktopRequest): {
 					approved: request.approved,
 					question_index: request.questionIndex,
 				},
+			};
+		case "sessions.seen":
+			return {
+				path: `/v1/desktop/sessions/${request.sessionId}/seen`,
+				method: "POST",
+				body: { completion_token: request.completionToken },
 			};
 		case "sessions.watch":
 			return {

--- a/src/shared/desktop-session-contract.ts
+++ b/src/shared/desktop-session-contract.ts
@@ -2,6 +2,40 @@
 // Owner state revisions and HTTP semantic receipt cursors are independent. See
 // docs/desktop-controls.md before implementing replay or notifications.
 export type CanonicalSessionId = string;
+export type CompletionAttention = {
+	conversation_id: string;
+	completion_token: string | null;
+	anchor_id: string | null;
+	kind: "complete" | "error" | "interrupted" | null;
+	unseen: boolean;
+	revision: [number, number];
+	/** False for a live owner that has not negotiated completion receipts. */
+	supported?: boolean;
+};
+export function mergeCompletionAttention(
+	current: CompletionAttention | undefined,
+	incoming: CompletionAttention | undefined,
+	sessionId: string,
+): CompletionAttention | undefined {
+	if (
+		!incoming ||
+		incoming.conversation_id !== `session/${sessionId}` ||
+		!Array.isArray(incoming.revision) ||
+		incoming.revision.length !== 2 ||
+		!incoming.revision.every((n) => Number.isSafeInteger(n) && n >= 0)
+	)
+		return current;
+	// These clocks survive owner/server epochs; an old snapshot or delayed ACK
+	// can never make a newer completion, or an already-observed read, disappear.
+	if (
+		current?.conversation_id === incoming.conversation_id &&
+		(incoming.revision[0] < current.revision[0] ||
+			incoming.revision[1] < current.revision[1])
+	)
+		return current;
+	return incoming;
+}
+
 export type CanonicalModel = {
 	provider: string;
 	model_id: string;
@@ -24,6 +58,7 @@ export type PendingDesktopGate = {
 	question_total: number;
 };
 export type CanonicalFrontendState = {
+	attention?: CompletionAttention;
 	state_version: number;
 	session_id: CanonicalSessionId;
 	epoch: string;
@@ -104,6 +139,7 @@ export type DesktopSessionFrame =
 			}
 	  >
 	| Receipt<"snapshot", DesktopSnapshot>
+	| Receipt<"attention", CompletionAttention>
 	| Receipt<
 			"frontend.update",
 			{


### PR DESCRIPTION
# PR Description

## Summary of Changes

Marks a conversation read when the user has actually viewed its completed result, so a
result read in the desktop app stops showing as unread on the phone and in the terminal.
Backend companion: damianvtran/local-operator#697.

Acknowledgement is deliberately hard to earn, because every cheap proxy for "viewed" is
wrong: mounting a screen, holding a stream open, or owning a watch lease all happen while
the window is buried behind another application.

- **Renderer eligibility.** The conversation must be the selected one, the document visible
  and focused, and the **end** of the completed result actually painted and unoccluded —
  hit-tested at its bottom edge, because a result whose tail is below the fold has not been
  read. Streaming, loading and history-backfill states are excluded.
- **Native admission in main.** Renderer evidence cannot prove native foreground: an
  occluded, hidden or minimized window still reports `visibilityState === "visible"` and can
  hold document focus. Main re-checks the real `BrowserWindow` (visible, not minimized,
  focused) and does so on the **shared typed request door**, so no other IPC caller can
  route around it. Ordinary control traffic from a background window is unaffected — only
  receipts are gated.
- **Monotonic receipt merging.** Owner epochs restart and frames arrive reordered after a
  reconnect, so applying whichever payload arrived last would resurrect an already-read
  result or hide a newer unread one. Neither clock may run backwards, and identity is
  namespaced: a persistent agent conversation is not the session that shares its id.
- **Durable outcome anchors.** Error and interrupted endings anchor at their durable marker
  position rather than the current tail, so an old failure is not re-presented as the newest
  thing in the conversation.

## Related Issue(s)

- Backend companion: damianvtran/local-operator#697
- Depends on: #83 (desktop control surface) — **held on backend C5 approval**

## Impact

**Breaking changes:** none. `sessions.seen` is a new contract operation; the transcript
gains data attributes and an optional `frontend` prop.

**Dependency and review scope.** Stacked directly on #83's head (`8c60fd2a`). Review only
the adapter commit above that base. **#83's backend prerequisite is held for human C5
approval and must not be assumed merged.**

**Security.** The receipt cannot be issued by a background window, an occluded window, a
non-selected conversation, or any caller other than the owned main frame. It carries a
completion token only — no timestamp a client could use to acknowledge something it never
saw.

## Testing

There is no test runner in this repository, so verification is typecheck, lint, the theme
gates, a real build, and the contract suite driving the **actual bundled TypeScript**.

### Native foreground admission (`scripts/desktop-contract.test.mjs`)

Drives the real `registerDesktopIPC` against a fixture `BrowserWindow`:

| Window state | Receipt |
| --- | --- |
| visible, not minimized, focused | **admitted** |
| unfocused | **refused** |
| not visible | **refused** |
| minimized | **refused** |
| any background state, `settings.list` | **still works** — the gate is receipt-specific |

### Receipt convergence, on the real merge function

Ten cases bundled from the shipped contract: fresh adoption, newer completion, newer
receipt, stale published clock, stale receipt clock, foreign session id, `agent/<id>`
namespace collision, malformed and negative revisions, missing payload. Every stale or
foreign payload is rejected; no clock runs backwards.

### Request shaping

`sessions.seen` is asserted to reach `/v1/desktop/sessions/{id}/seen` with a
`completion_token` body and bearer authorization, while a bodyless call, a `"now"` token, a
traversal session id and an extra `seenAt` field are all rejected before any HTTP happens.

### Gates

```text
pnpm check-types    0 errors (main + renderer)
pnpm lint           7 warnings — pre-existing, verified identical on a stashed clean tree
pnpm check-themes   themes.generated.css up to date; 1884 contrast assertions, 12 themes
node --test scripts/desktop-contract.test.mjs    13/13 pass
pnpm build          succeeds
```

## Non-goals

- **No new visual surface.** This PR adds no unread badge, indicator or styling; it makes
  the existing shared state correct. A visible unread affordance is a separate change.
- **No native notification withdrawal.** Reading does not retract a delivered notification.
- **Pending approvals and questions are never cleared by reading.** A gate is an action, not
  a notification.
- **No optimistic local clear.** A failed or refused receipt leaves authoritative state
  untouched and simply permits a later retry, so the app never claims a read the backend
  did not record.

## Rollout

Self-enabling and additive. Against a backend without `completion-ack-v1` the renderer sees
`supported: false` and never attempts a receipt, so the app behaves exactly as it does
today.
