### PR TITLE
feat(chat): mark a completion read only when it is actually viewed

### DIFF
--- a/scripts/check-edit-diffs.mjs
+++ b/scripts/check-edit-diffs.mjs
@@ -18,46 +18,80 @@ const source = new URL(
 );
 const filename = process.argv[2] || fileURLToPath(source);
 const compiled = ts.transpileModule(readFileSync(filename, "utf8"), {
-	compilerOptions: { module: ts.ModuleKind.CommonJS, target: ts.ScriptTarget.ES2022 },
+	compilerOptions: {
+		module: ts.ModuleKind.CommonJS,
+		target: ts.ScriptTarget.ES2022,
+	},
 }).outputText;
 const module = { exports: {} };
 // Execute exactly the checked-in implementation, not a reimplementation of its
 // ranges. createRequire resolves dependencies from this repository even when a
 // before-fix source snapshot is passed as an explicit argument.
 new Function("require", "module", "exports", compiled)(
-	createRequire(source), module, module.exports,
+	createRequire(source),
+	module,
+	module.exports,
 );
 const { diffHighlight } = module.exports;
 
 for (const document of ["", "Existing trailing text"]) {
-	for (const replacement of ["New line", "First line\nSecond line\nThird line"]) {
+	for (const replacement of [
+		"New line",
+		"First line\nSecond line\nThird line",
+	]) {
 		const diff = { find: "", replace: replacement };
 		const plugin = diffHighlight({
-			diffs: [diff], currentIndex: 0, approvedDiffs: [], originalContent: document,
+			diffs: [diff],
+			currentIndex: 0,
+			approvedDiffs: [],
+			originalContent: document,
 		});
 		const state = EditorState.create({ doc: document });
 		const instance = plugin.create({ state });
 		const cursor = instance.decorations.iter();
 		assert.equal(cursor.from, 0);
 		assert.equal(cursor.to, 0);
-		assert.ok(cursor.value.spec.widget, "insertion must remain inspectable as a widget");
+		assert.ok(
+			cursor.value.spec.widget,
+			"insertion must remain inspectable as a widget",
+		);
 		assert.equal(cursor.value.spec.widget.newText, replacement);
 		assert.equal(cursor.value.spec.widget.oldText, "");
-		assert.equal(state.doc.toString(), document, "preview cannot modify the live buffer");
+		assert.equal(
+			state.doc.toString(),
+			document,
+			"preview cannot modify the live buffer",
+		);
 	}
 }
 
 const normal = diffHighlight({
-	diffs: [{ find: "old", replace: "new" }], currentIndex: 0,
-	approvedDiffs: [], originalContent: "old",
+	diffs: [{ find: "old", replace: "new" }],
+	currentIndex: 0,
+	approvedDiffs: [],
+	originalContent: "old",
 }).create({ state: EditorState.create({ doc: "old" }) });
-assert.equal(normal.decorations.size, 1, "nonempty inline replacement must stay unchanged");
+assert.equal(
+	normal.decorations.size,
+	1,
+	"nonempty inline replacement must stay unchanged",
+);
 assert.equal(normal.decorations.iter().to, 3);
 const multiline = diffHighlight({
-	diffs: [{ find: "old\nline", replace: "new\nline" }], currentIndex: 0,
-	approvedDiffs: [], originalContent: "old\nline",
+	diffs: [{ find: "old\nline", replace: "new\nline" }],
+	currentIndex: 0,
+	approvedDiffs: [],
+	originalContent: "old\nline",
 }).create({ state: EditorState.create({ doc: "old\nline" }) });
-assert.equal(multiline.decorations.size, 2, "nonempty multiline mark + widget must stay unchanged");
-const dismissed = diffHighlight(null).create({ state: EditorState.create({ doc: "" }) });
+assert.equal(
+	multiline.decorations.size,
+	2,
+	"nonempty multiline mark + widget must stay unchanged",
+);
+const dismissed = diffHighlight(null).create({
+	state: EditorState.create({ doc: "" }),
+});
 assert.equal(dismissed.decorations.size, 0);
-console.log("Edit diff regressions: 4 insertion previews + unchanged nonempty/dismissed states passed");
+console.log(
+	"Edit diff regressions: 4 insertion previews + unchanged nonempty/dismissed states passed",
+);

--- a/scripts/desktop-contract.test.mjs
+++ b/scripts/desktop-contract.test.mjs
@@ -188,6 +188,16 @@ test("canonical session operations preserve identity, arguments and main-owned a
 			"POST",
 			{ subscription_id: "a".repeat(32), visible: false, can_notify: true },
 		],
+		[
+			{
+				op: "sessions.seen",
+				sessionId,
+				completionToken: "bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb",
+			},
+			`/${sessionId}/seen`,
+			"POST",
+			{ completion_token: "bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb" },
+		],
 	]) {
 		assert.equal((await requestDesktop(operation, url, token)).status, 200);
 		const actual = seen.at(-1);
@@ -209,6 +219,21 @@ test("canonical session operations preserve identity, arguments and main-owned a
 			text: "hello",
 		},
 		{ op: "sessions.command", sessionId, requestId, command: "goal extra" },
+		// A receipt carries a completion token and nothing else: a timestamp or a
+		// bodyless call is what let a background tab acknowledge an unseen result.
+		{ op: "sessions.seen", sessionId },
+		{ op: "sessions.seen", sessionId, completionToken: "now" },
+		{
+			op: "sessions.seen",
+			sessionId: "../config",
+			completionToken: "bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb",
+		},
+		{
+			op: "sessions.seen",
+			sessionId,
+			completionToken: "bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb",
+			seenAt: 123,
+		},
 		{
 			op: "sessions.watch",
 			sessionId,
@@ -724,4 +749,135 @@ test("IPC rejects other frames and opens only backend-returned authorization onc
 	await assert.rejects(() => open(event, "https://evil.example"));
 	frame.url = "https://evil.example";
 	assert.throws(() => invoke(event, { op: "settings.list" }));
+});
+
+test("a read receipt is admitted only by an actually foreground native window", async () => {
+	// Renderer visibility cannot prove native foreground: an occluded, hidden or
+	// minimized window still reports `visibilityState === "visible"` and can
+	// still hold document focus. Main owns the real BrowserWindow, so this is
+	// the only place the claim can be checked -- and it is enforced on the
+	// shared typed request door so no alternate caller can route around it.
+	globalThis.__desktopHandlers = new Map();
+	const frame = { url: "file:///app/index.html" };
+	const contents = { mainFrame: frame };
+	const state = {
+		destroyed: false,
+		visible: true,
+		minimized: false,
+		focused: true,
+	};
+	const owner = {
+		webContents: contents,
+		isDestroyed: () => state.destroyed,
+		isVisible: () => state.visible,
+		isMinimized: () => state.minimized,
+		isFocused: () => state.focused,
+	};
+	const calls = [];
+	registerDesktopIPC(
+		() => owner,
+		"file:///app/index.html",
+		async (request) => {
+			calls.push(request);
+			return { status: 200, body: { result: { unseen: false } } };
+		},
+	);
+	const invoke = globalThis.__desktopHandlers.get("desktop-request");
+	const event = { sender: contents, senderFrame: frame };
+	const receipt = {
+		op: "sessions.seen",
+		sessionId: "123456abcdef",
+		completionToken: "bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb",
+	};
+
+	await invoke(event, receipt);
+	assert.equal(calls.length, 1, "a focused, visible window may acknowledge");
+
+	// Every individual negative must refuse on its own: a background window is
+	// unfocused, an occluded/hidden one is not visible, and a minimized one can
+	// report both while showing the user nothing.
+	for (const background of [
+		{ focused: false },
+		{ visible: false },
+		{ minimized: true },
+	]) {
+		Object.assign(state, { visible: true, minimized: false, focused: true });
+		Object.assign(state, background);
+		assert.throws(
+			() => invoke(event, receipt),
+			/foreground/,
+			JSON.stringify(background),
+		);
+	}
+	assert.equal(calls.length, 1, "no background state reached the backend");
+
+	// The gate is specific to receipts. Ordinary control traffic from a
+	// background window is legitimate and must not be broken by it.
+	Object.assign(state, { visible: false, minimized: true, focused: false });
+	await invoke(event, { op: "settings.list" });
+	assert.equal(calls.at(-1).op, "settings.list");
+
+	Object.assign(state, { visible: true, minimized: false, focused: true });
+	await invoke(event, receipt);
+	assert.equal(
+		calls.length,
+		3,
+		"the receipt is admitted again once foreground",
+	);
+});
+
+test("receipt revisions converge monotonically across reconnects and reordering", async () => {
+	// Owner epochs restart; the receipt clock does not. Frames arrive reordered
+	// after a reconnect, and a snapshot captured before an acknowledgement can
+	// land after it -- so applying whatever arrived last would resurrect an
+	// already-read result or, worse, hide a newer unread one.
+	const contract = await build({
+		stdin: {
+			contents: 'export * from "./src/shared/desktop-session-contract";',
+			resolveDir: process.cwd(),
+		},
+		bundle: true,
+		format: "esm",
+		platform: "node",
+		write: false,
+	});
+	const { mergeCompletionAttention } = await import(
+		`data:text/javascript;base64,${Buffer.from(contract.outputFiles[0].text).toString("base64")}`
+	);
+	const sessionId = "123456abcdef";
+	const at = (published, acknowledged, extra = {}) => ({
+		conversation_id: `session/${sessionId}`,
+		completion_token: "bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb",
+		anchor_id: "result-1",
+		kind: "complete",
+		unseen: published > acknowledged,
+		revision: [published, acknowledged],
+		supported: true,
+		...extra,
+	});
+	const merge = (current, incoming) =>
+		mergeCompletionAttention(current, incoming, sessionId)?.revision;
+
+	assert.deepEqual(merge(undefined, at(2, 1)), [2, 1]);
+	assert.deepEqual(merge(at(1, 1), at(2, 1)), [2, 1]);
+	assert.deepEqual(merge(at(2, 1), at(2, 2)), [2, 2]);
+	// Neither clock may run backwards, whichever direction the staleness is in.
+	assert.deepEqual(merge(at(2, 2), at(1, 1)), [2, 2]);
+	assert.deepEqual(merge(at(2, 2), at(2, 1)), [2, 2]);
+	// Identity is namespaced: a persistent agent conversation and an unrelated
+	// session are different authorities even when the trailing id matches.
+	for (const foreign of [
+		{ conversation_id: "session/ffffffffffff" },
+		{ conversation_id: `agent/${sessionId}` },
+		{ revision: ["x", 1] },
+		{ revision: [-1, 0] },
+		{ revision: [3] },
+	]) {
+		assert.deepEqual(
+			merge(at(2, 2), at(9, 9, foreign)),
+			[2, 2],
+			JSON.stringify(foreign),
+		);
+	}
+	assert.deepEqual(merge(at(2, 2), undefined), [2, 2]);
 });

--- a/scripts/desktop-contract.test.mjs
+++ b/scripts/desktop-contract.test.mjs
@@ -34,10 +34,14 @@ const bundle = await build({
 		},
 	],
 });
-const { requestDesktop, trustedDesktopFrame, registerDesktopIPC } =
-	await import(
-		`data:text/javascript;base64,${Buffer.from(bundle.outputFiles[0].text).toString("base64")}`
-	);
+const {
+	requestDesktop,
+	trustedDesktopFrame,
+	registerDesktopIPC,
+	guardForegroundReceipts,
+} = await import(
+	`data:text/javascript;base64,${Buffer.from(bundle.outputFiles[0].text).toString("base64")}`
+);
 let server;
 let url;
 const seen = [];
@@ -803,7 +807,7 @@ test("a read receipt is admitted only by an actually foreground native window", 
 	]) {
 		Object.assign(state, { visible: true, minimized: false, focused: true });
 		Object.assign(state, background);
-		assert.throws(
+		await assert.rejects(
 			() => invoke(event, receipt),
 			/foreground/,
 			JSON.stringify(background),
@@ -880,4 +884,57 @@ test("receipt revisions converge monotonically across reconnects and reordering"
 		);
 	}
 	assert.deepEqual(merge(at(2, 2), undefined), [2, 2]);
+});
+
+test("the receipt gate rides the sender, so a non-IPC main caller cannot bypass it", async () => {
+	// `DesktopNotifier` holds its own reference to the same underlying sender
+	// and calls it directly, so a gate living only inside the `desktop-request`
+	// IPC handler would not cover it. Not exploitable while the notifier emits
+	// only `sessions.watch` — but it is precisely how a future main-process
+	// caller would acquire an ungated `sessions.seen`.
+	const state = { visible: false, minimized: true, focused: false };
+	const owner = {
+		isDestroyed: () => false,
+		isVisible: () => state.visible,
+		isMinimized: () => state.minimized,
+		isFocused: () => state.focused,
+	};
+	const calls = [];
+	const guarded = guardForegroundReceipts(
+		() => owner,
+		async (input) => {
+			calls.push(input);
+			return { status: 200, body: { result: {} } };
+		},
+	);
+	const receipt = {
+		op: "sessions.seen",
+		sessionId: "123456abcdef",
+		completionToken: "bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb",
+	};
+
+	// A background window is refused even though this never touches ipcMain.
+	await assert.rejects(() => guarded(receipt), /foreground/);
+	assert.equal(calls.length, 0);
+
+	// The notifier's own traffic is unaffected: a lease is not a read, and it
+	// legitimately reports presence from a background window.
+	await guarded({
+		op: "sessions.watch",
+		sessionId: "123456abcdef",
+		subscriptionId: "a".repeat(32),
+		visible: false,
+		canNotify: true,
+	});
+	assert.equal(calls.length, 1);
+
+	Object.assign(state, { visible: true, minimized: false, focused: true });
+	await guarded(receipt);
+	assert.equal(calls.length, 2);
+
+	// Double application (sender-wrapped AND registered through the IPC entry)
+	// must stay idempotent rather than double-refusing a legitimate receipt.
+	const twice = guardForegroundReceipts(() => owner, guarded);
+	await twice(receipt);
+	assert.equal(calls.length, 3);
 });

--- a/scripts/test-publish-workflow.mjs
+++ b/scripts/test-publish-workflow.mjs
@@ -5,139 +5,296 @@
  * the YAML and CLI parsers; no second parser or dependency install is needed.
  */
 import assert from "node:assert/strict";
-import { test } from "node:test";
-import { createRequire } from "node:module";
-import { readFileSync, writeFileSync, mkdtempSync, mkdirSync, rmSync, existsSync } from "node:fs";
+import { spawnSync } from "node:child_process";
 import { createHash } from "node:crypto";
+import {
+	existsSync,
+	mkdirSync,
+	mkdtempSync,
+	readFileSync,
+	rmSync,
+	writeFileSync,
+} from "node:fs";
+import { createRequire } from "node:module";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import { spawnSync } from "node:child_process";
+import { test } from "node:test";
 
 const require = createRequire(import.meta.url);
-const builderRequire = createRequire(require.resolve("electron-builder/package.json"));
+const builderRequire = createRequire(
+	require.resolve("electron-builder/package.json"),
+);
 const appRequire = createRequire(builderRequire.resolve("app-builder-lib"));
 const { load } = appRequire("js-yaml");
 const builder = require("electron-builder/out/builder");
-const workflow = load(readFileSync(new URL("../.github/workflows/publish.yml", import.meta.url), "utf8"));
-const pkg = JSON.parse(readFileSync(new URL("../package.json", import.meta.url), "utf8"));
+const workflow = load(
+	readFileSync(
+		new URL("../.github/workflows/publish.yml", import.meta.url),
+		"utf8",
+	),
+);
+const pkg = JSON.parse(
+	readFileSync(new URL("../package.json", import.meta.url), "utf8"),
+);
 const jobs = workflow.jobs;
 const steps = (job) => jobs[job].steps;
 const step = (job, name) => steps(job).find((s) => s.name === name);
 const needsOf = (job) => [].concat(jobs[job].needs || []);
 function condition(expression, context) {
-  if (!expression) return true;
-  const code = expression.replace(/^\$\{\{\s*|\s*\}\}$/g, "").replace(/needs\.([\w-]+)\.result/g, 'needs["$1"].result');
-  // Expressions come only from the checked-in workflow, not user input. Status
-  // functions are deliberately unsupported: they can bypass GitHub's skip gate.
-  return Boolean(Function(...Object.keys(context), `return (${code})`)(...Object.values(context)));
+	if (!expression) return true;
+	const code = expression
+		.replace(/^\$\{\{\s*|\s*\}\}$/g, "")
+		.replace(/needs\.([\w-]+)\.result/g, 'needs["$1"].result');
+	// Expressions come only from the checked-in workflow, not user input. Status
+	// functions are deliberately unsupported: they can bypass GitHub's skip gate.
+	return Boolean(
+		Function(
+			...Object.keys(context),
+			`return (${code})`,
+		)(...Object.values(context)),
+	);
 }
 function graph(event, prerelease = false, forced = {}) {
-  const result = {};
-  for (const job of Object.keys(jobs)) {
-    const needs = Object.fromEntries(needsOf(job).map((n) => [n, { result: result[n] }]));
-    const success = Object.values(needs).every((n) => n.result === "success");
-    const eligible = success && condition(jobs[job].if, { needs, github: { event_name: event, event: { release: { prerelease } } } });
-    result[job] = eligible ? forced[job] || "success" : "skipped";
-  }
-  return result;
+	const result = {};
+	for (const job of Object.keys(jobs)) {
+		const needs = Object.fromEntries(
+			needsOf(job).map((n) => [n, { result: result[n] }]),
+		);
+		const success = Object.values(needs).every((n) => n.result === "success");
+		const eligible =
+			success &&
+			condition(jobs[job].if, {
+				needs,
+				github: { event_name: event, event: { release: { prerelease } } },
+			});
+		result[job] = eligible ? forced[job] || "success" : "skipped";
+	}
+	return result;
 }
 function sandbox(fn) {
-  const dir = mkdtempSync(join(tmpdir(), "publish-contract-"));
-  try { return fn(dir); } finally { rmSync(dir, { recursive: true, force: true }); }
+	const dir = mkdtempSync(join(tmpdir(), "publish-contract-"));
+	try {
+		return fn(dir);
+	} finally {
+		rmSync(dir, { recursive: true, force: true });
+	}
 }
-const cleanEnv = { PATH: process.env.PATH, HOME: process.env.HOME, NODE_PATH: process.env.NODE_PATH || "" };
+const cleanEnv = {
+	PATH: process.env.PATH,
+	HOME: process.env.HOME,
+	NODE_PATH: process.env.NODE_PATH || "",
+};
 function shell(script, env, cwd) {
-  return spawnSync("bash", ["--noprofile", "--norc", "-e", "-o", "pipefail", "-c", script], { encoding: "utf8", cwd, env: { ...cleanEnv, ...env } });
+	return spawnSync(
+		"bash",
+		["--noprofile", "--norc", "-e", "-o", "pipefail", "-c", script],
+		{ encoding: "utf8", cwd, env: { ...cleanEnv, ...env } },
+	);
 }
 
-for (const [event, prerelease] of [["workflow_dispatch", false], ["release", false], ["release", true]]) {
-  test(`${event} prerelease=${prerelease}: every required job reaches upload`, () => {
-    const result = graph(event, prerelease);
-    assert.ok(Object.values(result).every((r) => r === "success"), JSON.stringify(result));
-    console.log(`REACHABLE ${event} prerelease=${prerelease}: ${Object.keys(result).join(" -> ")}`);
-  });
-  for (const failed of ["validate-release", "preflight-macos", "npm-publish", "build-macos", "build-windows", "build-linux"]) {
-    for (const status of ["failure", "cancelled", "skipped"]) {
-      test(`${event} prerelease=${prerelease}: ${failed} ${status} blocks upload`, () => {
-        assert.equal(graph(event, prerelease, { [failed]: status })["attach-to-release"], "skipped");
-      });
-    }
-  }
+for (const [event, prerelease] of [
+	["workflow_dispatch", false],
+	["release", false],
+	["release", true],
+]) {
+	test(`${event} prerelease=${prerelease}: every required job reaches upload`, () => {
+		const result = graph(event, prerelease);
+		assert.ok(
+			Object.values(result).every((r) => r === "success"),
+			JSON.stringify(result),
+		);
+		console.log(
+			`REACHABLE ${event} prerelease=${prerelease}: ${Object.keys(result).join(" -> ")}`,
+		);
+	});
+	for (const failed of [
+		"validate-release",
+		"preflight-macos",
+		"npm-publish",
+		"build-macos",
+		"build-windows",
+		"build-linux",
+	]) {
+		for (const status of ["failure", "cancelled", "skipped"]) {
+			test(`${event} prerelease=${prerelease}: ${failed} ${status} blocks upload`, () => {
+				assert.equal(
+					graph(event, prerelease, { [failed]: status })["attach-to-release"],
+					"skipped",
+				);
+			});
+		}
+	}
 }
 test("upload requires all platform jobs; no status-function bypass", () => {
-  assert.deepEqual(needsOf("attach-to-release").sort(), ["build-linux", "build-macos", "build-windows", "validate-release"]);
-  for (const job of Object.values(jobs)) assert.doesNotMatch(job.if || "", /always\(|failure\(|cancelled\(/);
+	assert.deepEqual(needsOf("attach-to-release").sort(), [
+		"build-linux",
+		"build-macos",
+		"build-windows",
+		"validate-release",
+	]);
+	for (const job of Object.values(jobs))
+		assert.doesNotMatch(job.if || "", /always\(|failure\(|cancelled\(/);
 });
 test("payload checkouts use validated source, helper checkouts use workflow SHA", () => {
-  for (const job of ["npm-publish", "build-macos", "build-windows", "build-linux"]) {
-    assert.equal(step(job, "Checkout code").with.ref, "${{ needs.validate-release.outputs.source_sha }}");
-  }
-  for (const job of ["validate-release", "attach-to-release"]) {
-    assert.equal(step(job, "Checkout workflow scripts").with.ref, "${{ github.workflow_sha }}");
-  }
-  const upload = step("attach-to-release", "Revalidate and attach artifacts to existing release");
-  assert.equal(upload.run, "node workflow/scripts/upload-release.mjs");
-  assert.equal(upload.env.EXPECTED_SOURCE_SHA, "${{ needs.validate-release.outputs.source_sha }}");
-  assert.equal(upload.env.EXPECTED_RELEASE_ID, "${{ needs.validate-release.outputs.release_id }}");
-  assert.match(step("attach-to-release", "Checkout workflow scripts").with["sparse-checkout"], /scripts\/upload-release.mjs/);
-  assert.equal(step("attach-to-release", "Checkout workflow scripts").with.path, "workflow");
+	for (const job of [
+		"npm-publish",
+		"build-macos",
+		"build-windows",
+		"build-linux",
+	]) {
+		assert.equal(
+			step(job, "Checkout code").with.ref,
+			"${{ needs.validate-release.outputs.source_sha }}",
+		);
+	}
+	for (const job of ["validate-release", "attach-to-release"]) {
+		assert.equal(
+			step(job, "Checkout workflow scripts").with.ref,
+			"${{ github.workflow_sha }}",
+		);
+	}
+	const upload = step(
+		"attach-to-release",
+		"Revalidate and attach artifacts to existing release",
+	);
+	assert.equal(upload.run, "node workflow/scripts/upload-release.mjs");
+	assert.equal(
+		upload.env.EXPECTED_SOURCE_SHA,
+		"${{ needs.validate-release.outputs.source_sha }}",
+	);
+	assert.equal(
+		upload.env.EXPECTED_RELEASE_ID,
+		"${{ needs.validate-release.outputs.release_id }}",
+	);
+	assert.match(
+		step("attach-to-release", "Checkout workflow scripts").with[
+			"sparse-checkout"
+		],
+		/scripts\/upload-release.mjs/,
+	);
+	assert.equal(
+		step("attach-to-release", "Checkout workflow scripts").with.path,
+		"workflow",
+	);
 });
 for (const event of ["release", "workflow_dispatch"]) {
-  for (const published of ["true", "false"]) {
-    test(`npm publish guard event=${event}, published=${published}`, () => {
-      assert.equal(condition(step("npm-publish", "Publish to npm").if, { github: { event_name: event }, steps: { check_version: { outputs: { published } } } }), event === "release" && published === "false");
-    });
-  }
+	for (const published of ["true", "false"]) {
+		test(`npm publish guard event=${event}, published=${published}`, () => {
+			assert.equal(
+				condition(step("npm-publish", "Publish to npm").if, {
+					github: { event_name: event },
+					steps: { check_version: { outputs: { published } } },
+				}),
+				event === "release" && published === "false",
+			);
+		});
+	}
 }
-for (const [label, output, exitCode] of [["exists", "0.14.1", 0], ["absent", "", 1], ["registry unavailable", "", 42], ["wrong version", "0.14.0", 0]]) {
-  for (const manual of [true, false]) {
-    test(`npm registry ${label}, manual=${manual}: actual shell gate`, () => sandbox((dir) => {
-      writeFileSync(join(dir, "package.json"), JSON.stringify({ name: "local-operator-ui", version: "0.14.1" }));
-      writeFileSync(join(dir, "npm"), `#!/bin/sh\nprintf '%s\\n' '${output}'\nexit ${exitCode}\n`, { mode: 0o755 });
-      const result = shell(step("npm-publish", "Check if version already published").run, { PATH: `${dir}:${process.env.PATH}`, IS_MANUAL_DISPATCH: String(manual), GITHUB_OUTPUT: join(dir, "outputs") }, dir);
-      assert.equal(result.status, manual && label !== "exists" ? 1 : 0, result.stderr);
-      if (result.status === 0) assert.equal(readFileSync(join(dir, "outputs"), "utf8").trim(), `published=${label === "exists"}`);
-    }));
-  }
+for (const [label, output, exitCode] of [
+	["exists", "0.14.1", 0],
+	["absent", "", 1],
+	["registry unavailable", "", 42],
+	["wrong version", "0.14.0", 0],
+]) {
+	for (const manual of [true, false]) {
+		test(`npm registry ${label}, manual=${manual}: actual shell gate`, () =>
+			sandbox((dir) => {
+				writeFileSync(
+					join(dir, "package.json"),
+					JSON.stringify({ name: "local-operator-ui", version: "0.14.1" }),
+				);
+				writeFileSync(
+					join(dir, "npm"),
+					`#!/bin/sh\nprintf '%s\\n' '${output}'\nexit ${exitCode}\n`,
+					{ mode: 0o755 },
+				);
+				const result = shell(
+					step("npm-publish", "Check if version already published").run,
+					{
+						PATH: `${dir}:${process.env.PATH}`,
+						IS_MANUAL_DISPATCH: String(manual),
+						GITHUB_OUTPUT: join(dir, "outputs"),
+					},
+					dir,
+				);
+				assert.equal(
+					result.status,
+					manual && label !== "exists" ? 1 : 0,
+					result.stderr,
+				);
+				if (result.status === 0)
+					assert.equal(
+						readFileSync(join(dir, "outputs"), "utf8").trim(),
+						`published=${label === "exists"}`,
+					);
+			}));
+	}
 }
 const preflight = step("preflight-macos", "Check required secrets");
-const signingEnv = { NOTARIZE: workflow.env.NOTARIZE, ...Object.fromEntries(Object.keys(preflight.env).map((k) => [k, "fixture-secret-value-never-log"])) };
-test("signing preflight accepts complete credentials", () => assert.equal(shell(preflight.run, signingEnv).status, 0));
+const signingEnv = {
+	NOTARIZE: workflow.env.NOTARIZE,
+	...Object.fromEntries(
+		Object.keys(preflight.env).map((k) => [
+			k,
+			"fixture-secret-value-never-log",
+		]),
+	),
+};
+test("signing preflight accepts complete credentials", () =>
+	assert.equal(shell(preflight.run, signingEnv).status, 0));
 for (const name of Object.keys(signingEnv)) {
-  test(`signing preflight rejects missing ${name} without exposing values`, () => {
-    const result = shell(preflight.run, { ...signingEnv, [name]: "" });
-    assert.equal(result.status, 1);
-    assert.match(result.stdout, new RegExp(name));
-    assert.doesNotMatch(result.stdout + result.stderr, /fixture-secret-value/);
-  });
+	test(`signing preflight rejects missing ${name} without exposing values`, () => {
+		const result = shell(preflight.run, { ...signingEnv, [name]: "" });
+		assert.equal(result.status, 1);
+		assert.match(result.stdout, new RegExp(name));
+		assert.doesNotMatch(result.stdout + result.stderr, /fixture-secret-value/);
+	});
 }
-test("NOTARIZE=false is rejected", () => assert.equal(shell(preflight.run, { ...signingEnv, NOTARIZE: "false" }).status, 1));
+test("NOTARIZE=false is rejected", () =>
+	assert.equal(
+		shell(preflight.run, { ...signingEnv, NOTARIZE: "false" }).status,
+		1,
+	));
 test("mac signing uses imported keychain without CSC_LINK, keeps notarization", () => {
-  assert.equal(workflow.env.NOTARIZE, "true");
-  const mac = step("build-macos", "Build macOS app");
-  assert.ok(!("NOTARIZE" in mac.env));
-  assert.ok(!("CSC_LINK" in mac.env));
-  for (const key of ["APPLE_ID", "APPLE_ID_PASSWORD", "APPLE_TEAM_ID"]) assert.equal(mac.env[key], preflight.env[key]);
-  const setup = step("build-macos", "Setup code signing").run;
-  assert.match(setup, /CSC_KEYCHAIN=\"\$RUNNER_TEMP\/build.keychain-db\"/);
-  assert.match(setup, /echo "CSC_KEYCHAIN=\$CSC_KEYCHAIN" >> "\$GITHUB_ENV"/);
-  assert.match(setup, /set-key-partition-list .* -k "\$KEYCHAIN_PASSWORD" "\$CSC_KEYCHAIN"/);
-  for (const job of ["build-windows", "build-linux"]) assert.ok(!JSON.stringify(jobs[job]).includes("forceCodeSigning"));
+	assert.equal(workflow.env.NOTARIZE, "true");
+	const mac = step("build-macos", "Build macOS app");
+	assert.ok(!("NOTARIZE" in mac.env));
+	assert.ok(!("CSC_LINK" in mac.env));
+	for (const key of ["APPLE_ID", "APPLE_ID_PASSWORD", "APPLE_TEAM_ID"])
+		assert.equal(mac.env[key], preflight.env[key]);
+	const setup = step("build-macos", "Setup code signing").run;
+	assert.match(setup, /CSC_KEYCHAIN=\"\$RUNNER_TEMP\/build.keychain-db\"/);
+	assert.match(setup, /echo "CSC_KEYCHAIN=\$CSC_KEYCHAIN" >> "\$GITHUB_ENV"/);
+	assert.match(
+		setup,
+		/set-key-partition-list .* -k "\$KEYCHAIN_PASSWORD" "\$CSC_KEYCHAIN"/,
+	);
+	for (const job of ["build-windows", "build-linux"])
+		assert.ok(!JSON.stringify(jobs[job]).includes("forceCodeSigning"));
 });
 test("keychain password is generated per job, masked, and never a repository dependency", () => {
-  assert.ok(!("KEYCHAIN_PASSWORD" in preflight.env));
-  assert.doesNotMatch(preflight.run, /KEYCHAIN_PASSWORD/);
-  assert.doesNotMatch(JSON.stringify(workflow), /secrets\.KEYCHAIN_PASSWORD/);
-  assert.deepEqual(Object.keys(preflight.env).sort(), ["APPLE_ID", "APPLE_ID_PASSWORD", "APPLE_TEAM_ID", "CSC_CONTENT", "CSC_KEY_PASSWORD"]);
-  const setup = step("build-macos", "Setup code signing");
-  assert.ok(!("KEYCHAIN_PASSWORD" in setup.env));
-  assert.match(setup.run, /KEYCHAIN_PASSWORD="\$\(openssl rand -hex 32\)"/);
+	assert.ok(!("KEYCHAIN_PASSWORD" in preflight.env));
+	assert.doesNotMatch(preflight.run, /KEYCHAIN_PASSWORD/);
+	assert.doesNotMatch(JSON.stringify(workflow), /secrets\.KEYCHAIN_PASSWORD/);
+	assert.deepEqual(Object.keys(preflight.env).sort(), [
+		"APPLE_ID",
+		"APPLE_ID_PASSWORD",
+		"APPLE_TEAM_ID",
+		"CSC_CONTENT",
+		"CSC_KEY_PASSWORD",
+	]);
+	const setup = step("build-macos", "Setup code signing");
+	assert.ok(!("KEYCHAIN_PASSWORD" in setup.env));
+	assert.match(setup.run, /KEYCHAIN_PASSWORD="\$\(openssl rand -hex 32\)"/);
 });
 test("actual signing setup masks one random password and passes it consistently", () => {
-  const digests = [0, 1].map(() => sandbox((dir) => {
-    // Only security is stubbed: execute the checked-in shell, real OpenSSL
-    // generation, base64 decoding and cleanup. Persist hashes, never passwords.
-    writeFileSync(join(dir, "security"), `#!/usr/bin/env node
+	const digests = [0, 1].map(() =>
+		sandbox((dir) => {
+			// Only security is stubbed: execute the checked-in shell, real OpenSSL
+			// generation, base64 decoding and cleanup. Persist hashes, never passwords.
+			writeFileSync(
+				join(dir, "security"),
+				`#!/usr/bin/env node
 const { appendFileSync } = require('node:fs');
 const { createHash } = require('node:crypto');
 const args = process.argv.slice(2);
@@ -146,70 +303,171 @@ const flag = command === 'set-key-partition-list' ? '-k' : '-p';
 const password = ['create-keychain', 'unlock-keychain', 'set-key-partition-list'].includes(command) ? args[args.indexOf(flag) + 1] : undefined;
 appendFileSync(process.env.CALLS_FILE, JSON.stringify({ command, keychain: args.at(-1), flags: args.slice(1, -1).filter((a) => a.startsWith('-')), passwordShape: password ? /^[a-f0-9]{64}$/.test(password) : null, digest: password ? createHash('sha256').update(password).digest('hex') : null }) + '\\n');
 console.log('SECURITY_CALLED');
-`, { mode: 0o755 });
-    const result = shell(step("build-macos", "Setup code signing").run, {
-      PATH: `${dir}:${process.env.PATH}`, RUNNER_TEMP: dir,
-      GITHUB_ENV: join(dir, "env"), CALLS_FILE: join(dir, "calls"),
-      CSC_CONTENT: Buffer.from("fixture-p12").toString("base64"), CSC_KEY_PASSWORD: "fixture-p12-password",
-    }, dir);
-    // Avoid including captured stdout in assertion errors: the Actions mask
-    // command necessarily contains the value, but no test output may reveal it.
-    assert.equal(result.status, 0, "signing setup shell must succeed");
-    const lines = result.stdout.trim().split("\n");
-    assert.ok(/^::add-mask::[a-f0-9]{64}$/.test(lines[0]), "mask must precede every security invocation");
-    const password = lines[0].slice("::add-mask::".length);
-    const digest = createHash("sha256").update(password).digest("hex");
-    assert.ok(!result.stderr.includes(password));
-    assert.deepEqual(lines.slice(1), Array(7).fill("SECURITY_CALLED"));
-    const calls = readFileSync(join(dir, "calls"), "utf8").trim().split("\n").map((line) => JSON.parse(line));
-    assert.deepEqual(calls.map((c) => c.command), ["create-keychain", "default-keychain", "unlock-keychain", "set-keychain-settings", "show-keychain-info", "import", "set-key-partition-list"]);
-    // Regression for run 33948569170: a fresh keychain auto-locks after 300s and
-    // codesign then hangs on a GUI prompt. The settings call must follow unlock,
-    // precede import/partition-list, and carry no -t timeout or -l lock flag.
-    const settings = calls.find((c) => c.command === "set-keychain-settings");
-    assert.equal(settings.keychain, join(dir, "build.keychain-db"));
-    assert.deepEqual(settings.flags, [], "set-keychain-settings must remove the timeout, not set one");
-    assert.ok(!settings.passwordShape, "keychain settings do not take the password");
-    const passwordCalls = calls.filter((c) => c.digest);
-    assert.equal(passwordCalls.length, 3);
-    assert.ok(passwordCalls.every((c) => c.passwordShape && c.digest === digest), "create/unlock/partition must share the generated 32-byte password");
-    assert.ok(calls.filter((c) => c.command !== "import").every((c) => c.keychain === join(dir, "build.keychain-db")));
-    assert.equal(calls.findIndex((c) => c.command === "set-keychain-settings") - calls.findIndex((c) => c.command === "unlock-keychain"), 1, "settings must be applied immediately after unlock");
-    assert.equal(readFileSync(join(dir, "env"), "utf8"), `CSC_KEYCHAIN=${join(dir, "build.keychain-db")}\n`);
-    assert.ok(!existsSync(join(dir, "certificate.p12")), "temporary certificate must be removed");
-    return digest;
-  }));
-  assert.notEqual(digests[0], digests[1], "each job must generate a fresh password");
-  console.log("SIGNING_SHELL: 2 fresh 32-byte passwords; mask before use; create/unlock/partition equal; set-keychain-settings after unlock with no timeout; only keychain path persisted");
+`,
+				{ mode: 0o755 },
+			);
+			const result = shell(
+				step("build-macos", "Setup code signing").run,
+				{
+					PATH: `${dir}:${process.env.PATH}`,
+					RUNNER_TEMP: dir,
+					GITHUB_ENV: join(dir, "env"),
+					CALLS_FILE: join(dir, "calls"),
+					CSC_CONTENT: Buffer.from("fixture-p12").toString("base64"),
+					CSC_KEY_PASSWORD: "fixture-p12-password",
+				},
+				dir,
+			);
+			// Avoid including captured stdout in assertion errors: the Actions mask
+			// command necessarily contains the value, but no test output may reveal it.
+			assert.equal(result.status, 0, "signing setup shell must succeed");
+			const lines = result.stdout.trim().split("\n");
+			assert.ok(
+				/^::add-mask::[a-f0-9]{64}$/.test(lines[0]),
+				"mask must precede every security invocation",
+			);
+			const password = lines[0].slice("::add-mask::".length);
+			const digest = createHash("sha256").update(password).digest("hex");
+			assert.ok(!result.stderr.includes(password));
+			assert.deepEqual(lines.slice(1), Array(7).fill("SECURITY_CALLED"));
+			const calls = readFileSync(join(dir, "calls"), "utf8")
+				.trim()
+				.split("\n")
+				.map((line) => JSON.parse(line));
+			assert.deepEqual(
+				calls.map((c) => c.command),
+				[
+					"create-keychain",
+					"default-keychain",
+					"unlock-keychain",
+					"set-keychain-settings",
+					"show-keychain-info",
+					"import",
+					"set-key-partition-list",
+				],
+			);
+			// Regression for run 33948569170: a fresh keychain auto-locks after 300s and
+			// codesign then hangs on a GUI prompt. The settings call must follow unlock,
+			// precede import/partition-list, and carry no -t timeout or -l lock flag.
+			const settings = calls.find((c) => c.command === "set-keychain-settings");
+			assert.equal(settings.keychain, join(dir, "build.keychain-db"));
+			assert.deepEqual(
+				settings.flags,
+				[],
+				"set-keychain-settings must remove the timeout, not set one",
+			);
+			assert.ok(
+				!settings.passwordShape,
+				"keychain settings do not take the password",
+			);
+			const passwordCalls = calls.filter((c) => c.digest);
+			assert.equal(passwordCalls.length, 3);
+			assert.ok(
+				passwordCalls.every((c) => c.passwordShape && c.digest === digest),
+				"create/unlock/partition must share the generated 32-byte password",
+			);
+			assert.ok(
+				calls
+					.filter((c) => c.command !== "import")
+					.every((c) => c.keychain === join(dir, "build.keychain-db")),
+			);
+			assert.equal(
+				calls.findIndex((c) => c.command === "set-keychain-settings") -
+					calls.findIndex((c) => c.command === "unlock-keychain"),
+				1,
+				"settings must be applied immediately after unlock",
+			);
+			assert.equal(
+				readFileSync(join(dir, "env"), "utf8"),
+				`CSC_KEYCHAIN=${join(dir, "build.keychain-db")}\n`,
+			);
+			assert.ok(
+				!existsSync(join(dir, "certificate.p12")),
+				"temporary certificate must be removed",
+			);
+			return digest;
+		}),
+	);
+	assert.notEqual(
+		digests[0],
+		digests[1],
+		"each job must generate a fresh password",
+	);
+	console.log(
+		"SIGNING_SHELL: 2 fresh 32-byte passwords; mask before use; create/unlock/partition equal; set-keychain-settings after unlock with no timeout; only keychain path persisted",
+	);
 });
-test("failed random generation stops before keychain setup", () => sandbox((dir) => {
-  writeFileSync(join(dir, "openssl"), "#!/bin/sh\nexit 1\n", { mode: 0o755 });
-  writeFileSync(join(dir, "security"), "#!/bin/sh\necho SECURITY_CALLED\n", { mode: 0o755 });
-  const result = shell(step("build-macos", "Setup code signing").run, { PATH: `${dir}:${process.env.PATH}`, RUNNER_TEMP: dir, GITHUB_ENV: join(dir, "env") }, dir);
-  assert.equal(result.status, 1);
-  assert.equal(result.stdout, "");
-  assert.ok(!existsSync(join(dir, "env")));
-}));
+test("failed random generation stops before keychain setup", () =>
+	sandbox((dir) => {
+		writeFileSync(join(dir, "openssl"), "#!/bin/sh\nexit 1\n", { mode: 0o755 });
+		writeFileSync(join(dir, "security"), "#!/bin/sh\necho SECURITY_CALLED\n", {
+			mode: 0o755,
+		});
+		const result = shell(
+			step("build-macos", "Setup code signing").run,
+			{
+				PATH: `${dir}:${process.env.PATH}`,
+				RUNNER_TEMP: dir,
+				GITHUB_ENV: join(dir, "env"),
+			},
+			dir,
+		);
+		assert.equal(result.status, 1);
+		assert.equal(result.stdout, "");
+		assert.ok(!existsSync(join(dir, "env")));
+	}));
 test("actual pnpm forwarding and electron-builder parser enforce signing", async () => {
-  const captures = sandbox((dir) => {
-  // Preserve the real dist script. Only its expensive build and packaging
-  // executables are replaced at the process boundary to capture actual argv.
-  writeFileSync(join(dir, "package.json"), JSON.stringify({ scripts: { build: "node -e ''", "dist:mac": pkg.scripts["dist:mac"] } }));
-  mkdirSync(join(dir, "bin"));
-  writeFileSync(join(dir, "bin", "electron-builder"), '#!/usr/bin/env node\nconsole.log("BUILDER_ARGV="+JSON.stringify(process.argv.slice(2)));\n', { mode: 0o755 });
-  return [["pnpm dist:mac -- -c.forceCodeSigning=true", false], [step("build-macos", "Build macOS app").run, true]].map(([command, shouldForce]) => {
-    const result = shell(command, { PATH: `${join(dir, "bin")}:${process.env.PATH}` }, dir);
-    assert.equal(result.status, 0, result.stderr);
-    const args = JSON.parse(result.stdout.split("\n").find((line) => line.startsWith("BUILDER_ARGV=")).slice(13));
-    const parsed = builder.configureBuildCommand(builder.createYargs()).parse(args);
-    const options = builder.normalizeOptions(parsed);
-    return { command, shouldForce, args, options };
-  });
-  });
-  for (const { command, shouldForce, args, options } of captures) {
-    // AJV performs boolean coercion after yargs and normalizeOptions.
-    await appRequire("./util/config/config").validateConfiguration(options.config || {}, { add() {} });
-    assert.equal(options.config?.forceCodeSigning === true, shouldForce, JSON.stringify({ args, options }));
-    console.log(`ACTUAL ${command}: argv=${JSON.stringify(args)} forceCodeSigning=${options.config?.forceCodeSigning}`);
-  }
+	const captures = sandbox((dir) => {
+		// Preserve the real dist script. Only its expensive build and packaging
+		// executables are replaced at the process boundary to capture actual argv.
+		writeFileSync(
+			join(dir, "package.json"),
+			JSON.stringify({
+				scripts: { build: "node -e ''", "dist:mac": pkg.scripts["dist:mac"] },
+			}),
+		);
+		mkdirSync(join(dir, "bin"));
+		writeFileSync(
+			join(dir, "bin", "electron-builder"),
+			'#!/usr/bin/env node\nconsole.log("BUILDER_ARGV="+JSON.stringify(process.argv.slice(2)));\n',
+			{ mode: 0o755 },
+		);
+		return [
+			["pnpm dist:mac -- -c.forceCodeSigning=true", false],
+			[step("build-macos", "Build macOS app").run, true],
+		].map(([command, shouldForce]) => {
+			const result = shell(
+				command,
+				{ PATH: `${join(dir, "bin")}:${process.env.PATH}` },
+				dir,
+			);
+			assert.equal(result.status, 0, result.stderr);
+			const args = JSON.parse(
+				result.stdout
+					.split("\n")
+					.find((line) => line.startsWith("BUILDER_ARGV="))
+					.slice(13),
+			);
+			const parsed = builder
+				.configureBuildCommand(builder.createYargs())
+				.parse(args);
+			const options = builder.normalizeOptions(parsed);
+			return { command, shouldForce, args, options };
+		});
+	});
+	for (const { command, shouldForce, args, options } of captures) {
+		// AJV performs boolean coercion after yargs and normalizeOptions.
+		await appRequire("./util/config/config").validateConfiguration(
+			options.config || {},
+			{ add() {} },
+		);
+		assert.equal(
+			options.config?.forceCodeSigning === true,
+			shouldForce,
+			JSON.stringify({ args, options }),
+		);
+		console.log(
+			`ACTUAL ${command}: argv=${JSON.stringify(args)} forceCodeSigning=${options.config?.forceCodeSigning}`,
+		);
+	}
 });

--- a/scripts/test-release-safety.mjs
+++ b/scripts/test-release-safety.mjs
@@ -1,111 +1,257 @@
 #!/usr/bin/env node
 /** Metadata tests use explicit fixtures, not live-release evidence. No network. */
 import assert from "node:assert/strict";
-import { test } from "node:test";
-import { mkdtempSync, mkdirSync, writeFileSync, rmSync, symlinkSync } from "node:fs";
+import {
+	mkdirSync,
+	mkdtempSync,
+	rmSync,
+	symlinkSync,
+	writeFileSync,
+} from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import { validateInputs, validateRelease, resolveTagSha } from "./validate-release.mjs";
-import { artifactFiles, checkAssetCollisions, uploadRelease } from "./upload-release.mjs";
+import { test } from "node:test";
+import {
+	artifactFiles,
+	checkAssetCollisions,
+	uploadRelease,
+} from "./upload-release.mjs";
+import {
+	resolveTagSha,
+	validateInputs,
+	validateRelease,
+} from "./validate-release.mjs";
 
 const SHA = "3becfb9c462f6adb1f47f9815767f5522755f849";
 const TAG = "v0.14.1";
 const ID = 383131955;
-function fixture({ tag = TAG, sha = SHA, ref = `refs/tags/${tag}`, release = {}, pkg = {}, missing = "", assets = [] } = {}) {
-  return (path) => {
-    if (path === missing) throw new Error("GitHub HTTP 404");
-    if (path === `/git/ref/tags/${tag}`) return { ref, object: { type: "commit", sha } };
-    if (path === `/releases/tags/${tag}`) return { id: ID, tag_name: tag, draft: false, prerelease: false, published_at: "2026-09-05T00:00:00Z", ...release };
-    if (path === `/contents/package.json?ref=${sha}`) return { content: Buffer.from(JSON.stringify({ name: "local-operator-ui", version: tag.slice(1), ...pkg })).toString("base64") };
-    if (path.startsWith(`/releases/${ID}/assets?`)) return assets;
-    throw new Error(`Unexpected API path: ${path}`);
-  };
+function fixture({
+	tag = TAG,
+	sha = SHA,
+	ref = `refs/tags/${tag}`,
+	release = {},
+	pkg = {},
+	missing = "",
+	assets = [],
+} = {}) {
+	return (path) => {
+		if (path === missing) throw new Error("GitHub HTTP 404");
+		if (path === `/git/ref/tags/${tag}`)
+			return { ref, object: { type: "commit", sha } };
+		if (path === `/releases/tags/${tag}`)
+			return {
+				id: ID,
+				tag_name: tag,
+				draft: false,
+				prerelease: false,
+				published_at: "2026-09-05T00:00:00Z",
+				...release,
+			};
+		if (path === `/contents/package.json?ref=${sha}`)
+			return {
+				content: Buffer.from(
+					JSON.stringify({
+						name: "local-operator-ui",
+						version: tag.slice(1),
+						...pkg,
+					}),
+				).toString("base64"),
+			};
+		if (path.startsWith(`/releases/${ID}/assets?`)) return assets;
+		throw new Error(`Unexpected API path: ${path}`);
+	};
 }
 
 for (const manual of [true, false]) {
-  test(`matching published release validates (manual=${manual})`, () => {
-    assert.deepEqual(validateRelease(fixture(), TAG, SHA, manual, ID), { source_sha: SHA, release_id: ID, release_tag: TAG, prerelease: false });
-  });
-  test(`moved source rejected (manual=${manual})`, () => {
-    assert.throws(() => validateRelease(fixture(), TAG, "0".repeat(40), manual, ID), /Tag SHA.*does not match/);
-  });
-  test(`recreated release rejected (manual=${manual})`, () => {
-    assert.throws(() => validateRelease(fixture({ release: { id: ID + 1 } }), TAG, SHA, manual, ID), /Release ID.*does not match/);
-  });
+	test(`matching published release validates (manual=${manual})`, () => {
+		assert.deepEqual(validateRelease(fixture(), TAG, SHA, manual, ID), {
+			source_sha: SHA,
+			release_id: ID,
+			release_tag: TAG,
+			prerelease: false,
+		});
+	});
+	test(`moved source rejected (manual=${manual})`, () => {
+		assert.throws(
+			() => validateRelease(fixture(), TAG, "0".repeat(40), manual, ID),
+			/Tag SHA.*does not match/,
+		);
+	});
+	test(`recreated release rejected (manual=${manual})`, () => {
+		assert.throws(
+			() =>
+				validateRelease(
+					fixture({ release: { id: ID + 1 } }),
+					TAG,
+					SHA,
+					manual,
+					ID,
+				),
+			/Release ID.*does not match/,
+		);
+	});
 }
 for (const [name, options, error] of [
-  ["missing tag", { missing: `/git/ref/tags/${TAG}` }, /404/],
-  ["missing release", { missing: `/releases/tags/${TAG}` }, /404/],
-  ["wrong package", { pkg: { name: "other" } }, /name mismatch/],
-  ["wrong version", { pkg: { version: "0.14.2" } }, /version mismatch/],
-  ["draft", { release: { draft: true } }, /draft/],
-  ["unpublished", { release: { published_at: null } }, /not published/],
-  ["wrong release tag", { release: { tag_name: "v0.14.0" } }, /tag_name/],
-  ["missing release ID", { release: { id: undefined } }, /valid release ID/],
+	["missing tag", { missing: `/git/ref/tags/${TAG}` }, /404/],
+	["missing release", { missing: `/releases/tags/${TAG}` }, /404/],
+	["wrong package", { pkg: { name: "other" } }, /name mismatch/],
+	["wrong version", { pkg: { version: "0.14.2" } }, /version mismatch/],
+	["draft", { release: { draft: true } }, /draft/],
+	["unpublished", { release: { published_at: null } }, /not published/],
+	["wrong release tag", { release: { tag_name: "v0.14.0" } }, /tag_name/],
+	["missing release ID", { release: { id: undefined } }, /valid release ID/],
 ]) {
-  test(`${name} rejected`, () => assert.throws(() => validateRelease(fixture(options), TAG, SHA, true, ID), error));
+	test(`${name} rejected`, () =>
+		assert.throws(
+			() => validateRelease(fixture(options), TAG, SHA, true, ID),
+			error,
+		));
 }
 test("suffix-matching but nonexact ref rejected", () => {
-  assert.throws(() => resolveTagSha(fixture({ ref: `refs/heads/tags/${TAG}` }), TAG), /Unexpected ref/);
+	assert.throws(
+		() => resolveTagSha(fixture({ ref: `refs/heads/tags/${TAG}` }), TAG),
+		/Unexpected ref/,
+	);
 });
 test("published prerelease is supported without changing its metadata", () => {
-  const tag = "v0.15.0-beta.1";
-  validateInputs(tag, SHA, true, "fixture-token");
-  assert.equal(validateRelease(fixture({ tag, release: { prerelease: true } }), tag, SHA, true, ID).prerelease, true);
+	const tag = "v0.15.0-beta.1";
+	validateInputs(tag, SHA, true, "fixture-token");
+	assert.equal(
+		validateRelease(
+			fixture({ tag, release: { prerelease: true } }),
+			tag,
+			SHA,
+			true,
+			ID,
+		).prerelease,
+		true,
+	);
 });
 test("missing API token fails by name only", () => {
-  assert.throws(() => validateInputs(TAG, SHA, true, ""), { message: "GH_TOKEN required for read-only API calls" });
+	assert.throws(() => validateInputs(TAG, SHA, true, ""), {
+		message: "GH_TOKEN required for read-only API calls",
+	});
 });
 test("duplicate artifact filenames fail before upload", () => {
-  assert.throws(() => checkAssetCollisions(fixture(), ID, ["mac/latest.yml", "win/latest.yml"]), /Duplicate/);
+	assert.throws(
+		() =>
+			checkAssetCollisions(fixture(), ID, ["mac/latest.yml", "win/latest.yml"]),
+		/Duplicate/,
+	);
 });
 test("existing filename collision rejected", () => {
-  assert.throws(() => checkAssetCollisions(fixture({ assets: [{ name: "app.dmg" }] }), ID, ["app.dmg"]), /collisions/);
+	assert.throws(
+		() =>
+			checkAssetCollisions(fixture({ assets: [{ name: "app.dmg" }] }), ID, [
+				"app.dmg",
+			]),
+		/collisions/,
+	);
 });
 test("collisions on paginated assets rejected", () => {
-  const api = (path) => path.endsWith("page=1") ? Array.from({ length: 100 }, (_, i) => ({ name: `old-${i}` })) : [{ name: "app.dmg" }];
-  assert.throws(() => checkAssetCollisions(api, ID, ["app.dmg"]), /collisions/);
+	const api = (path) =>
+		path.endsWith("page=1")
+			? Array.from({ length: 100 }, (_, i) => ({ name: `old-${i}` }))
+			: [{ name: "app.dmg" }];
+	assert.throws(() => checkAssetCollisions(api, ID, ["app.dmg"]), /collisions/);
 });
-test("empty artifact set rejected", () => assert.throws(() => checkAssetCollisions(fixture(), ID, []), /No artifacts/));
+test("empty artifact set rejected", () =>
+	assert.throws(() => checkAssetCollisions(fixture(), ID, []), /No artifacts/));
 for (const [name, overrides, error] of [
-  ["missing SHA", { expectedSha: "" }, /EXPECTED_SOURCE_SHA/],
-  ["missing ID", { expectedReleaseId: "" }, /EXPECTED_RELEASE_ID/],
-  ["moved SHA", { expectedSha: "0".repeat(40) }, /Tag SHA/],
-  ["changed ID", { expectedReleaseId: ID + 1 }, /Release ID/],
-  ["collision", { api: fixture({ assets: [{ name: "app.dmg" }] }) }, /collisions/],
+	["missing SHA", { expectedSha: "" }, /EXPECTED_SOURCE_SHA/],
+	["missing ID", { expectedReleaseId: "" }, /EXPECTED_RELEASE_ID/],
+	["moved SHA", { expectedSha: "0".repeat(40) }, /Tag SHA/],
+	["changed ID", { expectedReleaseId: ID + 1 }, /Release ID/],
+	[
+		"collision",
+		{ api: fixture({ assets: [{ name: "app.dmg" }] }) },
+		/collisions/,
+	],
 ]) {
-  test(`upload rejects ${name} without writes`, () => {
-    let writes = 0;
-    assert.throws(() => uploadRelease({ api: fixture(), tag: TAG, expectedSha: SHA, expectedReleaseId: ID, files: ["app.dmg"], upload: () => writes++, ...overrides }), error);
-    assert.equal(writes, 0);
-  });
+	test(`upload rejects ${name} without writes`, () => {
+		let writes = 0;
+		assert.throws(
+			() =>
+				uploadRelease({
+					api: fixture(),
+					tag: TAG,
+					expectedSha: SHA,
+					expectedReleaseId: ID,
+					files: ["app.dmg"],
+					upload: () => writes++,
+					...overrides,
+				}),
+			error,
+		);
+		assert.equal(writes, 0);
+	});
 }
 test("upload addresses validated ID and does not mutate release metadata", () => {
-  const writes = [];
-  uploadRelease({ api: fixture(), tag: TAG, expectedSha: SHA, expectedReleaseId: ID, files: ["app.dmg", "app.exe"], upload: (...args) => writes.push(args) });
-  assert.deepEqual(writes, [[ID, "app.dmg"], [ID, "app.exe"]]);
+	const writes = [];
+	uploadRelease({
+		api: fixture(),
+		tag: TAG,
+		expectedSha: SHA,
+		expectedReleaseId: ID,
+		files: ["app.dmg", "app.exe"],
+		upload: (...args) => writes.push(args),
+	});
+	assert.deepEqual(writes, [
+		[ID, "app.dmg"],
+		[ID, "app.exe"],
+	]);
 });
 for (const mode of ["complete", "missing-linux", "metadata-only", "symlink"]) {
-  test(`artifact collection ${mode}`, () => {
-    const root = mkdtempSync(join(tmpdir(), "release-artifact-test-"));
-    try {
-      for (const [platform, file] of [["macos", "app.dmg"], ["windows", "app.exe"], ["linux", "app.deb"]]) {
-        if (mode === "missing-linux" && platform === "linux") continue;
-        const dir = join(root, `${platform}-artifacts`);
-        mkdirSync(dir);
-        writeFileSync(join(dir, mode === "metadata-only" ? "latest.yml" : file), "fixture");
-        if (mode === "symlink") symlinkSync(join(dir, file), join(dir, "linked-installer"));
-      }
-      if (mode === "complete") assert.equal(artifactFiles(root).length, 3);
-      else assert.throws(() => artifactFiles(root), mode === "missing-linux" ? /ENOENT/ : mode === "symlink" ? /non-file/ : /Missing macos installer/);
-    } finally {
-      rmSync(root, { recursive: true, force: true });
-    }
-  });
+	test(`artifact collection ${mode}`, () => {
+		const root = mkdtempSync(join(tmpdir(), "release-artifact-test-"));
+		try {
+			for (const [platform, file] of [
+				["macos", "app.dmg"],
+				["windows", "app.exe"],
+				["linux", "app.deb"],
+			]) {
+				if (mode === "missing-linux" && platform === "linux") continue;
+				const dir = join(root, `${platform}-artifacts`);
+				mkdirSync(dir);
+				writeFileSync(
+					join(dir, mode === "metadata-only" ? "latest.yml" : file),
+					"fixture",
+				);
+				if (mode === "symlink")
+					symlinkSync(join(dir, file), join(dir, "linked-installer"));
+			}
+			if (mode === "complete") assert.equal(artifactFiles(root).length, 3);
+			else
+				assert.throws(
+					() => artifactFiles(root),
+					mode === "missing-linux"
+						? /ENOENT/
+						: mode === "symlink"
+							? /non-file/
+							: /Missing macos installer/,
+				);
+		} finally {
+			rmSync(root, { recursive: true, force: true });
+		}
+	});
 }
 
 test("a failed upload stops instead of replacing or retrying assets", () => {
-  let writes = 0;
-  assert.throws(() => uploadRelease({ api: fixture(), tag: TAG, expectedSha: SHA, expectedReleaseId: ID, files: ["app.dmg", "app.exe"], upload: () => { writes++; throw new Error("HTTP 422 duplicate"); } }), /422/);
-  assert.equal(writes, 1);
+	let writes = 0;
+	assert.throws(
+		() =>
+			uploadRelease({
+				api: fixture(),
+				tag: TAG,
+				expectedSha: SHA,
+				expectedReleaseId: ID,
+				files: ["app.dmg", "app.exe"],
+				upload: () => {
+					writes++;
+					throw new Error("HTTP 422 duplicate");
+				},
+			}),
+		/422/,
+	);
+	assert.equal(writes, 1);
 });

--- a/scripts/test-validate-release.mjs
+++ b/scripts/test-validate-release.mjs
@@ -1,129 +1,310 @@
 #!/usr/bin/env node
 /** Bounded unit tests for validate-release.mjs — dependency-injected API, no network. */
-import { validateInputs, validateRelease, resolveTagSha, ValidationError } from "./validate-release.mjs";
+import {
+	ValidationError,
+	resolveTagSha,
+	validateInputs,
+	validateRelease,
+} from "./validate-release.mjs";
 
 const SHA = "3becfb9c462f6adb1f47f9815767f5522755f849";
 const TAG = "v0.14.1";
 let failures = 0;
 let passes = 0;
 
-function ok(name) { passes++; console.log(`PASS: ${name}`); }
-function fail(name, msg) { failures++; console.error(`FAIL: ${name}: ${msg}`); }
+function ok(name) {
+	passes++;
+	console.log(`PASS: ${name}`);
+}
+function fail(name, msg) {
+	failures++;
+	console.error(`FAIL: ${name}: ${msg}`);
+}
 
 function expectThrow(fn, name, pattern) {
-  try {
-    fn();
-    fail(name, "expected throw but succeeded");
-  } catch (e) {
-    if (!(e instanceof ValidationError)) {
-      fail(name, `expected ValidationError, got ${e.constructor.name}: ${e.message}`);
-    } else if (e.message.includes(pattern) || e.message.match(new RegExp(pattern))) {
-      ok(name);
-    } else {
-      fail(name, `wrong error: ${e.message}`);
-    }
-  }
+	try {
+		fn();
+		fail(name, "expected throw but succeeded");
+	} catch (e) {
+		if (!(e instanceof ValidationError)) {
+			fail(
+				name,
+				`expected ValidationError, got ${e.constructor.name}: ${e.message}`,
+			);
+		} else if (
+			e.message.includes(pattern) ||
+			e.message.match(new RegExp(pattern))
+		) {
+			ok(name);
+		} else {
+			fail(name, `wrong error: ${e.message}`);
+		}
+	}
 }
 
 function mockApi(responses) {
-  return (path) => {
-    for (const [key, val] of Object.entries(responses)) {
-      if (path === key || path.startsWith(key)) return val;
-    }
-    throw new Error(`unmocked path: ${path}`);
-  };
+	return (path) => {
+		for (const [key, val] of Object.entries(responses)) {
+			if (path === key || path.startsWith(key)) return val;
+		}
+		throw new Error(`unmocked path: ${path}`);
+	};
 }
 
 // --- Input validation ---
 console.log("--- Input validation ---");
 
 expectThrow(() => validateInputs("", SHA, true, "t"), "empty tag", "vX.Y.Z");
-expectThrow(() => validateInputs("0.14.1", SHA, true, "t"), "tag without v", "vX.Y.Z");
-expectThrow(() => validateInputs("v0.14", SHA, true, "t"), "incomplete version", "vX.Y.Z");
-try { validateInputs("v0.14.1-beta.1", SHA, true, "t"); ok("prerelease suffix supported"); } catch (e) { fail("prerelease suffix", e.message); }
-expectThrow(() => validateInputs(TAG, "abc", true, "t"), "short SHA", "40-char");
-expectThrow(() => validateInputs(TAG, "", true, "t"), "empty SHA manual", "40-char");
-try { validateInputs(TAG, "", false, "t"); ok("empty SHA release event valid"); } catch (e) { fail("empty SHA release event", e.message); }
-expectThrow(() => validateInputs(TAG, "abc", false, "t"), "invalid SHA release event", "40-char");
-expectThrow(() => validateInputs(TAG, SHA, true, ""), "missing token", "GH_TOKEN");
-expectThrow(() => validateInputs(TAG, SHA, false, ""), "missing token release", "GH_TOKEN");
-try { validateInputs(TAG, SHA, true, "t"); ok("valid manual inputs"); } catch (e) { fail("valid manual", e.message); }
-try { validateInputs(TAG, "", false, "t"); ok("valid release inputs"); } catch (e) { fail("valid release", e.message); }
+expectThrow(
+	() => validateInputs("0.14.1", SHA, true, "t"),
+	"tag without v",
+	"vX.Y.Z",
+);
+expectThrow(
+	() => validateInputs("v0.14", SHA, true, "t"),
+	"incomplete version",
+	"vX.Y.Z",
+);
+try {
+	validateInputs("v0.14.1-beta.1", SHA, true, "t");
+	ok("prerelease suffix supported");
+} catch (e) {
+	fail("prerelease suffix", e.message);
+}
+expectThrow(
+	() => validateInputs(TAG, "abc", true, "t"),
+	"short SHA",
+	"40-char",
+);
+expectThrow(
+	() => validateInputs(TAG, "", true, "t"),
+	"empty SHA manual",
+	"40-char",
+);
+try {
+	validateInputs(TAG, "", false, "t");
+	ok("empty SHA release event valid");
+} catch (e) {
+	fail("empty SHA release event", e.message);
+}
+expectThrow(
+	() => validateInputs(TAG, "abc", false, "t"),
+	"invalid SHA release event",
+	"40-char",
+);
+expectThrow(
+	() => validateInputs(TAG, SHA, true, ""),
+	"missing token",
+	"GH_TOKEN",
+);
+expectThrow(
+	() => validateInputs(TAG, SHA, false, ""),
+	"missing token release",
+	"GH_TOKEN",
+);
+try {
+	validateInputs(TAG, SHA, true, "t");
+	ok("valid manual inputs");
+} catch (e) {
+	fail("valid manual", e.message);
+}
+try {
+	validateInputs(TAG, "", false, "t");
+	ok("valid release inputs");
+} catch (e) {
+	fail("valid release", e.message);
+}
 
 // --- Tag resolution ---
 console.log("--- Tag resolution ---");
 
-const lightweightRef = { ref: `refs/tags/${TAG}`, object: { sha: SHA, type: "commit" } };
-const annotatedRef = { ref: `refs/tags/${TAG}`, object: { sha: "annotated1234567890123456789012345678901234", type: "tag" } };
+const lightweightRef = {
+	ref: `refs/tags/${TAG}`,
+	object: { sha: SHA, type: "commit" },
+};
+const annotatedRef = {
+	ref: `refs/tags/${TAG}`,
+	object: { sha: "annotated1234567890123456789012345678901234", type: "tag" },
+};
 const annotatedTagObj = { object: { sha: SHA, type: "commit" } };
 
-expectThrow(() => resolveTagSha(mockApi({ "/git/ref/tags/v0.14.1": { ref: "refs/heads/main", object: { sha: SHA, type: "commit" } } }), TAG), "wrong ref format", "Unexpected ref");
-expectThrow(() => resolveTagSha(mockApi({ "/git/ref/tags/v0.14.1": { ref: `refs/tags/${TAG}`, object: { sha: SHA, type: "blob" } } }), TAG), "non-commit ref", "expected commit");
+expectThrow(
+	() =>
+		resolveTagSha(
+			mockApi({
+				"/git/ref/tags/v0.14.1": {
+					ref: "refs/heads/main",
+					object: { sha: SHA, type: "commit" },
+				},
+			}),
+			TAG,
+		),
+	"wrong ref format",
+	"Unexpected ref",
+);
+expectThrow(
+	() =>
+		resolveTagSha(
+			mockApi({
+				"/git/ref/tags/v0.14.1": {
+					ref: `refs/tags/${TAG}`,
+					object: { sha: SHA, type: "blob" },
+				},
+			}),
+			TAG,
+		),
+	"non-commit ref",
+	"expected commit",
+);
 
 try {
-  const sha = resolveTagSha(mockApi({ "/git/ref/tags/v0.14.1": lightweightRef }), TAG);
-  if (sha === SHA) ok("lightweight tag resolution"); else fail("lightweight", `got ${sha}`);
-} catch (e) { fail("lightweight tag", e.message); }
+	const sha = resolveTagSha(
+		mockApi({ "/git/ref/tags/v0.14.1": lightweightRef }),
+		TAG,
+	);
+	if (sha === SHA) ok("lightweight tag resolution");
+	else fail("lightweight", `got ${sha}`);
+} catch (e) {
+	fail("lightweight tag", e.message);
+}
 
 try {
-  const sha = resolveTagSha(mockApi({
-    "/git/ref/tags/v0.14.1": annotatedRef,
-    "/git/tags/annotated1234567890123456789012345678901234": annotatedTagObj,
-  }), TAG);
-  if (sha === SHA) ok("annotated tag peeling"); else fail("annotated", `got ${sha}`);
-} catch (e) { fail("annotated tag", e.message); }
+	const sha = resolveTagSha(
+		mockApi({
+			"/git/ref/tags/v0.14.1": annotatedRef,
+			"/git/tags/annotated1234567890123456789012345678901234": annotatedTagObj,
+		}),
+		TAG,
+	);
+	if (sha === SHA) ok("annotated tag peeling");
+	else fail("annotated", `got ${sha}`);
+} catch (e) {
+	fail("annotated tag", e.message);
+}
 
 // --- Release validation ---
 console.log("--- Release validation ---");
 
-const publishedRelease = { id: 383131955, tag_name: TAG, draft: false, prerelease: false, published_at: "2026-09-05T00:00:00Z" };
+const publishedRelease = {
+	id: 383131955,
+	tag_name: TAG,
+	draft: false,
+	prerelease: false,
+	published_at: "2026-09-05T00:00:00Z",
+};
 const draftRelease = { id: 123, tag_name: TAG, draft: true, prerelease: false };
-const wrongTagRelease = { id: 123, tag_name: "v0.14.0", draft: false, prerelease: false };
-const validPkg = { content: Buffer.from(JSON.stringify({ name: "local-operator-ui", version: "0.14.1" })).toString("base64") };
-const wrongNamePkg = { content: Buffer.from(JSON.stringify({ name: "other", version: "0.14.1" })).toString("base64") };
-const wrongVersionPkg = { content: Buffer.from(JSON.stringify({ name: "local-operator-ui", version: "0.14.0" })).toString("base64") };
+const wrongTagRelease = {
+	id: 123,
+	tag_name: "v0.14.0",
+	draft: false,
+	prerelease: false,
+};
+const validPkg = {
+	content: Buffer.from(
+		JSON.stringify({ name: "local-operator-ui", version: "0.14.1" }),
+	).toString("base64"),
+};
+const wrongNamePkg = {
+	content: Buffer.from(
+		JSON.stringify({ name: "other", version: "0.14.1" }),
+	).toString("base64"),
+};
+const wrongVersionPkg = {
+	content: Buffer.from(
+		JSON.stringify({ name: "local-operator-ui", version: "0.14.0" }),
+	).toString("base64"),
+};
 
 const happyApi = mockApi({
-  "/git/ref/tags/v0.14.1": lightweightRef,
-  "/releases/tags/v0.14.1": publishedRelease,
-  "/contents/package.json?ref=": validPkg,
+	"/git/ref/tags/v0.14.1": lightweightRef,
+	"/releases/tags/v0.14.1": publishedRelease,
+	"/contents/package.json?ref=": validPkg,
 });
 
 try {
-  const result = validateRelease(happyApi, TAG, SHA, true);
-  if (result.source_sha === SHA && result.release_id === 383131955) ok("happy path manual");
-  else fail("happy manual", JSON.stringify(result));
-} catch (e) { fail("happy manual", e.message); }
+	const result = validateRelease(happyApi, TAG, SHA, true);
+	if (result.source_sha === SHA && result.release_id === 383131955)
+		ok("happy path manual");
+	else fail("happy manual", JSON.stringify(result));
+} catch (e) {
+	fail("happy manual", e.message);
+}
 
 try {
-  const result = validateRelease(happyApi, TAG, "", false);
-  if (result.source_sha === SHA) ok("happy path release event");
-  else fail("happy release", JSON.stringify(result));
-} catch (e) { fail("happy release", e.message); }
+	const result = validateRelease(happyApi, TAG, "", false);
+	if (result.source_sha === SHA) ok("happy path release event");
+	else fail("happy release", JSON.stringify(result));
+} catch (e) {
+	fail("happy release", e.message);
+}
 
-expectThrow(() => validateRelease(mockApi({
-  "/git/ref/tags/v0.14.1": lightweightRef,
-  "/releases/tags/v0.14.1": draftRelease,
-}), TAG, SHA, true), "draft release rejected", "draft");
+expectThrow(
+	() =>
+		validateRelease(
+			mockApi({
+				"/git/ref/tags/v0.14.1": lightweightRef,
+				"/releases/tags/v0.14.1": draftRelease,
+			}),
+			TAG,
+			SHA,
+			true,
+		),
+	"draft release rejected",
+	"draft",
+);
 
-expectThrow(() => validateRelease(mockApi({
-  "/git/ref/tags/v0.14.1": lightweightRef,
-  "/releases/tags/v0.14.1": wrongTagRelease,
-}), TAG, SHA, true), "tag_name mismatch rejected", "tag_name");
+expectThrow(
+	() =>
+		validateRelease(
+			mockApi({
+				"/git/ref/tags/v0.14.1": lightweightRef,
+				"/releases/tags/v0.14.1": wrongTagRelease,
+			}),
+			TAG,
+			SHA,
+			true,
+		),
+	"tag_name mismatch rejected",
+	"tag_name",
+);
 
-expectThrow(() => validateRelease(mockApi({
-  "/git/ref/tags/v0.14.1": lightweightRef,
-  "/releases/tags/v0.14.1": publishedRelease,
-  "/contents/package.json?ref=": wrongNamePkg,
-}), TAG, SHA, true), "package name mismatch rejected", "name mismatch");
+expectThrow(
+	() =>
+		validateRelease(
+			mockApi({
+				"/git/ref/tags/v0.14.1": lightweightRef,
+				"/releases/tags/v0.14.1": publishedRelease,
+				"/contents/package.json?ref=": wrongNamePkg,
+			}),
+			TAG,
+			SHA,
+			true,
+		),
+	"package name mismatch rejected",
+	"name mismatch",
+);
 
-expectThrow(() => validateRelease(mockApi({
-  "/git/ref/tags/v0.14.1": lightweightRef,
-  "/releases/tags/v0.14.1": publishedRelease,
-  "/contents/package.json?ref=": wrongVersionPkg,
-}), TAG, SHA, true), "package version mismatch rejected", "version mismatch");
+expectThrow(
+	() =>
+		validateRelease(
+			mockApi({
+				"/git/ref/tags/v0.14.1": lightweightRef,
+				"/releases/tags/v0.14.1": publishedRelease,
+				"/contents/package.json?ref=": wrongVersionPkg,
+			}),
+			TAG,
+			SHA,
+			true,
+		),
+	"package version mismatch rejected",
+	"version mismatch",
+);
 
-expectThrow(() => validateRelease(happyApi, TAG, "0".repeat(40), true), "SHA mismatch manual rejected", "does not match");
+expectThrow(
+	() => validateRelease(happyApi, TAG, "0".repeat(40), true),
+	"SHA mismatch manual rejected",
+	"does not match",
+);
 
 // --- Summary ---
 console.log(`\n${passes} passed, ${failures} failed`);

--- a/scripts/transcript-reducer.test.mjs
+++ b/scripts/transcript-reducer.test.mjs
@@ -29,6 +29,7 @@ const {
 	applyLiveSeed,
 	clearTranscript,
 	dropLiveRecords,
+	withRecoveredOutcome,
 } = reducer;
 
 const assistant = (id, text) => ({
@@ -333,4 +334,141 @@ test("throughput: 5000 deltas over a 400-row transcript stays sub-millisecond pe
 	);
 	assert.ok(perDelta < 1, `per-delta cost ${perDelta}ms`);
 	assert.equal(state.records.at(-1).text.length, n);
+});
+
+// --- crash-recovered outcomes -------------------------------------------------
+//
+// `withRecoveredOutcome` is the only producer of the row for an outcome that
+// crash recovery republished without a durable `completion_attention` entry.
+// It fixes an unclearable unread badge, so it is exactly the function that must
+// not itself be untested.
+
+const ANCHOR = "completion-1f8f5be8-0000-4000-8000-00000000000a";
+const seeded = () =>
+	applyHistoryPage(EMPTY_TRANSCRIPT, {
+		entries: [
+			{
+				id: "u1",
+				ts: 1,
+				type: "message",
+				payload: { role: "user", message: "hi" },
+			},
+		],
+		has_more: false,
+		cursor_missing: false,
+	});
+const attention = (overrides = {}) => ({
+	anchor_id: ANCHOR,
+	kind: "interrupted",
+	unseen: true,
+	conversation_id: "session/123456abcdef",
+	...overrides,
+});
+const rowFor = (state) => state.records.find((record) => record.id === ANCHOR);
+
+test("a crash-recovered outcome is rendered at its own anchor, and is ackable", () => {
+	const state = withRecoveredOutcome(seeded(), attention(), false, new Set());
+	const row = rowFor(state);
+	assert.equal(row.kind, "notice");
+	assert.equal(row.text, "Interrupted");
+	assert.equal(row.level, "warning");
+	// Without this the view has nothing to hit-test and the badge never clears.
+	assert.equal(row.complete, true);
+	assert.equal(
+		rowFor(
+			withRecoveredOutcome(
+				seeded(),
+				attention({ kind: "error" }),
+				false,
+				new Set(),
+			),
+		).text,
+		"Stopped with an error",
+	);
+});
+
+test("the recovered row survives its own acknowledgement", () => {
+	// The row is ackable, so it acknowledges itself within ~500 ms, and the
+	// receipt writes only to the store -- no durable row ever replaces it.
+	// Deriving its existence from `unseen` made "Interrupted" vanish under the
+	// user and stay gone, disagreeing with the TUI, whose notice persists.
+	const remembered = new Set();
+	assert.ok(
+		rowFor(withRecoveredOutcome(seeded(), attention(), false, remembered)),
+	);
+	const afterAck = withRecoveredOutcome(
+		seeded(),
+		attention({ unseen: false }),
+		false,
+		remembered,
+	);
+	assert.ok(rowFor(afterAck), "the outcome disappeared once it was read");
+});
+
+test("an outcome already read elsewhere does not appear in a conversation that never showed it", () => {
+	// Opening a conversation whose outcome was acknowledged on the phone must
+	// not resurrect a notice this surface never displayed.
+	const state = withRecoveredOutcome(
+		seeded(),
+		attention({ unseen: false }),
+		false,
+		new Set(),
+	);
+	assert.equal(rowFor(state), undefined);
+});
+
+test("a historical failure is not inserted at the tail of a running retry", () => {
+	// The TUI's own guard: while a retry is streaming, an older outcome must not
+	// be painted as though it were the current one.
+	assert.equal(
+		rowFor(withRecoveredOutcome(seeded(), attention(), true, new Set())),
+		undefined,
+	);
+});
+
+test("synthesis is idempotent and never overwrites a real durable row", () => {
+	const remembered = new Set();
+	const once = withRecoveredOutcome(seeded(), attention(), false, remembered);
+	const twice = withRecoveredOutcome(once, attention(), false, remembered);
+	assert.equal(
+		twice.records.filter((record) => record.id === ANCHOR).length,
+		1,
+	);
+	assert.equal(twice, once, "a second apply must not rebuild the state");
+
+	// An anchor colliding with a durable id leaves that row untouched.
+	const collides = applyHistoryPage(EMPTY_TRANSCRIPT, {
+		entries: [
+			{
+				id: ANCHOR,
+				ts: 1,
+				type: "message",
+				payload: { role: "user", message: "real" },
+			},
+		],
+		has_more: false,
+		cursor_missing: false,
+	});
+	assert.equal(
+		rowFor(withRecoveredOutcome(collides, attention(), false, new Set())).kind,
+		"user",
+	);
+});
+
+test("only error and interrupted outcomes are synthesized", () => {
+	for (const kind of ["complete", null, undefined, "weird"]) {
+		assert.equal(
+			rowFor(
+				withRecoveredOutcome(seeded(), attention({ kind }), false, new Set()),
+			),
+			undefined,
+			String(kind),
+		);
+	}
+	for (const missing of [null, undefined, {}, { anchor_id: null }]) {
+		assert.equal(
+			rowFor(withRecoveredOutcome(seeded(), missing, false, new Set())),
+			undefined,
+		);
+	}
 });

--- a/scripts/transcript-reducer.test.mjs
+++ b/scripts/transcript-reducer.test.mjs
@@ -46,22 +46,38 @@ const user = (id, text) => ({
 
 test("streaming deltas coalesce into one record with stable identity", () => {
 	let state = EMPTY_TRANSCRIPT;
-	state = applyEvent(state, { type: "message_start", message: user("u1", "hi") }, 1);
+	state = applyEvent(
+		state,
+		{ type: "message_start", message: user("u1", "hi") },
+		1,
+	);
 	state = applyEvent(state, { type: "agent_start", generation: "1" }, 2);
-	state = applyEvent(state, { type: "message_start", message: assistant("a1", "") }, 3);
+	state = applyEvent(
+		state,
+		{ type: "message_start", message: assistant("a1", "") },
+		3,
+	);
 	const before = state.records.find((r) => r.id === "u1");
 	const deltas = 200;
 	for (let i = 0; i < deltas; i++) {
 		state = applyEvent(
 			state,
-			{ type: "message_update", delta: `tok${i} `, message: assistant("a1", "") },
+			{
+				type: "message_update",
+				delta: `tok${i} `,
+				message: assistant("a1", ""),
+			},
 			4 + i,
 		);
 	}
 	const after = state.records.find((r) => r.id === "u1");
 	// The equality gate: a record untouched by the delta stream is the SAME
 	// object, so a memoised row sees no prop change and does not re-render.
-	assert.equal(before, after, "unchanged record identity preserved across deltas");
+	assert.equal(
+		before,
+		after,
+		"unchanged record identity preserved across deltas",
+	);
 	const a1 = state.records.find((r) => r.id === "a1");
 	assert.equal(a1.kind, "assistant");
 	assert.equal(a1.streaming, true);
@@ -71,9 +87,21 @@ test("streaming deltas coalesce into one record with stable identity", () => {
 
 test("message_end is authoritative over accumulated deltas", () => {
 	let state = EMPTY_TRANSCRIPT;
-	state = applyEvent(state, { type: "message_start", message: assistant("a1", "") }, 1);
-	state = applyEvent(state, { type: "message_update", delta: "Hel", message: assistant("a1", "") }, 2);
-	state = applyEvent(state, { type: "message_end", message: assistant("a1", "Hello!") }, 3);
+	state = applyEvent(
+		state,
+		{ type: "message_start", message: assistant("a1", "") },
+		1,
+	);
+	state = applyEvent(
+		state,
+		{ type: "message_update", delta: "Hel", message: assistant("a1", "") },
+		2,
+	);
+	state = applyEvent(
+		state,
+		{ type: "message_end", message: assistant("a1", "Hello!") },
+		3,
+	);
 	const a1 = state.records.find((r) => r.id === "a1");
 	assert.equal(a1.text, "Hello!");
 	assert.equal(a1.streaming, false);
@@ -82,12 +110,25 @@ test("message_end is authoritative over accumulated deltas", () => {
 test("durable history wins over live projections and replay never regresses it", () => {
 	let state = EMPTY_TRANSCRIPT;
 	// Live projection from an old replay (partial text).
-	state = applyEvent(state, { type: "message_start", message: assistant("a1", "") }, 1);
-	state = applyEvent(state, { type: "message_update", delta: "part", message: assistant("a1", "") }, 2);
+	state = applyEvent(
+		state,
+		{ type: "message_start", message: assistant("a1", "") },
+		1,
+	);
+	state = applyEvent(
+		state,
+		{ type: "message_update", delta: "part", message: assistant("a1", "") },
+		2,
+	);
 	// Snapshot's durable page carries the full row.
 	const page = {
 		entries: [
-			{ id: "u1", ts: 10, type: "message", payload: { kind: "message", ...user("u1", "hi") } },
+			{
+				id: "u1",
+				ts: 10,
+				type: "message",
+				payload: { kind: "message", ...user("u1", "hi") },
+			},
 			{
 				id: "a1",
 				ts: 11,
@@ -110,7 +151,11 @@ test("durable history wins over live projections and replay never regresses it",
 	);
 	a1 = again.records.find((r) => r.id === "a1");
 	assert.equal(a1.text, "partial then full");
-	assert.equal(again, state, "stale replay is a no-op returning the same state");
+	assert.equal(
+		again,
+		state,
+		"stale replay is a no-op returning the same state",
+	);
 	// Re-applying the same page is idempotent (reconnect replay).
 	assert.equal(applyHistoryPage(state, page), state);
 	assert.deepEqual(
@@ -124,7 +169,12 @@ test("live seed after snapshot does not duplicate durable rows", () => {
 	let state = EMPTY_TRANSCRIPT;
 	const page = {
 		entries: [
-			{ id: "u1", ts: 10, type: "message", payload: { kind: "message", ...user("u1", "hi") } },
+			{
+				id: "u1",
+				ts: 10,
+				type: "message",
+				payload: { kind: "message", ...user("u1", "hi") },
+			},
 		],
 		has_more: false,
 		cursor_missing: false,
@@ -138,7 +188,11 @@ test("live seed after snapshot does not duplicate durable rows", () => {
 			live_events: [
 				{ type: "message_start", message: user("u1", "hi") },
 				{ type: "message_start", message: assistant("a2", "") },
-				{ type: "message_update", delta: "in flight", message: assistant("a2", "") },
+				{
+					type: "message_update",
+					delta: "in flight",
+					message: assistant("a2", ""),
+				},
 			],
 		},
 		20,
@@ -155,7 +209,12 @@ test("tool call lifecycle collapses to one row with output behind it", () => {
 	let state = EMPTY_TRANSCRIPT;
 	state = applyEvent(
 		state,
-		{ type: "tool_call_compose", tool_call_id: "c1", tool_name: "read", argument_bytes: 0 },
+		{
+			type: "tool_call_compose",
+			tool_call_id: "c1",
+			tool_name: "read",
+			argument_bytes: 0,
+		},
 		1,
 	);
 	state = applyEvent(
@@ -191,12 +250,21 @@ test("gap drops only live projections; clear is view-only", () => {
 	let state = EMPTY_TRANSCRIPT;
 	state = applyHistoryPage(state, {
 		entries: [
-			{ id: "u1", ts: 10, type: "message", payload: { kind: "message", ...user("u1", "hi") } },
+			{
+				id: "u1",
+				ts: 10,
+				type: "message",
+				payload: { kind: "message", ...user("u1", "hi") },
+			},
 		],
 		has_more: false,
 		cursor_missing: false,
 	});
-	state = applyEvent(state, { type: "message_start", message: assistant("a9", "") }, 1);
+	state = applyEvent(
+		state,
+		{ type: "message_start", message: assistant("a9", "") },
+		1,
+	);
 	const dropped = dropLiveRecords(state);
 	assert.deepEqual(
 		dropped.records.map((r) => r.id),
@@ -206,13 +274,21 @@ test("gap drops only live projections; clear is view-only", () => {
 	assert.equal(cleared.records.length, 0);
 	// Clearing is a renderer concern: the reducer holds nothing that would
 	// tell a backend to delete, and re-applying the page repaints it.
-	assert.equal(applyHistoryPage(cleared, {
-		entries: [
-			{ id: "u1", ts: 10, type: "message", payload: { kind: "message", ...user("u1", "hi") } },
-		],
-		has_more: false,
-		cursor_missing: false,
-	}).records.length, 1);
+	assert.equal(
+		applyHistoryPage(cleared, {
+			entries: [
+				{
+					id: "u1",
+					ts: 10,
+					type: "message",
+					payload: { kind: "message", ...user("u1", "hi") },
+				},
+			],
+			has_more: false,
+			cursor_missing: false,
+		}).records.length,
+		1,
+	);
 });
 
 test("throughput: 5000 deltas over a 400-row transcript stays sub-millisecond per delta", () => {
@@ -232,8 +308,16 @@ test("throughput: 5000 deltas over a 400-row transcript stays sub-millisecond pe
 			payload: { kind: "message", ...assistant(`a${i}`, `answer ${i}`) },
 		});
 	}
-	state = applyHistoryPage(state, { entries, has_more: false, cursor_missing: false });
-	state = applyEvent(state, { type: "message_start", message: assistant("live", "") }, 1000);
+	state = applyHistoryPage(state, {
+		entries,
+		has_more: false,
+		cursor_missing: false,
+	});
+	state = applyEvent(
+		state,
+		{ type: "message_start", message: assistant("live", "") },
+		1000,
+	);
 	const t0 = performance.now();
 	const n = 5000;
 	for (let i = 0; i < n; i++) {
@@ -244,7 +328,9 @@ test("throughput: 5000 deltas over a 400-row transcript stays sub-millisecond pe
 		);
 	}
 	const perDelta = (performance.now() - t0) / n;
-	console.log(`reducer: ${perDelta.toFixed(4)} ms per delta over ${state.records.length} rows`);
+	console.log(
+		`reducer: ${perDelta.toFixed(4)} ms per delta over ${state.records.length} rows`,
+	);
 	assert.ok(perDelta < 1, `per-delta cost ${perDelta}ms`);
 	assert.equal(state.records.at(-1).text.length, n);
 });

--- a/scripts/upload-release.mjs
+++ b/scripts/upload-release.mjs
@@ -9,73 +9,132 @@ import { execFileSync } from "node:child_process";
 import { readdirSync } from "node:fs";
 import { basename, join } from "node:path";
 import { pathToFileURL } from "node:url";
-import { createApi, validateInputs, validateRelease, ValidationError } from "./validate-release.mjs";
+import {
+	ValidationError,
+	createApi,
+	validateInputs,
+	validateRelease,
+} from "./validate-release.mjs";
 
 function artifactFiles(root) {
-  const platforms = { macos: /\.(dmg|zip)$/, windows: /\.(exe|msi)$/, linux: /\.(deb|AppImage|rpm)$/ };
-  return Object.entries(platforms).flatMap(([platform, installer]) => {
-    const dir = join(root, `${platform}-artifacts`);
-    const files = readdirSync(dir, { withFileTypes: true });
-    if (!files.some((f) => f.isFile() && installer.test(f.name))) {
-      throw new ValidationError(`Missing ${platform} installer artifacts`);
-    }
-    if (files.some((f) => !f.isFile())) throw new ValidationError(`Unexpected non-file in ${platform} artifacts`);
-    return files.map((f) => join(dir, f.name));
-  });
+	const platforms = {
+		macos: /\.(dmg|zip)$/,
+		windows: /\.(exe|msi)$/,
+		linux: /\.(deb|AppImage|rpm)$/,
+	};
+	return Object.entries(platforms).flatMap(([platform, installer]) => {
+		const dir = join(root, `${platform}-artifacts`);
+		const files = readdirSync(dir, { withFileTypes: true });
+		if (!files.some((f) => f.isFile() && installer.test(f.name))) {
+			throw new ValidationError(`Missing ${platform} installer artifacts`);
+		}
+		if (files.some((f) => !f.isFile()))
+			throw new ValidationError(`Unexpected non-file in ${platform} artifacts`);
+		return files.map((f) => join(dir, f.name));
+	});
 }
 
 function checkAssetCollisions(api, releaseId, files) {
-  if (!files.length) throw new ValidationError("No artifacts to upload");
-  const names = files.map((file) => basename(file));
-  if (new Set(names).size !== names.length) throw new ValidationError("Duplicate artifact filenames across platforms");
-  // The release summary can truncate its assets; page the ID-addressed list.
-  const existing = new Set();
-  for (let page = 1; ; page++) {
-    const assets = api(`/releases/${releaseId}/assets?per_page=100&page=${page}`);
-    for (const asset of assets) existing.add(asset.name);
-    if (assets.length < 100) break;
-  }
-  const collisions = names.filter((name) => existing.has(name));
-  if (collisions.length) throw new ValidationError(`Asset filename collisions: ${collisions.join(", ")}`);
+	if (!files.length) throw new ValidationError("No artifacts to upload");
+	const names = files.map((file) => basename(file));
+	if (new Set(names).size !== names.length)
+		throw new ValidationError("Duplicate artifact filenames across platforms");
+	// The release summary can truncate its assets; page the ID-addressed list.
+	const existing = new Set();
+	for (let page = 1; ; page++) {
+		const assets = api(
+			`/releases/${releaseId}/assets?per_page=100&page=${page}`,
+		);
+		for (const asset of assets) existing.add(asset.name);
+		if (assets.length < 100) break;
+	}
+	const collisions = names.filter((name) => existing.has(name));
+	if (collisions.length)
+		throw new ValidationError(
+			`Asset filename collisions: ${collisions.join(", ")}`,
+		);
 }
 
-function uploadRelease({ api, tag, expectedSha, expectedReleaseId, files, upload }) {
-  // Both pins must survive the build, even for release events (not just repairs).
-  if (!/^[0-9a-f]{40}$/.test(expectedSha || "")) throw new ValidationError("EXPECTED_SOURCE_SHA required for upload");
-  if (!/^[1-9]\d*$/.test(String(expectedReleaseId || ""))) throw new ValidationError("EXPECTED_RELEASE_ID required for upload");
-  const release = validateRelease(api, tag, expectedSha, false, expectedReleaseId);
-  checkAssetCollisions(api, release.release_id, files);
-  for (const file of files) upload(release.release_id, file);
-  return release;
+function uploadRelease({
+	api,
+	tag,
+	expectedSha,
+	expectedReleaseId,
+	files,
+	upload,
+}) {
+	// Both pins must survive the build, even for release events (not just repairs).
+	if (!/^[0-9a-f]{40}$/.test(expectedSha || ""))
+		throw new ValidationError("EXPECTED_SOURCE_SHA required for upload");
+	if (!/^[1-9]\d*$/.test(String(expectedReleaseId || "")))
+		throw new ValidationError("EXPECTED_RELEASE_ID required for upload");
+	const release = validateRelease(
+		api,
+		tag,
+		expectedSha,
+		false,
+		expectedReleaseId,
+	);
+	checkAssetCollisions(api, release.release_id, files);
+	for (const file of files) upload(release.release_id, file);
+	return release;
 }
 
-if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
-  try {
-    const { RELEASE_TAG: tag, EXPECTED_SOURCE_SHA: expectedSha, EXPECTED_RELEASE_ID: expectedReleaseId } = process.env;
-    const token = process.env.GH_TOKEN || process.env.GITHUB_TOKEN;
-    const repo = process.env.GITHUB_REPOSITORY;
-    validateInputs(tag, expectedSha, true, token);
-    if (!repo) throw new ValidationError("GITHUB_REPOSITORY required");
-    uploadRelease({
-      api: createApi(repo, token), tag, expectedSha, expectedReleaseId,
-      files: artifactFiles(process.env.ARTIFACTS_DIR || "artifacts"),
-      upload: (releaseId, file) => {
-        try {
-          execFileSync("gh", ["api", "--method", "POST",
-            `https://uploads.github.com/repos/${repo}/releases/${releaseId}/assets?name=${encodeURIComponent(basename(file))}`,
-            "-H", "Content-Type: application/octet-stream", "--input", file], {
-            env: { ...process.env, GH_TOKEN: token }, stdio: ["ignore", "pipe", "pipe"],
-          });
-          console.log(`Uploaded ${basename(file)} to release ${releaseId}`);
-        } catch {
-          throw new ValidationError(`Asset upload failed: ${basename(file)}; existing assets were not replaced`);
-        }
-      },
-    });
-  } catch (error) {
-    console.error(error instanceof ValidationError ? error.message : "Release upload failed; inspect artifact inputs");
-    process.exitCode = 1;
-  }
+if (
+	process.argv[1] &&
+	import.meta.url === pathToFileURL(process.argv[1]).href
+) {
+	try {
+		const {
+			RELEASE_TAG: tag,
+			EXPECTED_SOURCE_SHA: expectedSha,
+			EXPECTED_RELEASE_ID: expectedReleaseId,
+		} = process.env;
+		const token = process.env.GH_TOKEN || process.env.GITHUB_TOKEN;
+		const repo = process.env.GITHUB_REPOSITORY;
+		validateInputs(tag, expectedSha, true, token);
+		if (!repo) throw new ValidationError("GITHUB_REPOSITORY required");
+		uploadRelease({
+			api: createApi(repo, token),
+			tag,
+			expectedSha,
+			expectedReleaseId,
+			files: artifactFiles(process.env.ARTIFACTS_DIR || "artifacts"),
+			upload: (releaseId, file) => {
+				try {
+					execFileSync(
+						"gh",
+						[
+							"api",
+							"--method",
+							"POST",
+							`https://uploads.github.com/repos/${repo}/releases/${releaseId}/assets?name=${encodeURIComponent(basename(file))}`,
+							"-H",
+							"Content-Type: application/octet-stream",
+							"--input",
+							file,
+						],
+						{
+							env: { ...process.env, GH_TOKEN: token },
+							stdio: ["ignore", "pipe", "pipe"],
+						},
+					);
+					console.log(`Uploaded ${basename(file)} to release ${releaseId}`);
+				} catch {
+					throw new ValidationError(
+						`Asset upload failed: ${basename(file)}; existing assets were not replaced`,
+					);
+				}
+			},
+		});
+	} catch (error) {
+		console.error(
+			error instanceof ValidationError
+				? error.message
+				: "Release upload failed; inspect artifact inputs",
+		);
+		process.exitCode = 1;
+	}
 }
 
 export { artifactFiles, checkAssetCollisions, uploadRelease };

--- a/scripts/validate-release.mjs
+++ b/scripts/validate-release.mjs
@@ -14,123 +14,183 @@ import { writeFileSync } from "node:fs";
 import { pathToFileURL } from "node:url";
 
 // Published prereleases use the same pipeline as stable releases.
-const TAG_RE = /^v(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)(?:-(?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*)(?:\.(?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*))*)?(?:\+[0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*)?$/;
+const TAG_RE =
+	/^v(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)(?:-(?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*)(?:\.(?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*))*)?(?:\+[0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*)?$/;
 const SHA_RE = /^[0-9a-f]{40}$/;
 
 class ValidationError extends Error {}
 
 function fail(msg) {
-  throw new ValidationError(msg);
+	throw new ValidationError(msg);
 }
 
 function validateInputs(tag, expectedSha, isManual, token) {
-  if (!tag || !TAG_RE.test(tag)) fail(`RELEASE_TAG must match vX.Y.Z, got: ${tag}`);
-  if (!token) fail("GH_TOKEN required for read-only API calls");
-  if (isManual && (!expectedSha || !SHA_RE.test(expectedSha))) {
-    fail(`EXPECTED_SOURCE_SHA must be a full 40-char hex SHA for manual dispatch, got: ${expectedSha || "(empty)"}`);
-  }
-  if (!isManual && expectedSha && !SHA_RE.test(expectedSha)) {
-    fail(`EXPECTED_SOURCE_SHA must be a full 40-char hex SHA or empty for release event, got: ${expectedSha}`);
-  }
+	if (!tag || !TAG_RE.test(tag))
+		fail(`RELEASE_TAG must match vX.Y.Z, got: ${tag}`);
+	if (!token) fail("GH_TOKEN required for read-only API calls");
+	if (isManual && (!expectedSha || !SHA_RE.test(expectedSha))) {
+		fail(
+			`EXPECTED_SOURCE_SHA must be a full 40-char hex SHA for manual dispatch, got: ${expectedSha || "(empty)"}`,
+		);
+	}
+	if (!isManual && expectedSha && !SHA_RE.test(expectedSha)) {
+		fail(
+			`EXPECTED_SOURCE_SHA must be a full 40-char hex SHA or empty for release event, got: ${expectedSha}`,
+		);
+	}
 }
 
 function createApi(repo, token) {
-  return (path) => {
-    try {
-      return JSON.parse(execFileSync("gh", ["api", `repos/${repo}${path}`], {
-        env: { ...process.env, GH_TOKEN: token },
-        encoding: "utf8",
-        stdio: ["ignore", "pipe", "pipe"],
-      }));
-    } catch {
-      // Do not echo subprocess output: it can include authentication details.
-      fail(`GitHub metadata lookup failed: ${path}`);
-    }
-  };
+	return (path) => {
+		try {
+			return JSON.parse(
+				execFileSync("gh", ["api", `repos/${repo}${path}`], {
+					env: { ...process.env, GH_TOKEN: token },
+					encoding: "utf8",
+					stdio: ["ignore", "pipe", "pipe"],
+				}),
+			);
+		} catch {
+			// Do not echo subprocess output: it can include authentication details.
+			fail(`GitHub metadata lookup failed: ${path}`);
+		}
+	};
 }
 
 function resolveTagSha(api, tag) {
-  const ref = api(`/git/ref/tags/${encodeURIComponent(tag)}`);
-  if (ref?.ref !== `refs/tags/${tag}`) {
-    fail(`Unexpected ref format: expected refs/tags/${tag}`);
-  }
-  if (!ref.object) fail("Missing tag object");
-  let sha = ref.object.sha;
-  if (ref.object.type === "tag") {
-    const tagObj = api(`/git/tags/${sha}`);
-    if (tagObj.object.type !== "commit") fail(`Annotated tag points to ${tagObj.object.type}, expected commit`);
-    sha = tagObj.object.sha;
-  } else if (ref.object.type !== "commit") {
-    fail(`Tag ref points to ${ref.object.type}, expected commit`);
-  }
-  if (!SHA_RE.test(sha)) fail("Tag must resolve to a full 40-char commit SHA");
-  return sha;
+	const ref = api(`/git/ref/tags/${encodeURIComponent(tag)}`);
+	if (ref?.ref !== `refs/tags/${tag}`) {
+		fail(`Unexpected ref format: expected refs/tags/${tag}`);
+	}
+	if (!ref.object) fail("Missing tag object");
+	let sha = ref.object.sha;
+	if (ref.object.type === "tag") {
+		const tagObj = api(`/git/tags/${sha}`);
+		if (tagObj.object.type !== "commit")
+			fail(`Annotated tag points to ${tagObj.object.type}, expected commit`);
+		sha = tagObj.object.sha;
+	} else if (ref.object.type !== "commit") {
+		fail(`Tag ref points to ${ref.object.type}, expected commit`);
+	}
+	if (!SHA_RE.test(sha)) fail("Tag must resolve to a full 40-char commit SHA");
+	return sha;
 }
 
-function validateRelease(api, tag, expectedSha, isManual, expectedReleaseId = "") {
-  const tagSha = resolveTagSha(api, tag);
-  console.log(`Tag ${tag} resolves to commit ${tagSha}`);
+function validateRelease(
+	api,
+	tag,
+	expectedSha,
+	isManual,
+	expectedReleaseId = "",
+) {
+	const tagSha = resolveTagSha(api, tag);
+	console.log(`Tag ${tag} resolves to commit ${tagSha}`);
 
-  const release = api(`/releases/tags/${encodeURIComponent(tag)}`);
-  if (!release) fail(`Missing release ${tag}`);
-  if (release.tag_name !== tag) fail(`Release tag_name ${release.tag_name} does not match requested ${tag}`);
-  if (release.draft !== false || !release.published_at) fail(`Release ${tag} is a draft or not published`);
-  if (!Number.isSafeInteger(release.id) || release.id <= 0) fail("Missing valid release ID");
-  if (expectedReleaseId && String(release.id) !== String(expectedReleaseId)) {
-    fail(`Release ID ${release.id} does not match expected release ID ${expectedReleaseId}`);
-  }
-  console.log(`Release ${tag} (id ${release.id}) state: published, prerelease: ${release.prerelease}`);
+	const release = api(`/releases/tags/${encodeURIComponent(tag)}`);
+	if (!release) fail(`Missing release ${tag}`);
+	if (release.tag_name !== tag)
+		fail(
+			`Release tag_name ${release.tag_name} does not match requested ${tag}`,
+		);
+	if (release.draft !== false || !release.published_at)
+		fail(`Release ${tag} is a draft or not published`);
+	if (!Number.isSafeInteger(release.id) || release.id <= 0)
+		fail("Missing valid release ID");
+	if (expectedReleaseId && String(release.id) !== String(expectedReleaseId)) {
+		fail(
+			`Release ID ${release.id} does not match expected release ID ${expectedReleaseId}`,
+		);
+	}
+	console.log(
+		`Release ${tag} (id ${release.id}) state: published, prerelease: ${release.prerelease}`,
+	);
 
-  if (isManual && !expectedSha) fail("EXPECTED_SOURCE_SHA required for manual dispatch");
-  if (expectedSha && tagSha !== expectedSha) {
-    fail(`Tag SHA ${tagSha} does not match expected source SHA ${expectedSha}`);
-  }
+	if (isManual && !expectedSha)
+		fail("EXPECTED_SOURCE_SHA required for manual dispatch");
+	if (expectedSha && tagSha !== expectedSha) {
+		fail(`Tag SHA ${tagSha} does not match expected source SHA ${expectedSha}`);
+	}
 
-  const pkg = JSON.parse(Buffer.from(api(`/contents/package.json?ref=${tagSha}`).content, "base64").toString());
-  if (pkg.name !== "local-operator-ui") fail(`package.json name mismatch: expected local-operator-ui, got ${pkg.name}`);
-  const expectedVersion = tag.slice(1);
-  if (pkg.version !== expectedVersion) fail(`package.json version mismatch: expected ${expectedVersion}, got ${pkg.version}`);
-  console.log(`package.json name=${pkg.name} version=${pkg.version} OK`);
+	const pkg = JSON.parse(
+		Buffer.from(
+			api(`/contents/package.json?ref=${tagSha}`).content,
+			"base64",
+		).toString(),
+	);
+	if (pkg.name !== "local-operator-ui")
+		fail(
+			`package.json name mismatch: expected local-operator-ui, got ${pkg.name}`,
+		);
+	const expectedVersion = tag.slice(1);
+	if (pkg.version !== expectedVersion)
+		fail(
+			`package.json version mismatch: expected ${expectedVersion}, got ${pkg.version}`,
+		);
+	console.log(`package.json name=${pkg.name} version=${pkg.version} OK`);
 
-  return { source_sha: tagSha, release_tag: tag, release_id: release.id, prerelease: release.prerelease };
+	return {
+		source_sha: tagSha,
+		release_tag: tag,
+		release_id: release.id,
+		prerelease: release.prerelease,
+	};
 }
 
 function emitOutputs(result) {
-  const outFile = process.env.GITHUB_OUTPUT;
-  if (outFile) {
-    writeFileSync(outFile, [
-      `source_sha=${result.source_sha}`,
-      `release_tag=${result.release_tag}`,
-      `release_id=${result.release_id}`,
-      `prerelease=${result.prerelease}`,
-    ].join("\n") + "\n", { flag: "a" });
-  } else {
-    console.log(JSON.stringify(result));
-  }
+	const outFile = process.env.GITHUB_OUTPUT;
+	if (outFile) {
+		writeFileSync(
+			outFile,
+			[
+				`source_sha=${result.source_sha}`,
+				`release_tag=${result.release_tag}`,
+				`release_id=${result.release_id}`,
+				`prerelease=${result.prerelease}`,
+			].join("\n") + "\n",
+			{ flag: "a" },
+		);
+	} else {
+		console.log(JSON.stringify(result));
+	}
 }
 
 // Main execution (skip when imported for testing)
-if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
-  const tag = process.env.RELEASE_TAG;
-  const expectedSha = process.env.EXPECTED_SOURCE_SHA || "";
-  const isManual = process.env.IS_MANUAL_DISPATCH === "true";
-  const token = process.env.GH_TOKEN || process.env.GITHUB_TOKEN;
-  const repo = process.env.GITHUB_REPOSITORY || "damianvtran/local-operator-ui";
+if (
+	process.argv[1] &&
+	import.meta.url === pathToFileURL(process.argv[1]).href
+) {
+	const tag = process.env.RELEASE_TAG;
+	const expectedSha = process.env.EXPECTED_SOURCE_SHA || "";
+	const isManual = process.env.IS_MANUAL_DISPATCH === "true";
+	const token = process.env.GH_TOKEN || process.env.GITHUB_TOKEN;
+	const repo = process.env.GITHUB_REPOSITORY || "damianvtran/local-operator-ui";
 
-  try {
-    validateInputs(tag, expectedSha, isManual, token);
-    const api = createApi(repo, token);
-    const result = validateRelease(api, tag, expectedSha, isManual, process.env.EXPECTED_RELEASE_ID);
-    emitOutputs(result);
-    console.log("Validation passed");
-  } catch (e) {
-    if (e instanceof ValidationError) {
-      console.error(e.message);
-      process.exit(1);
-    }
-    throw e;
-  }
+	try {
+		validateInputs(tag, expectedSha, isManual, token);
+		const api = createApi(repo, token);
+		const result = validateRelease(
+			api,
+			tag,
+			expectedSha,
+			isManual,
+			process.env.EXPECTED_RELEASE_ID,
+		);
+		emitOutputs(result);
+		console.log("Validation passed");
+	} catch (e) {
+		if (e instanceof ValidationError) {
+			console.error(e.message);
+			process.exit(1);
+		}
+		throw e;
+	}
 }
 
 // Export for testing
-export { validateInputs, validateRelease, resolveTagSha, createApi, ValidationError };
+export {
+	validateInputs,
+	validateRelease,
+	resolveTagSha,
+	createApi,
+	ValidationError,
+};

--- a/scripts/vite-plugins/desktop-proxy.ts
+++ b/scripts/vite-plugins/desktop-proxy.ts
@@ -170,9 +170,7 @@ export function desktopProxyPlugin(): Plugin {
 					const header = req.headers["x-desktop-media"];
 					let operation: unknown;
 					try {
-						operation = JSON.parse(
-							typeof header === "string" ? header : "",
-						);
+						operation = JSON.parse(typeof header === "string" ? header : "");
 					} catch {
 						res.statusCode = 422;
 						res.setHeader("Content-Type", "application/json");
@@ -191,7 +189,8 @@ export function desktopProxyPlugin(): Plugin {
 						}
 						chunks.push(chunk as Buffer);
 					}
-					const bytes = total > 0 ? new Uint8Array(Buffer.concat(chunks)) : null;
+					const bytes =
+						total > 0 ? new Uint8Array(Buffer.concat(chunks)) : null;
 					const result = await requestDesktopMedia(
 						operation,
 						bytes,
@@ -215,14 +214,28 @@ export function desktopProxyPlugin(): Plugin {
 				if (req.url !== "/__desktop") return next();
 				const origin = req.headers.origin;
 				const address = server.httpServer?.address();
-				const port = typeof address === "object" && address ? address.port : server.config.server.port;
-				const allowed = new Set([`http://127.0.0.1:${port}`, `http://localhost:${port}`]);
+				const port =
+					typeof address === "object" && address
+						? address.port
+						: server.config.server.port;
+				const allowed = new Set([
+					`http://127.0.0.1:${port}`,
+					`http://localhost:${port}`,
+				]);
 				res.setHeader("Cache-Control", "no-store");
 				res.setHeader("Content-Type", "application/json");
-				if (req.method !== "POST" || !origin || !allowed.has(origin) ||
-					!req.headers["content-type"]?.startsWith("application/json")) {
+				if (
+					req.method !== "POST" ||
+					!origin ||
+					!allowed.has(origin) ||
+					!req.headers["content-type"]?.startsWith("application/json")
+				) {
 					res.statusCode = 403;
-					res.end(JSON.stringify({ detail: "This origin cannot use desktop controls." }));
+					res.end(
+						JSON.stringify({
+							detail: "This origin cannot use desktop controls.",
+						}),
+					);
 					return;
 				}
 				try {
@@ -239,7 +252,8 @@ export function desktopProxyPlugin(): Plugin {
 					}
 					const result = await requestDesktop(
 						JSON.parse(Buffer.concat(chunks).toString("utf-8")),
-						process.env.LOCAL_OPERATOR_DESKTOP_BACKEND_URL || "http://127.0.0.1:1111",
+						process.env.LOCAL_OPERATOR_DESKTOP_BACKEND_URL ||
+							"http://127.0.0.1:1111",
 						process.env.LOCAL_OPERATOR_DESKTOP_TOKEN || null,
 					);
 					res.end(JSON.stringify(result));

--- a/src/main/desktop-ipc.ts
+++ b/src/main/desktop-ipc.ts
@@ -12,6 +12,52 @@ import { trustedDesktopFrame } from "./desktop-transport";
 
 const OPERATION_ID = /^[a-zA-Z0-9_-]{1,128}$/;
 
+/**
+ * Wrap a desktop request sender so a read receipt requires native foreground.
+ *
+ * Applied to the sender ITSELF rather than inside the renderer IPC handler,
+ * because `DesktopNotifier` holds its own reference to the same underlying
+ * sender and calls it directly. Guarding only the IPC entry would leave that
+ * path unguarded — harmless while the notifier emits nothing but
+ * `sessions.watch`, but it is exactly how a future main-process caller would
+ * acquire an ungated `sessions.seen`.
+ *
+ * The renderer's own visibility test cannot establish this: an occluded,
+ * hidden or minimized window still reports `visibilityState === "visible"` and
+ * can hold document focus. Only main can see the real window.
+ */
+export function guardForegroundReceipts(
+	window: () => BrowserWindow | null,
+	send: (input: unknown) => Promise<DesktopResponse>,
+): (input: unknown) => Promise<DesktopResponse> {
+	return (input: unknown) => {
+		if (
+			input !== null &&
+			typeof input === "object" &&
+			"op" in input &&
+			input.op === "sessions.seen"
+		) {
+			const owner = window();
+			if (
+				!owner ||
+				owner.isDestroyed() ||
+				!owner.isVisible() ||
+				owner.isMinimized() ||
+				!owner.isFocused()
+			) {
+				// Not user-facing copy: the renderer treats a refusal as "not read
+				// yet" and retries, so this text only ever reaches a log.
+				return Promise.reject(
+					new Error(
+						"View this completion in the foreground before marking it read.",
+					),
+				);
+			}
+		}
+		return send(input);
+	};
+}
+
 export function registerDesktopIPC(
 	window: () => BrowserWindow | null,
 	expectedUrl: string,
@@ -36,31 +82,14 @@ export function registerDesktopIPC(
 			throw new Error("This window cannot use desktop controls.");
 		}
 	}
+	// Guarded here as well as at the sender: `registerDesktopIPC` is called with
+	// the raw sender in some hosts (and in the contract tests), so the receipt
+	// gate must not depend on the caller having wrapped it. Double application is
+	// idempotent — the second check simply passes.
+	const guarded = guardForegroundReceipts(window, request);
 	ipcMain.handle("desktop-request", (event, input: unknown) => {
 		authorize(event);
-		if (
-			input !== null &&
-			typeof input === "object" &&
-			"op" in input &&
-			input.op === "sessions.seen"
-		) {
-			// Renderer visibility is necessary but cannot prove native foreground.
-			// Enforce this on the shared typed request entry so no alternate IPC
-			// caller can bypass it. Watch leases remain notification routing only.
-			const owner = window();
-			if (
-				!owner ||
-				owner.isDestroyed() ||
-				!owner.isVisible() ||
-				owner.isMinimized() ||
-				!owner.isFocused()
-			) {
-				throw new Error(
-					"View this completion in the foreground before marking it read.",
-				);
-			}
-		}
-		return request(input);
+		return guarded(input);
 	});
 	// `/exit`: the window closes through the ordinary close path, so the
 	// renderer's `beforeunload` guard and macOS keep-alive behaviour apply

--- a/src/main/desktop-ipc.ts
+++ b/src/main/desktop-ipc.ts
@@ -38,6 +38,28 @@ export function registerDesktopIPC(
 	}
 	ipcMain.handle("desktop-request", (event, input: unknown) => {
 		authorize(event);
+		if (
+			input !== null &&
+			typeof input === "object" &&
+			"op" in input &&
+			input.op === "sessions.seen"
+		) {
+			// Renderer visibility is necessary but cannot prove native foreground.
+			// Enforce this on the shared typed request entry so no alternate IPC
+			// caller can bypass it. Watch leases remain notification routing only.
+			const owner = window();
+			if (
+				!owner ||
+				owner.isDestroyed() ||
+				!owner.isVisible() ||
+				owner.isMinimized() ||
+				!owner.isFocused()
+			) {
+				throw new Error(
+					"View this completion in the foreground before marking it read.",
+				);
+			}
+		}
 		return request(input);
 	});
 	// `/exit`: the window closes through the ordinary close path, so the

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -217,6 +217,18 @@ function createWindow(): BrowserWindow {
 		},
 	});
 
+	// Renderer warnings and errors reach a durable file, not just devTools.
+	// devTools are off outside `pnpm dev`, so a `console.warn` in a shipped
+	// build previously landed nowhere a user could send us — which made the
+	// receipt-backoff diagnostic unreadable on the machines where it matters.
+	// Only warning (2) and error (3) are forwarded; info and debug would make
+	// the log unusable for the failures it exists to explain.
+	mainWindow.webContents.on("console-message", (_event, level, message) => {
+		if (level < 2) return;
+		const write = level >= 3 ? logger.error : logger.warn;
+		write.call(logger, `[renderer] ${message}`, LogFileType.BACKEND);
+	});
+
 	mainWindow.on("ready-to-show", () => {
 		mainWindow.show();
 	});

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -22,7 +22,7 @@ import {
 } from "./backend";
 import { backendConfig } from "./backend/config";
 import { LogFileType, logger } from "./backend/logger";
-import { registerDesktopIPC } from "./desktop-ipc";
+import { guardForegroundReceipts, registerDesktopIPC } from "./desktop-ipc";
 import { DesktopNotifier } from "./desktop-notifier";
 import { UpdateService } from "./update-service";
 
@@ -377,10 +377,15 @@ app
 			optimizer.watchWindowShortcuts(window);
 		});
 
-		const desktopNotifier = new DesktopNotifier(
+		// One guarded sender for every main-process caller, so a read receipt
+		// requires a genuinely foreground window no matter which path emits it.
+		// The notifier holds its own reference to this sender, so guarding only
+		// the renderer IPC entry would leave that path ungated.
+		const sendDesktop = guardForegroundReceipts(
 			() => mainWindow,
 			(input) => backendService.requestDesktop(input),
 		);
+		const desktopNotifier = new DesktopNotifier(() => mainWindow, sendDesktop);
 		backendService.observeStream((sessionId, data) => {
 			try {
 				desktopNotifier.observe(sessionId, JSON.parse(data));
@@ -392,7 +397,7 @@ app
 			() => mainWindow,
 			process.env.ELECTRON_RENDERER_URL ||
 				pathToFileURL(join(__dirname, "../renderer/index.html")).href,
-			(input) => backendService.requestDesktop(input),
+			sendDesktop,
 			() => backendService.getStreamRelay(),
 			(input, bytes) => backendService.requestDesktopMedia(input, bytes),
 			desktopNotifier,

--- a/src/renderer/src/features/chat/canonical/canonical-transcript.tsx
+++ b/src/renderer/src/features/chat/canonical/canonical-transcript.tsx
@@ -31,6 +31,7 @@
 
 import { Spinner } from "@shared/components/common/spinner";
 import { Button } from "@shared/components/ui/button";
+import { useCompletionView } from "@shared/hooks/use-completion-view";
 import { cn } from "@shared/lib/utils";
 import {
 	CircleAlert,
@@ -48,7 +49,10 @@ import {
 	useRef,
 	useState,
 } from "react";
-import type { PendingDesktopGate } from "../../../../../shared/desktop-session-contract";
+import type {
+	CanonicalFrontendState,
+	PendingDesktopGate,
+} from "../../../../../shared/desktop-session-contract";
 import { MarkdownRenderer } from "../components/markdown-renderer";
 import { ErrorBlock } from "../components/message-item/error-block";
 import {
@@ -67,6 +71,7 @@ const WINDOW = 60;
 const WINDOW_STEP = 60;
 
 export type CanonicalTranscriptProps = {
+	frontend?: CanonicalFrontendState | null;
 	transcript: TranscriptState;
 	gate: PendingDesktopGate | null;
 	/** The owner is generating and nothing has painted yet for this turn. */
@@ -441,6 +446,15 @@ const TranscriptRow = memo(function TranscriptRow({
 	return (
 		<div
 			data-record-id={record.id}
+			data-completion-anchor={record.id}
+			data-completion-complete={
+				"complete" in record &&
+				record.complete === true &&
+				(record.kind !== "assistant" ||
+					(!record.streaming && Boolean(record.text)))
+					? "true"
+					: "false"
+			}
 			className={cn(GAP[row.gap][isSmallView ? 1 : 0])}
 		>
 			{body}
@@ -449,6 +463,7 @@ const TranscriptRow = memo(function TranscriptRow({
 });
 
 export const CanonicalTranscript: FC<CanonicalTranscriptProps> = ({
+	frontend,
 	transcript,
 	gate,
 	waiting,
@@ -459,6 +474,11 @@ export const CanonicalTranscript: FC<CanonicalTranscriptProps> = ({
 	status,
 	error,
 }) => {
+	useCompletionView(
+		frontend,
+		status === "live" && !waiting && !loadingOlder,
+		containerRef,
+	);
 	const previousRows = useRef<Row[]>([]);
 	const rows = useMemo(() => {
 		const next = buildRows(transcript.records, previousRows.current);

--- a/src/renderer/src/features/chat/canonical/canonical-transcript.tsx
+++ b/src/renderer/src/features/chat/canonical/canonical-transcript.tsx
@@ -63,7 +63,11 @@ import { MessageTimestamp } from "../components/message-item/message-timestamp";
 import { OutputBlock } from "../components/message-item/output-block";
 import { AgentQuestion, TraceLine } from "../components/trace";
 import { TraceGlyph } from "../components/trace/trace-rail";
-import type { TranscriptRecord, TranscriptState } from "./transcript-reducer";
+import {
+	type TranscriptRecord,
+	type TranscriptState,
+	withRecoveredOutcome,
+} from "./transcript-reducer";
 
 /** Opts prose into the ~72-character measure defined in `markdown.css`. */
 const MEASURE = "lo-measured";
@@ -447,13 +451,15 @@ const TranscriptRow = memo(function TranscriptRow({
 		<div
 			data-record-id={record.id}
 			data-completion-anchor={record.id}
+			// Only `"true"` is ever queried, so the attribute is omitted rather
+			// than emitted as `"false"` on every row of a long transcript.
 			data-completion-complete={
 				"complete" in record &&
 				record.complete === true &&
 				(record.kind !== "assistant" ||
 					(!record.streaming && Boolean(record.text)))
 					? "true"
-					: "false"
+					: undefined
 			}
 			className={cn(GAP[row.gap][isSmallView ? 1 : 0])}
 		>
@@ -474,6 +480,19 @@ export const CanonicalTranscript: FC<CanonicalTranscriptProps> = ({
 	status,
 	error,
 }) => {
+	// A crash-recovered outcome has no durable row of its own, so it is
+	// synthesized here rather than in the stream reducer: this is the layer that
+	// decides what is renderable, and an anchor with nothing to hit-test is an
+	// unread badge the user can never clear.
+	const painted = useMemo(
+		() =>
+			withRecoveredOutcome(
+				transcript,
+				frontend?.attention,
+				Boolean(frontend?.streaming),
+			),
+		[transcript, frontend?.attention, frontend?.streaming],
+	);
 	useCompletionView(
 		frontend,
 		status === "live" && !waiting && !loadingOlder,
@@ -481,10 +500,10 @@ export const CanonicalTranscript: FC<CanonicalTranscriptProps> = ({
 	);
 	const previousRows = useRef<Row[]>([]);
 	const rows = useMemo(() => {
-		const next = buildRows(transcript.records, previousRows.current);
+		const next = buildRows(painted.records, previousRows.current);
 		previousRows.current = next;
 		return next;
-	}, [transcript.records]);
+	}, [painted.records]);
 	// Windowing: newest rows first. The window widens when the reader nears the
 	// top, and resets when the transcript is replaced (session switch/clear).
 	const [windowSize, setWindowSize] = useState(WINDOW);

--- a/src/renderer/src/features/chat/canonical/canonical-transcript.tsx
+++ b/src/renderer/src/features/chat/canonical/canonical-transcript.tsx
@@ -484,12 +484,25 @@ export const CanonicalTranscript: FC<CanonicalTranscriptProps> = ({
 	// synthesized here rather than in the stream reducer: this is the layer that
 	// decides what is renderable, and an anchor with nothing to hit-test is an
 	// unread badge the user can never clear.
+	// Anchors already synthesized for THIS conversation. Held in a ref because
+	// the row must outlive the `unseen` flag that created it (see
+	// `withRecoveredOutcome`), and reset per conversation so one session's
+	// recovered outcome can never paint into another's transcript.
+	const recovered = useRef<{ session: string | null; anchors: Set<string> }>({
+		session: null,
+		anchors: new Set(),
+	});
+	const sessionId = frontend?.session_id ?? null;
+	if (recovered.current.session !== sessionId) {
+		recovered.current = { session: sessionId, anchors: new Set() };
+	}
 	const painted = useMemo(
 		() =>
 			withRecoveredOutcome(
 				transcript,
 				frontend?.attention,
 				Boolean(frontend?.streaming),
+				recovered.current.anchors,
 			),
 		[transcript, frontend?.attention, frontend?.streaming],
 	);

--- a/src/renderer/src/features/chat/canonical/transcript-reducer.ts
+++ b/src/renderer/src/features/chat/canonical/transcript-reducer.ts
@@ -760,3 +760,56 @@ export function appendLocalNote(
 		level,
 	});
 }
+
+/**
+ * Give a crash-recovered outcome a row, so it can be read at all.
+ *
+ * The normal settle path writes a `completion_attention` transcript entry and
+ * `durableRecord` renders it. Crash recovery does not: `bootstrap_transcript`
+ * republishes an `interrupted` completion from the `attention_started` journal
+ * with anchor `completion-<token>`, and that entry never exists because the
+ * turn that would have written it is exactly the one that died.
+ *
+ * Without a row carrying the anchor, the view finds nothing to hit-test and the
+ * conversation stays unread forever while the user is looking straight at it —
+ * self-healing only if some later turn completes, which for a finished
+ * conversation may be never. The TUI already synthesizes this notice
+ * (`tui/app.py::_poll_completion_attention`); this is the same guard for the
+ * surface that decides what is renderable on desktop.
+ */
+export function withRecoveredOutcome(
+	state: TranscriptState,
+	attention:
+		| {
+				anchor_id?: string | null;
+				kind?: string | null;
+				unseen?: boolean;
+				conversation_id?: string;
+		  }
+		| null
+		| undefined,
+	streaming: boolean,
+): TranscriptState {
+	const anchor = attention?.anchor_id;
+	const kind = attention?.kind;
+	if (
+		!anchor ||
+		!attention?.unseen ||
+		(kind !== "error" && kind !== "interrupted") ||
+		// Mirrors the TUI's retry guard: a historical failure must not be
+		// inserted at the tail of a retry that is already running.
+		streaming ||
+		state.index.has(anchor)
+	)
+		return state;
+	return upsert(state, {
+		kind: "notice",
+		id: anchor,
+		// The recovered outcome has no timestamp of its own, so it sorts at the
+		// tail where the durable rows it follows already are.
+		ts: state.records.at(-1)?.ts ?? Date.now(),
+		complete: true,
+		text: kind === "error" ? "Stopped with an error" : "Interrupted",
+		level: kind === "error" ? "error" : "warning",
+	});
+}

--- a/src/renderer/src/features/chat/canonical/transcript-reducer.ts
+++ b/src/renderer/src/features/chat/canonical/transcript-reducer.ts
@@ -43,6 +43,8 @@ export type TranscriptRecord =
 	  }
 	| {
 			kind: "assistant";
+			/** Only a full durable history read certifies the actual ending. */
+			complete?: boolean;
 			id: string;
 			ts: number;
 			text: string;
@@ -70,6 +72,8 @@ export type TranscriptRecord =
 	  }
 	| {
 			kind: "notice";
+			/** A durable completion marker, not an arbitrary renderer notice. */
+			complete?: boolean;
 			id: string;
 			ts: number;
 			text: string;
@@ -193,6 +197,28 @@ function durableRecord(
 	if (entry.type === "compaction") {
 		return { kind: "compaction", id: entry.id, ts, text: "Context compacted" };
 	}
+	if (
+		entry.type === "custom" &&
+		payload.custom_type === "completion_attention"
+	) {
+		const details = (payload.details ?? {}) as Record<string, unknown>;
+		if (
+			typeof details.anchor === "string" &&
+			(details.kind === "error" || details.kind === "interrupted")
+		) {
+			// Preserve the marker's durable position. Appending an old failure at
+			// the current retry tail would misrepresent which outcome was viewed.
+			return {
+				kind: "notice",
+				id: details.anchor,
+				ts,
+				complete: true,
+				text:
+					details.kind === "error" ? "Stopped with an error" : "Interrupted",
+				level: details.kind === "error" ? "error" : "warning",
+			};
+		}
+	}
 	if (entry.type !== "message") return null;
 	const kind = String(payload.kind ?? "message");
 	if (kind === "custom") {
@@ -251,6 +277,7 @@ function durableRecord(
 			id: entry.id,
 			ts,
 			text,
+			complete: true,
 			streaming: false,
 			stopReason: (payload.stop_reason as string | null) ?? null,
 			error: Boolean(payload.is_error),

--- a/src/renderer/src/features/chat/canonical/transcript-reducer.ts
+++ b/src/renderer/src/features/chat/canonical/transcript-reducer.ts
@@ -776,6 +776,18 @@ export function appendLocalNote(
  * conversation may be never. The TUI already synthesizes this notice
  * (`tui/app.py::_poll_completion_attention`); this is the same guard for the
  * surface that decides what is renderable on desktop.
+ *
+ * `unseen` gates CREATION only. The row is itself ackable, so it acknowledges
+ * itself within about half a second — and because the receipt writes only to the
+ * store and never adds a transcript entry, nothing durable replaces it. Deriving
+ * its continued existence from `unseen` therefore made "Interrupted" appear and
+ * then vanish under the user, permanently: reopening the conversation the next
+ * day showed no trace that the run was ever interrupted. It also disagreed with
+ * the TUI, whose `_append_block(NoticeBlock)` survives the receipt, so the two
+ * surfaces rendered different transcripts for the same conversation — the exact
+ * divergence this feature exists to remove. `remembered` carries the anchors
+ * already synthesized for the mounted conversation so the row's LIFETIME matches
+ * the TUI's: reading an outcome marks it read, it does not delete it.
  */
 export function withRecoveredOutcome(
 	state: TranscriptState,
@@ -789,19 +801,23 @@ export function withRecoveredOutcome(
 		| null
 		| undefined,
 	streaming: boolean,
+	remembered?: Set<string>,
 ): TranscriptState {
 	const anchor = attention?.anchor_id;
 	const kind = attention?.kind;
 	if (
 		!anchor ||
-		!attention?.unseen ||
 		(kind !== "error" && kind !== "interrupted") ||
 		// Mirrors the TUI's retry guard: a historical failure must not be
 		// inserted at the tail of a retry that is already running.
 		streaming ||
-		state.index.has(anchor)
+		state.index.has(anchor) ||
+		// Already read AND never shown here: the outcome was acknowledged on
+		// another surface, so this conversation has no row to keep alive.
+		(!attention?.unseen && !remembered?.has(anchor))
 	)
 		return state;
+	remembered?.add(anchor);
 	return upsert(state, {
 		kind: "notice",
 		id: anchor,

--- a/src/renderer/src/features/chat/components/chat-content.tsx
+++ b/src/renderer/src/features/chat/components/chat-content.tsx
@@ -279,6 +279,7 @@ export const ChatContent: FC<ChatContentProps> = React.memo(
 									/* Messages container */
 									canonical ? (
 										<CanonicalTranscript
+											frontend={canonical.view.frontend}
 											transcript={canonical.view.transcript}
 											gate={canonical.view.frontend?.pending_gate ?? null}
 											waiting={canonical.busy}

--- a/src/renderer/src/shared/hooks/use-canonical-session.ts
+++ b/src/renderer/src/shared/hooks/use-canonical-session.ts
@@ -40,6 +40,7 @@ import {
 	subscribeDesktopStream,
 } from "@shared/api/local-operator/desktop-api";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { mergeCompletionAttention } from "../../../../shared/desktop-session-contract";
 import type {
 	CanonicalFrontendState,
 	DesktopHistoryPage,
@@ -146,9 +147,12 @@ export function useCanonicalSessionStream(
 			// tail is fetched once per snapshot and merged durable-wins.
 			const needsReconcile = frames.some(
 				(frame) =>
-					frame.type === "snapshot" &&
-					(frame.payload.history.cursor_missing ||
-						frame.payload.history.entries.length === 0),
+					frame.type === "attention" ||
+					(frame.type === "snapshot" &&
+						(frame.payload.frontend.snapshot.attention?.completion_token !=
+							null ||
+							frame.payload.history.cursor_missing ||
+							frame.payload.history.entries.length === 0)),
 			);
 			performance.mark("lop:transcript:flush:start");
 
@@ -234,7 +238,14 @@ export function useCanonicalSessionStream(
 							next = {
 								...next,
 								status: "live",
-								frontend: snapshot.frontend.snapshot,
+								frontend: {
+									...snapshot.frontend.snapshot,
+									attention: mergeCompletionAttention(
+										next.frontend?.attention,
+										snapshot.frontend.snapshot.attention,
+										sessionId,
+									),
+								},
 								history: snapshot.history,
 								cold: snapshot.cold,
 								ownerEpoch: snapshot.frontend.epoch,
@@ -245,6 +256,21 @@ export function useCanonicalSessionStream(
 							replayQueue.length = 0;
 							replayTranscript = null;
 						}
+						continue;
+					}
+					if (frame.type === "attention") {
+						if (next.frontend)
+							next = {
+								...next,
+								frontend: {
+									...next.frontend,
+									attention: mergeCompletionAttention(
+										next.frontend.attention,
+										frame.payload,
+										sessionId,
+									),
+								},
+							};
 						continue;
 					}
 					if (frame.type === "frontend.update") {
@@ -271,6 +297,11 @@ export function useCanonicalSessionStream(
 								frontend: {
 									...next.frontend,
 									...update.changes,
+									attention: mergeCompletionAttention(
+										next.frontend.attention,
+										update.changes.attention,
+										sessionId,
+									),
 									sequence: update.sequence,
 								},
 							};

--- a/src/renderer/src/shared/hooks/use-canonical-session.ts
+++ b/src/renderer/src/shared/hooks/use-canonical-session.ts
@@ -118,6 +118,9 @@ export function useCanonicalSessionStream(
 	// Mutable side-channel for the frame pump; React state is the published,
 	// coalesced view. Frames arriving between renders collect here.
 	const pending = useRef<DesktopSessionFrame[]>([]);
+	// Read outside the React updater (see the flush comment), so the painted set
+	// is tracked here rather than through the view state itself.
+	const paintedIds = useRef<TranscriptState["index"]>(EMPTY_TRANSCRIPT.index);
 	const receiptRef = useRef<{ epoch: string; seq: number } | null>(null);
 	const reconnectRef = useRef<{ epoch?: string; afterSeq?: number }>({});
 	const generationRef = useRef(0);
@@ -145,14 +148,23 @@ export function useCanonicalSessionStream(
 			// so an empty page; a replaced cursor reports cursor_missing. Both are
 			// the contract's "reconcile through /history" case: the authoritative
 			// tail is fetched once per snapshot and merged durable-wins.
-			const needsReconcile = frames.some(
-				(frame) =>
-					frame.type === "attention" ||
-					(frame.type === "snapshot" &&
-						(frame.payload.frontend.snapshot.attention?.completion_token !=
-							null ||
+			// An attention frame only justifies a refetch when it names an anchor
+			// the transcript has not painted: the backend publishes one after
+			// every successful ACK, so reconciling on all of them spent a
+			// 100-entry history fetch on a frame where only `unseen` changed.
+			const paintedAnchor = (anchor: string | null | undefined) =>
+				anchor != null && paintedIds.current.has(anchor);
+			const needsReconcile = frames.some((frame) =>
+				frame.type === "attention"
+					? !paintedAnchor(frame.payload.anchor_id)
+					: frame.type === "snapshot" &&
+						((frame.payload.frontend.snapshot.attention?.completion_token !=
+							null &&
+							!paintedAnchor(
+								frame.payload.frontend.snapshot.attention?.anchor_id,
+							)) ||
 							frame.payload.history.cursor_missing ||
-							frame.payload.history.entries.length === 0)),
+							frame.payload.history.entries.length === 0),
 			);
 			performance.mark("lop:transcript:flush:start");
 
@@ -325,6 +337,7 @@ export function useCanonicalSessionStream(
 					"lop:transcript:flush:start",
 					"lop:transcript:flush:end",
 				);
+				paintedIds.current = next.transcript.index;
 				return next;
 			});
 			if (needsReconcile) {
@@ -421,6 +434,9 @@ export function useCanonicalSessionStream(
 	useEffect(() => {
 		reconnectRef.current = {};
 		receiptRef.current = null;
+		// The transcript is replaced below, so a previous session's anchors must
+		// not suppress the first reconcile of the new one.
+		paintedIds.current = EMPTY_TRANSCRIPT.index;
 		setView((current) => ({
 			...current,
 			frontend: null,

--- a/src/renderer/src/shared/hooks/use-completion-view.ts
+++ b/src/renderer/src/shared/hooks/use-completion-view.ts
@@ -7,6 +7,13 @@ import type { CanonicalFrontendState } from "../../../../shared/desktop-session-
  * Capture canonical identity and completion together; navigation retires this
  * attempt, and main independently checks the actual BrowserWindow at admission.
  */
+
+/** Poll cadence while the completion has not been acknowledged. */
+const CHECK_MS = 500;
+/** Consecutive failures before the retry cadence starts backing off. */
+const FAILURES_BEFORE_BACKOFF = 3;
+/** Ceiling on the backed-off cadence: ~1 attempt/minute, not ~7,200/hour. */
+const MAX_BACKOFF_MS = 60_000;
 export function useCompletionView(
 	frontend: CanonicalFrontendState | null | undefined,
 	ready: boolean,
@@ -33,6 +40,15 @@ export function useCompletionView(
 		let cancelled = false;
 		let pending = false;
 		let acknowledged = false;
+		let failures = 0;
+		let nextAttempt = 0;
+		let timer = 0;
+		const stop = () => {
+			if (timer) {
+				clearInterval(timer);
+				timer = 0;
+			}
+		};
 		const check = () => {
 			if (
 				cancelled ||
@@ -40,7 +56,8 @@ export function useCompletionView(
 				acknowledged ||
 				document.visibilityState !== "visible" ||
 				!document.hasFocus() ||
-				useCanonicalSessionsStore.getState().activeSessionId !== sessionId
+				useCanonicalSessionsStore.getState().activeSessionId !== sessionId ||
+				Date.now() < nextAttempt
 			)
 				return;
 			const element = root.current?.querySelector<HTMLElement>(
@@ -65,21 +82,46 @@ export function useCompletionView(
 			void desktopResult({ op: "sessions.seen", sessionId, completionToken })
 				.then(() => {
 					acknowledged = true;
+					// Nothing left to attempt for this completion; a new one
+					// re-runs the effect with a fresh token.
+					stop();
 				})
-				.catch(() => {
+				.catch((error: unknown) => {
 					// No optimistic clear. A rejected native-focus check or stale
 					// token leaves authoritative state intact and permits a retry.
+					//
+					// Backed off and logged ONCE at the threshold because the
+					// failing cases are persistent, not transient: a backend that
+					// predates the receipt route, a wedged store, a window state
+					// the native gate keeps refusing. At a flat cadence that is
+					// thousands of silent IPC round trips an hour with nothing in
+					// the renderer rendering `attention` to explain them.
+					failures += 1;
+					if (failures === FAILURES_BEFORE_BACKOFF) {
+						console.warn(
+							`[attention] could not mark ${sessionId} read after ${failures} attempts; backing off`,
+							error,
+						);
+					}
+					if (failures >= FAILURES_BEFORE_BACKOFF) {
+						nextAttempt =
+							Date.now() +
+							Math.min(
+								MAX_BACKOFF_MS,
+								CHECK_MS * 2 ** (failures - FAILURES_BEFORE_BACKOFF + 1),
+							);
+					}
 				})
 				.finally(() => {
 					pending = false;
 				});
 		};
 		const frame = requestAnimationFrame(check);
-		const timer = window.setInterval(check, 500);
+		timer = window.setInterval(check, CHECK_MS);
 		return () => {
 			cancelled = true;
 			cancelAnimationFrame(frame);
-			clearInterval(timer);
+			stop();
 		};
 	}, [
 		ready,

--- a/src/renderer/src/shared/hooks/use-completion-view.ts
+++ b/src/renderer/src/shared/hooks/use-completion-view.ts
@@ -1,0 +1,96 @@
+import { desktopResult } from "@shared/api/local-operator/desktop-api";
+import { useCanonicalSessionsStore } from "@shared/store/canonical-sessions-store";
+import { type RefObject, useEffect } from "react";
+import type { CanonicalFrontendState } from "../../../../shared/desktop-session-contract";
+
+/** A stream, mount, watch lease or offscreen row is never evidence of reading.
+ * Capture canonical identity and completion together; navigation retires this
+ * attempt, and main independently checks the actual BrowserWindow at admission.
+ */
+export function useCompletionView(
+	frontend: CanonicalFrontendState | null | undefined,
+	ready: boolean,
+	root: RefObject<HTMLDivElement>,
+) {
+	const selected = useCanonicalSessionsStore((state) => state.activeSessionId);
+	const attention = frontend?.attention;
+	const sessionId = frontend?.session_id;
+	useEffect(() => {
+		if (
+			!ready ||
+			frontend?.streaming ||
+			!sessionId ||
+			selected !== sessionId ||
+			!attention?.unseen ||
+			attention.supported !== true ||
+			!attention.completion_token ||
+			!attention.anchor_id ||
+			attention.conversation_id !== `session/${sessionId}`
+		)
+			return;
+		const completionToken = attention.completion_token;
+		const anchorId = attention.anchor_id;
+		let cancelled = false;
+		let pending = false;
+		let acknowledged = false;
+		const check = () => {
+			if (
+				cancelled ||
+				pending ||
+				acknowledged ||
+				document.visibilityState !== "visible" ||
+				!document.hasFocus() ||
+				useCanonicalSessionsStore.getState().activeSessionId !== sessionId
+			)
+				return;
+			const element = root.current?.querySelector<HTMLElement>(
+				`[data-completion-anchor="${CSS.escape(anchorId)}"][data-completion-complete="true"]`,
+			);
+			if (!element) return;
+			const rect = element.getBoundingClientRect();
+			const x = rect.left + rect.width / 2;
+			const y = rect.bottom - 2;
+			if (
+				rect.width <= 0 ||
+				rect.height <= 0 ||
+				x < 0 ||
+				x >= innerWidth ||
+				y < 0 ||
+				y >= innerHeight
+			)
+				return;
+			const top = document.elementFromPoint(x, y);
+			if (!top || !element.contains(top)) return;
+			pending = true;
+			void desktopResult({ op: "sessions.seen", sessionId, completionToken })
+				.then(() => {
+					acknowledged = true;
+				})
+				.catch(() => {
+					// No optimistic clear. A rejected native-focus check or stale
+					// token leaves authoritative state intact and permits a retry.
+				})
+				.finally(() => {
+					pending = false;
+				});
+		};
+		const frame = requestAnimationFrame(check);
+		const timer = window.setInterval(check, 500);
+		return () => {
+			cancelled = true;
+			cancelAnimationFrame(frame);
+			clearInterval(timer);
+		};
+	}, [
+		ready,
+		frontend?.streaming,
+		sessionId,
+		selected,
+		attention?.conversation_id,
+		attention?.completion_token,
+		attention?.anchor_id,
+		attention?.unseen,
+		attention?.supported,
+		root,
+	]);
+}

--- a/src/shared/desktop-contract.ts
+++ b/src/shared/desktop-contract.ts
@@ -121,6 +121,13 @@ export const desktopRequestSchema = z.discriminatedUnion("op", [
 		.strict(),
 	z
 		.object({
+			op: z.literal("sessions.seen"),
+			sessionId,
+			completionToken: z.string().uuid(),
+		})
+		.strict(),
+	z
+		.object({
 			op: z.literal("sessions.watch"),
 			sessionId,
 			subscriptionId: z.string().regex(/^[a-f0-9]{32}$/),
@@ -750,6 +757,12 @@ export function desktopEndpoint(request: DesktopRequest): {
 					approved: request.approved,
 					question_index: request.questionIndex,
 				},
+			};
+		case "sessions.seen":
+			return {
+				path: `/v1/desktop/sessions/${request.sessionId}/seen`,
+				method: "POST",
+				body: { completion_token: request.completionToken },
 			};
 		case "sessions.watch":
 			return {

--- a/src/shared/desktop-session-contract.ts
+++ b/src/shared/desktop-session-contract.ts
@@ -2,6 +2,40 @@
 // Owner state revisions and HTTP semantic receipt cursors are independent. See
 // docs/desktop-controls.md before implementing replay or notifications.
 export type CanonicalSessionId = string;
+export type CompletionAttention = {
+	conversation_id: string;
+	completion_token: string | null;
+	anchor_id: string | null;
+	kind: "complete" | "error" | "interrupted" | null;
+	unseen: boolean;
+	revision: [number, number];
+	/** False for a live owner that has not negotiated completion receipts. */
+	supported?: boolean;
+};
+export function mergeCompletionAttention(
+	current: CompletionAttention | undefined,
+	incoming: CompletionAttention | undefined,
+	sessionId: string,
+): CompletionAttention | undefined {
+	if (
+		!incoming ||
+		incoming.conversation_id !== `session/${sessionId}` ||
+		!Array.isArray(incoming.revision) ||
+		incoming.revision.length !== 2 ||
+		!incoming.revision.every((n) => Number.isSafeInteger(n) && n >= 0)
+	)
+		return current;
+	// These clocks survive owner/server epochs; an old snapshot or delayed ACK
+	// can never make a newer completion, or an already-observed read, disappear.
+	if (
+		current?.conversation_id === incoming.conversation_id &&
+		(incoming.revision[0] < current.revision[0] ||
+			incoming.revision[1] < current.revision[1])
+	)
+		return current;
+	return incoming;
+}
+
 export type CanonicalModel = {
 	provider: string;
 	model_id: string;
@@ -24,6 +58,7 @@ export type PendingDesktopGate = {
 	question_total: number;
 };
 export type CanonicalFrontendState = {
+	attention?: CompletionAttention;
 	state_version: number;
 	session_id: CanonicalSessionId;
 	epoch: string;
@@ -104,6 +139,7 @@ export type DesktopSessionFrame =
 			}
 	  >
 	| Receipt<"snapshot", DesktopSnapshot>
+	| Receipt<"attention", CompletionAttention>
 	| Receipt<
 			"frontend.update",
 			{


### PR DESCRIPTION
# PR Description

## Summary of Changes

Marks a conversation read when the user has actually viewed its completed result, so a
result read in the desktop app stops showing as unread on the phone and in the terminal.
Backend companion: damianvtran/local-operator#697.

Acknowledgement is deliberately hard to earn, because every cheap proxy for "viewed" is
wrong: mounting a screen, holding a stream open, or owning a watch lease all happen while
the window is buried behind another application.

- **Renderer eligibility.** The conversation must be the selected one, the document visible
  and focused, and the **end** of the completed result actually painted and unoccluded —
  hit-tested at its bottom edge, because a result whose tail is below the fold has not been
  read. Streaming, loading and history-backfill states are excluded.
- **Native admission in main.** Renderer evidence cannot prove native foreground: an
  occluded, hidden or minimized window still reports `visibilityState === "visible"` and can
  hold document focus. Main re-checks the real `BrowserWindow` (visible, not minimized,
  focused) and does so on the **shared typed request door**, so no other IPC caller can
  route around it. Ordinary control traffic from a background window is unaffected — only
  receipts are gated.
- **Monotonic receipt merging.** Owner epochs restart and frames arrive reordered after a
  reconnect, so applying whichever payload arrived last would resurrect an already-read
  result or hide a newer unread one. Neither clock may run backwards, and identity is
  namespaced: a persistent agent conversation is not the session that shares its id.
- **Durable outcome anchors.** Error and interrupted endings anchor at their durable marker
  position rather than the current tail, so an old failure is not re-presented as the newest
  thing in the conversation.

## Related Issue(s)

- Backend companion: damianvtran/local-operator#697
- Depends on: #83 (desktop control surface) — **held on backend C5 approval**

## Impact

**Breaking changes:** none. `sessions.seen` is a new contract operation; the transcript
gains data attributes and an optional `frontend` prop.

**Dependency and review scope.** Stacked directly on #83's head (`8c60fd2a`). Review only
the adapter commit above that base. **#83's backend prerequisite is held for human C5
approval and must not be assumed merged.**

**Security.** The receipt cannot be issued by a background window, an occluded window, a
non-selected conversation, or any caller other than the owned main frame. It carries a
completion token only — no timestamp a client could use to acknowledge something it never
saw.

## Testing

There is no test runner in this repository, so verification is typecheck, lint, the theme
gates, a real build, and the contract suite driving the **actual bundled TypeScript**.

### Native foreground admission (`scripts/desktop-contract.test.mjs`)

Drives the real `registerDesktopIPC` against a fixture `BrowserWindow`:

| Window state | Receipt |
| --- | --- |
| visible, not minimized, focused | **admitted** |
| unfocused | **refused** |
| not visible | **refused** |
| minimized | **refused** |
| any background state, `settings.list` | **still works** — the gate is receipt-specific |

### Receipt convergence, on the real merge function

Ten cases bundled from the shipped contract: fresh adoption, newer completion, newer
receipt, stale published clock, stale receipt clock, foreign session id, `agent/<id>`
namespace collision, malformed and negative revisions, missing payload. Every stale or
foreign payload is rejected; no clock runs backwards.

### Request shaping

`sessions.seen` is asserted to reach `/v1/desktop/sessions/{id}/seen` with a
`completion_token` body and bearer authorization, while a bodyless call, a `"now"` token, a
traversal session id and an extra `seenAt` field are all rejected before any HTTP happens.

### Gates

```text
pnpm check-types    0 errors (main + renderer)
pnpm lint           7 warnings — pre-existing, verified identical on a stashed clean tree
pnpm check-themes   themes.generated.css up to date; 1884 contrast assertions, 12 themes
node --test scripts/desktop-contract.test.mjs    13/13 pass
pnpm build          succeeds
```

## Non-goals

- **No new visual surface.** This PR adds no unread badge, indicator or styling; it makes
  the existing shared state correct. A visible unread affordance is a separate change.
- **No native notification withdrawal.** Reading does not retract a delivered notification.
- **Pending approvals and questions are never cleared by reading.** A gate is an action, not
  a notification.
- **No optimistic local clear.** A failed or refused receipt leaves authoritative state
  untouched and simply permits a later retry, so the app never claims a read the backend
  did not record.

## Rollout

Self-enabling and additive. Against a backend without `completion-ack-v1` the renderer sees
`supported: false` and never attempts a receipt, so the app behaves exactly as it does
today.
