### PR TITLE
chore(repo): add CODEOWNERS and record who may merge

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,18 @@
+# Code owners for local-operator-ui.
+#
+# Unlike the backend repository, `main` here has no ruleset requiring a
+# code-owner review at the time of writing. This file is therefore about
+# review ROUTING, not about unblocking merges: GitHub requests these owners
+# automatically on every PR, so the right people see a change without anyone
+# remembering to add them by hand. It also means that if a code-owner rule is
+# ever switched on for this repository, it resolves against a real list from
+# the start rather than matching nobody -- the failure that forced every
+# backend PR through an admin bypass in September 2026.
+#
+# Keep this list to people who can actually approve. A handle that is not a
+# collaborator with write access is silently ignored by GitHub -- the line
+# looks correct and matches nobody. Verify a new entry against
+# `gh api repos/damianvtran/local-operator-ui/collaborators`.
+
+# Default owners for everything in the repository.
+* @damianvtran @bbqben

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -169,3 +169,33 @@ Use this process whenever asked to cut a release.
 - If the user asks for a release bump, execute the full workflow end-to-end unless told otherwise.
 - If there are unrelated uncommitted changes, do not discard them; proceed carefully and scope your commit.
 - Keep release notes aligned with prior repository style and include a compare-link changelog.
+
+## Who may merge: agent review is sufficient for a code owner
+
+Code owners are listed in `.github/CODEOWNERS`. When the agent is **acting for
+a code owner** — running on a code owner's machine and under their account,
+which is the normal case here — the standing agent review gate **is** the
+approval. A clean, fresh, independent agent review round plus green CI is
+sufficient to merge; do not wait for a second human to click approve.
+
+This is a statement about *authority*, not about rigour. Every requirement
+still holds in full: an **independent** reviewer subagent (never the agent that
+wrote the code), rounds repeated until no blocker or major remains, review
+freshness against the current head, QA evidence from the real running surface,
+and a design/UX round for anything user-visible — which, in this repository, is
+most changes. Merging is authorized by the review being genuinely clean, never
+by the merger being entitled to it.
+
+Two things this does not license:
+
+- **Never approve your own work to satisfy the rule.** The author and the
+  reviewer must be different agents. GitHub cannot tell them apart, because
+  every agent here pushes as the same account — so this separation is a
+  discipline the agents keep, not one the forge enforces.
+- **`--admin` stays a last resort, and stays disclosed.** If a bypass is ever
+  genuinely necessary, say plainly on the PR and in the release notes that the
+  merge bypassed rather than cleared review. A tag that implies a review it
+  never had is the failure this section exists to prevent.
+
+An agent that is **not** acting for a code owner prepares the PR, records the
+review rounds, and hands it to an owner to merge.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -172,11 +172,23 @@ Use this process whenever asked to cut a release.
 
 ## Who may merge: agent review is sufficient for a code owner
 
-Code owners are listed in `.github/CODEOWNERS`. When the agent is **acting for
-a code owner** — running on a code owner's machine and under their account,
-which is the normal case here — the standing agent review gate **is** the
-approval. A clean, fresh, independent agent review round plus green CI is
-sufficient to merge; do not wait for a second human to click approve.
+Code owners are listed in `.github/CODEOWNERS`. **This repository has no
+ruleset requiring an approving review**, so there is no approval gate to clear
+here — `CODEOWNERS` routes review requests, it does not block merges. The rule
+below is therefore about what makes a merge *legitimate*, not about what the
+forge will let through.
+
+When the agent is **acting for a code owner** — running on a code owner's
+machine and under their account, which is the normal case here — the standing
+agent review gate is what authorizes the merge. A clean, fresh, independent
+agent review round plus green CI is sufficient; do not wait for a second human
+to click approve. Nothing here is permission to merge on a *weaker* basis than
+that just because the forge would allow it: with no ruleset in the way, the
+agent review round is the only real control this repository has.
+
+If a code-owner ruleset is ever enabled here, read the backend's
+`AGENTS.md` § "Who may merge" first — it documents a self-approval limitation
+that bites the moment such a rule exists.
 
 This is a statement about *authority*, not about rigour. Every requirement
 still holds in full: an **independent** reviewer subagent (never the agent that


### PR DESCRIPTION
# PR Description

## Summary of Changes

Adds `.github/CODEOWNERS` and records who may merge, mirroring the companion
backend PR damianvtran/local-operator#700.

This repository has **no** code-owner ruleset today, so unlike the backend the
file is not unblocking anything. It is about review **routing**: GitHub
requests these owners automatically on every PR, so the right people see a
change without anyone remembering to add them by hand. It also means that if a
code-owner rule is ever switched on here, it resolves against a real list from
the start rather than matching nobody — the failure that forced every backend
PR through an admin bypass in September 2026.

- **`.github/CODEOWNERS`** — `* @damianvtran @bbqben` as default owners.
- **`AGENTS.md`** — a "Who may merge" section: when an agent acts for a code
  owner, a clean, fresh, independent agent review plus green CI is sufficient
  to merge.

## Impact

- **No behaviour change** to the app; repository configuration and docs only.
- Rigour is unchanged and restated: the reviewer must be a different agent from
  the author, design/UX rounds still apply to user-visible work (most changes
  in this repository), and an `--admin` bypass stays a last resort that must be
  disclosed on the PR and in the release notes.

## Testing Details

- Confirmed this repository has no ruleset requiring code-owner review
  (`gh api repos/damianvtran/local-operator-ui/rules/branches/main` returns
  `[]`), so the file is documented as routing rather than as a gate — it does
  not claim to unblock a merge it was never blocking.
- Confirmed both owners are collaborators with write access via
  `gh api repos/damianvtran/local-operator-ui/collaborators`.

## Checklist

- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my code.
- [x] Documentation updated (`AGENTS.md`).
- [x] No user-visible surface changed, so no screenshots apply.
