### PR TITLE
fix(desktop): onboarding census, badge overlap, and stale-agent 404

### DIFF
--- a/package.json
+++ b/package.json
@@ -61,7 +61,7 @@
     "check-types:main": "tsc --noEmit -p tsconfig.node.json",
     "check-types:renderer": "tsc --noEmit -p tsconfig.app.json",
     "check-types": "pnpm run check-types:main && pnpm run check-types:renderer",
-    "test:desktop": "node --test scripts/desktop-contract.test.mjs scripts/transcript-reducer.test.mjs",
+    "test:desktop": "node --test scripts/desktop-contract.test.mjs scripts/transcript-reducer.test.mjs scripts/provider-state.test.mjs scripts/stale-agent.test.mjs",
     "check-themes": "node scripts/generate-theme-css.mjs --check && node scripts/contrast-contract.mjs",
     "check-evidence": "node scripts/check-evidence.mjs",
     "check-edit-diffs": "node scripts/check-edit-diffs.mjs",

--- a/scripts/fixtures/auth-providers-0.50.0.json
+++ b/scripts/fixtures/auth-providers-0.50.0.json
@@ -1,0 +1,543 @@
+{
+ "status": 200,
+ "message": "Provider controls retrieved.",
+ "result": {
+  "providers": [
+   {
+    "id": "openai",
+    "name": "OpenAI (ChatGPT Plus/Pro)",
+    "auth_methods": [
+     {
+      "id": "openai",
+      "label": "OpenAI (ChatGPT Plus/Pro)",
+      "kind": "browser",
+      "method_id": "openai",
+      "requires_secret_input": false,
+      "paste_fallback": false
+     },
+     {
+      "id": "openai-device",
+      "label": "OpenAI (ChatGPT device code)",
+      "kind": "device",
+      "method_id": "openai-device",
+      "requires_secret_input": false,
+      "paste_fallback": false
+     },
+     {
+      "id": "openai",
+      "method_id": "openai:api-key",
+      "label": "API key",
+      "kind": "api_key",
+      "requires_secret_input": true,
+      "paste_fallback": false
+     }
+    ],
+    "storage_id": "openai",
+    "search_aliases": [
+     "gpt",
+     "chatgpt",
+     "codex"
+    ],
+    "login_kind": "browser",
+    "accepts_api_key": true,
+    "local": false,
+    "credential_name": "OPENAI_API_KEY",
+    "paste_required": false,
+    "paste_supported": false,
+    "configured": true,
+    "credential_optional": false,
+    "has_credential": true,
+    "stored_credentials": 1,
+    "base_url": "https://api.openai.com/v1"
+   },
+   {
+    "id": "anthropic",
+    "name": "Anthropic (Claude Pro/Max)",
+    "auth_methods": [
+     {
+      "id": "anthropic",
+      "label": "Anthropic (Claude Pro/Max)",
+      "kind": "browser",
+      "method_id": "anthropic",
+      "requires_secret_input": false,
+      "paste_fallback": true
+     },
+     {
+      "id": "anthropic",
+      "method_id": "anthropic:api-key",
+      "label": "API key",
+      "kind": "api_key",
+      "requires_secret_input": true,
+      "paste_fallback": false
+     }
+    ],
+    "storage_id": "anthropic",
+    "search_aliases": [
+     "claude",
+     "sonnet",
+     "opus",
+     "haiku"
+    ],
+    "login_kind": "browser",
+    "accepts_api_key": true,
+    "local": false,
+    "credential_name": null,
+    "paste_required": false,
+    "paste_supported": true,
+    "configured": true,
+    "credential_optional": false,
+    "has_credential": true,
+    "stored_credentials": 5,
+    "base_url": "https://api.anthropic.com"
+   },
+   {
+    "id": "kimi",
+    "name": "Kimi (Moonshot)",
+    "auth_methods": [
+     {
+      "id": "kimi",
+      "label": "Kimi (Moonshot)",
+      "kind": "device",
+      "method_id": "kimi",
+      "requires_secret_input": false,
+      "paste_fallback": false
+     },
+     {
+      "id": "kimi",
+      "method_id": "kimi:api-key",
+      "label": "API key",
+      "kind": "api_key",
+      "requires_secret_input": true,
+      "paste_fallback": false
+     }
+    ],
+    "storage_id": "kimi",
+    "search_aliases": [
+     "moonshot",
+     "k2",
+     "k3"
+    ],
+    "login_kind": "device",
+    "accepts_api_key": true,
+    "local": false,
+    "credential_name": "KIMI_API_KEY",
+    "paste_required": false,
+    "paste_supported": false,
+    "configured": true,
+    "credential_optional": false,
+    "has_credential": true,
+    "stored_credentials": 1,
+    "base_url": "https://api.moonshot.cn/v1"
+   },
+   {
+    "id": "xai",
+    "name": "xAI (Grok API key)",
+    "auth_methods": [
+     {
+      "id": "xai",
+      "label": "xAI (Grok API key)",
+      "kind": "api_key",
+      "method_id": "xai",
+      "requires_secret_input": true,
+      "paste_fallback": false
+     },
+     {
+      "id": "xai-oauth",
+      "label": "xAI (Grok OAuth)",
+      "kind": "device",
+      "method_id": "xai-oauth",
+      "requires_secret_input": false,
+      "paste_fallback": false
+     }
+    ],
+    "storage_id": "xai",
+    "search_aliases": [
+     "grok"
+    ],
+    "login_kind": "api_key",
+    "accepts_api_key": true,
+    "local": false,
+    "credential_name": "XAI_API_KEY",
+    "paste_required": true,
+    "paste_supported": true,
+    "configured": true,
+    "credential_optional": false,
+    "has_credential": true,
+    "stored_credentials": 1,
+    "base_url": "https://api.x.ai/v1"
+   },
+   {
+    "id": "deepseek",
+    "name": "DeepSeek",
+    "auth_methods": [
+     {
+      "id": "deepseek",
+      "label": "DeepSeek",
+      "kind": "api_key",
+      "method_id": "deepseek",
+      "requires_secret_input": true,
+      "paste_fallback": false
+     }
+    ],
+    "storage_id": "deepseek",
+    "search_aliases": [
+     "ds"
+    ],
+    "login_kind": "api_key",
+    "accepts_api_key": true,
+    "local": false,
+    "credential_name": "DEEPSEEK_API_KEY",
+    "paste_required": true,
+    "paste_supported": true,
+    "configured": true,
+    "credential_optional": false,
+    "has_credential": true,
+    "stored_credentials": 1,
+    "base_url": "https://api.deepseek.com/v1"
+   },
+   {
+    "id": "zai",
+    "name": "Z.AI (GLM API key)",
+    "auth_methods": [
+     {
+      "id": "zai",
+      "label": "Z.AI (GLM API key)",
+      "kind": "api_key",
+      "method_id": "zai",
+      "requires_secret_input": true,
+      "paste_fallback": false
+     },
+     {
+      "id": "zai-oauth",
+      "label": "Z.AI (GLM browser sign-in)",
+      "kind": "browser",
+      "method_id": "zai-oauth",
+      "requires_secret_input": false,
+      "paste_fallback": true
+     }
+    ],
+    "storage_id": "zai",
+    "search_aliases": [
+     "glm",
+     "zhipu",
+     "bigmodel",
+     "z-ai"
+    ],
+    "login_kind": "api_key",
+    "accepts_api_key": true,
+    "local": false,
+    "credential_name": "ZAI_API_KEY",
+    "paste_required": true,
+    "paste_supported": true,
+    "configured": true,
+    "credential_optional": false,
+    "has_credential": true,
+    "stored_credentials": 1,
+    "base_url": "https://api.z.ai/api/coding/paas/v4"
+   },
+   {
+    "id": "google",
+    "name": "Google (Gemini)",
+    "auth_methods": [
+     {
+      "id": "google",
+      "label": "Google (Gemini)",
+      "kind": "api_key",
+      "method_id": "google",
+      "requires_secret_input": true,
+      "paste_fallback": false
+     }
+    ],
+    "storage_id": "google",
+    "search_aliases": [
+     "gemini",
+     "vertex",
+     "aistudio"
+    ],
+    "login_kind": "api_key",
+    "accepts_api_key": true,
+    "local": false,
+    "credential_name": "GOOGLE_AI_STUDIO_API_KEY",
+    "paste_required": true,
+    "paste_supported": true,
+    "configured": false,
+    "credential_optional": false,
+    "has_credential": false,
+    "stored_credentials": 0,
+    "base_url": "https://generativelanguage.googleapis.com"
+   },
+   {
+    "id": "mistral",
+    "name": "Mistral AI",
+    "auth_methods": [
+     {
+      "id": "mistral",
+      "label": "Mistral AI",
+      "kind": "api_key",
+      "method_id": "mistral",
+      "requires_secret_input": true,
+      "paste_fallback": false
+     }
+    ],
+    "storage_id": "mistral",
+    "search_aliases": [
+     "codestral",
+     "magistral"
+    ],
+    "login_kind": "api_key",
+    "accepts_api_key": true,
+    "local": false,
+    "credential_name": "MISTRAL_API_KEY",
+    "paste_required": true,
+    "paste_supported": true,
+    "configured": false,
+    "credential_optional": false,
+    "has_credential": false,
+    "stored_credentials": 0,
+    "base_url": "https://api.mistral.ai/v1"
+   },
+   {
+    "id": "lmstudio",
+    "name": "LM Studio",
+    "auth_methods": [],
+    "storage_id": "lmstudio",
+    "search_aliases": [
+     "local",
+     "self-hosted"
+    ],
+    "login_kind": null,
+    "accepts_api_key": false,
+    "local": true,
+    "credential_name": null,
+    "paste_required": false,
+    "paste_supported": false,
+    "configured": true,
+    "credential_optional": true,
+    "has_credential": false,
+    "stored_credentials": 0,
+    "base_url": "http://localhost:1234/v1"
+   },
+   {
+    "id": "ollama",
+    "name": "Ollama",
+    "auth_methods": [],
+    "storage_id": "ollama",
+    "search_aliases": [
+     "local",
+     "self-hosted"
+    ],
+    "login_kind": null,
+    "accepts_api_key": false,
+    "local": true,
+    "credential_name": null,
+    "paste_required": false,
+    "paste_supported": false,
+    "configured": true,
+    "credential_optional": true,
+    "has_credential": false,
+    "stored_credentials": 0,
+    "base_url": "http://localhost:11434/v1"
+   },
+   {
+    "id": "vllm",
+    "name": "vLLM",
+    "auth_methods": [],
+    "storage_id": "vllm",
+    "search_aliases": [
+     "local",
+     "self-hosted"
+    ],
+    "login_kind": null,
+    "accepts_api_key": false,
+    "local": true,
+    "credential_name": null,
+    "paste_required": false,
+    "paste_supported": false,
+    "configured": true,
+    "credential_optional": true,
+    "has_credential": false,
+    "stored_credentials": 0,
+    "base_url": "http://localhost:8000/v1"
+   },
+   {
+    "id": "llamacpp",
+    "name": "llama.cpp",
+    "auth_methods": [],
+    "storage_id": "llamacpp",
+    "search_aliases": [
+     "local",
+     "self-hosted"
+    ],
+    "login_kind": null,
+    "accepts_api_key": false,
+    "local": true,
+    "credential_name": null,
+    "paste_required": false,
+    "paste_supported": false,
+    "configured": true,
+    "credential_optional": true,
+    "has_credential": false,
+    "stored_credentials": 0,
+    "base_url": "http://localhost:8080/v1"
+   },
+   {
+    "id": "openai-compatible",
+    "name": "OpenAI-compatible",
+    "auth_methods": [],
+    "storage_id": "openai-compatible",
+    "search_aliases": [
+     "local",
+     "self-hosted"
+    ],
+    "login_kind": null,
+    "accepts_api_key": false,
+    "local": true,
+    "credential_name": null,
+    "paste_required": false,
+    "paste_supported": false,
+    "configured": true,
+    "credential_optional": true,
+    "has_credential": false,
+    "stored_credentials": 0,
+    "base_url": ""
+   },
+   {
+    "id": "openrouter",
+    "name": "OpenRouter",
+    "auth_methods": [
+     {
+      "id": "openrouter",
+      "label": "OpenRouter",
+      "kind": "api_key",
+      "method_id": "openrouter",
+      "requires_secret_input": true,
+      "paste_fallback": false
+     }
+    ],
+    "storage_id": "openrouter",
+    "search_aliases": [
+     "or",
+     "router"
+    ],
+    "login_kind": "api_key",
+    "accepts_api_key": true,
+    "local": false,
+    "credential_name": "OPENROUTER_API_KEY",
+    "paste_required": true,
+    "paste_supported": true,
+    "configured": true,
+    "credential_optional": false,
+    "has_credential": true,
+    "stored_credentials": 1,
+    "base_url": "https://openrouter.ai/api/v1"
+   },
+   {
+    "id": "radient",
+    "name": "Radient",
+    "auth_methods": [
+     {
+      "id": "radient",
+      "label": "Radient",
+      "kind": "browser",
+      "method_id": "radient",
+      "requires_secret_input": false,
+      "paste_fallback": false
+     },
+     {
+      "id": "radient-key",
+      "label": "Radient (API key)",
+      "kind": "api_key",
+      "method_id": "radient-key",
+      "requires_secret_input": true,
+      "paste_fallback": false
+     }
+    ],
+    "storage_id": "radient",
+    "search_aliases": [
+     "radient-oauth"
+    ],
+    "login_kind": "browser",
+    "accepts_api_key": true,
+    "local": false,
+    "credential_name": "RADIENT_API_KEY",
+    "paste_required": false,
+    "paste_supported": false,
+    "configured": true,
+    "credential_optional": false,
+    "has_credential": true,
+    "stored_credentials": 1,
+    "base_url": "https://api.radienthq.com/v1"
+   },
+   {
+    "id": "alibaba",
+    "name": "Alibaba Cloud (Qwen)",
+    "auth_methods": [
+     {
+      "id": "alibaba",
+      "label": "Alibaba Cloud (Qwen)",
+      "kind": "api_key",
+      "method_id": "alibaba",
+      "requires_secret_input": true,
+      "paste_fallback": false
+     }
+    ],
+    "storage_id": "alibaba",
+    "search_aliases": [
+     "qwen",
+     "dashscope",
+     "tongyi"
+    ],
+    "login_kind": "api_key",
+    "accepts_api_key": true,
+    "local": false,
+    "credential_name": "ALIBABA_CLOUD_API_KEY",
+    "paste_required": true,
+    "paste_supported": true,
+    "configured": false,
+    "credential_optional": false,
+    "has_credential": false,
+    "stored_credentials": 0,
+    "base_url": "https://dashscope-intl.aliyuncs.com/compatible-mode/v1"
+   },
+   {
+    "id": "alibaba-token-plan",
+    "name": "QwenCloud Token Plan",
+    "auth_methods": [
+     {
+      "id": "alibaba-token-plan",
+      "label": "QwenCloud Token Plan",
+      "kind": "api_key",
+      "method_id": "alibaba-token-plan",
+      "requires_secret_input": true,
+      "paste_fallback": false
+     },
+     {
+      "id": "alibaba-token-plan-oauth",
+      "label": "QwenCloud Token Plan (usage OAuth)",
+      "kind": "device",
+      "method_id": "alibaba-token-plan-oauth",
+      "requires_secret_input": true,
+      "paste_fallback": false
+     }
+    ],
+    "storage_id": "alibaba-token-plan",
+    "search_aliases": [
+     "token-plan",
+     "tokenplan",
+     "qwencloud"
+    ],
+    "login_kind": "api_key",
+    "accepts_api_key": true,
+    "local": false,
+    "credential_name": "ALIBABA_TOKEN_PLAN_API_KEY",
+    "paste_required": true,
+    "paste_supported": true,
+    "configured": true,
+    "credential_optional": false,
+    "has_credential": true,
+    "stored_credentials": 3,
+    "base_url": "https://token-plan.ap-southeast-1.maas.aliyuncs.com/compatible-mode/v1"
+   }
+  ]
+ }
+}

--- a/scripts/provider-state.test.mjs
+++ b/scripts/provider-state.test.mjs
@@ -1,0 +1,170 @@
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { test } from "node:test";
+import { build } from "esbuild";
+
+// The two modules are pure TypeScript with no React or DOM imports, so they
+// bundle in memory the same way `transcript-reducer.test.mjs` does. The
+// fixture is a VERBATIM `GET /v1/auth/providers` body from a local-operator
+// 0.50.0 backend with nine providers signed in, captured for the 0.15.1
+// defect report in which onboarding showed "Needs sign-in" over a signed-in
+// census. It carries no credential values -- the census never does.
+const bundle = await build({
+	stdin: {
+		contents: [
+			'export * from "./src/renderer/src/features/providers/provider-labels";',
+			'export * from "./src/renderer/src/shared/hooks/first-time-user";',
+		].join("\n"),
+		resolveDir: process.cwd(),
+	},
+	bundle: true,
+	format: "esm",
+	platform: "neutral",
+	write: false,
+	tsconfig: "tsconfig.web.json",
+});
+const { providerReadiness, decideFirstTimeUser, hasConnectedProvider } =
+	await import(
+		`data:text/javascript;base64,${Buffer.from(bundle.outputFiles[0].text).toString("base64")}`
+	);
+
+const census = JSON.parse(
+	readFileSync(new URL("./fixtures/auth-providers-0.50.0.json", import.meta.url)),
+).result.providers;
+
+test("real 0.50.0 census renders 'Signed in' for every provider with a credential", () => {
+	const labels = Object.fromEntries(
+		census.map((provider) => [provider.id, providerReadiness(provider).label]),
+	);
+	assert.deepEqual(labels, {
+		openai: "Signed in",
+		anthropic: "Signed in",
+		kimi: "Signed in",
+		xai: "Signed in",
+		deepseek: "Signed in",
+		zai: "Signed in",
+		google: "Needs sign-in",
+		mistral: "Needs sign-in",
+		lmstudio: "No key needed",
+		ollama: "No key needed",
+		vllm: "No key needed",
+		llamacpp: "No key needed",
+		"openai-compatible": "No key needed",
+		openrouter: "Signed in",
+		radient: "Signed in",
+		alibaba: "Needs sign-in",
+		"alibaba-token-plan": "Signed in",
+	});
+	// The short local label keeps its full statement reachable.
+	assert.equal(
+		providerReadiness(census.find((p) => p.id === "ollama")).detail,
+		"No key needed - needs a running server",
+	);
+	// Signed in is the only success tone; a local server is not a connection.
+	for (const provider of census) {
+		const readiness = providerReadiness(provider);
+		assert.equal(readiness.tone === "success", readiness.label === "Signed in");
+	}
+});
+
+test("a credential in the environment alone still reads as signed in", () => {
+	// `has_credential` folds in `resolve_env_key`, so a provider keyed only
+	// through the environment arrives as has_credential: true with zero stored
+	// credentials. Grouping on the count would mislabel it.
+	const label = providerReadiness({
+		local: false,
+		credential_optional: false,
+		configured: true,
+		has_credential: true,
+		stored_credentials: 0,
+	}).label;
+	assert.equal(label, "Signed in");
+});
+
+test("first-time decision: all configured -> returning, no onboarding", () => {
+	assert.equal(
+		decideFirstTimeUser({
+			onboardingComplete: false,
+			census: { status: "ready", providers: census },
+			legacy: { status: "ready", keys: [] },
+		}),
+		"returning",
+	);
+});
+
+test("first-time decision: only local providers configured -> first time", () => {
+	const none = census.map((provider) => ({
+		...provider,
+		configured: provider.local,
+		has_credential: false,
+	}));
+	assert.equal(hasConnectedProvider(none), false);
+	assert.equal(
+		decideFirstTimeUser({
+			onboardingComplete: false,
+			census: { status: "ready", providers: none },
+			// The legacy list is IGNORED once the census has answered: on a real
+			// machine it held Google/AWS/Radient keys and still meant nothing
+			// about model providers.
+			legacy: { status: "ready", keys: ["GOOGLE_ACCESS_TOKEN", "AWS_ACCESS_KEY_ID"] },
+		}),
+		"first_time",
+	);
+});
+
+test("first-time decision: loading -> nothing decided yet", () => {
+	assert.equal(
+		decideFirstTimeUser({
+			onboardingComplete: false,
+			census: { status: "loading" },
+			legacy: { status: "ready", keys: [] },
+		}),
+		"pending",
+	);
+	assert.equal(
+		decideFirstTimeUser({
+			onboardingComplete: false,
+			census: { status: "unavailable" },
+			legacy: { status: "loading" },
+		}),
+		"pending",
+	);
+	assert.equal(
+		decideFirstTimeUser({
+			onboardingComplete: false,
+			census: { status: "unavailable" },
+			legacy: { status: "error" },
+		}),
+		"pending",
+	);
+});
+
+test("first-time decision: older backend falls back to the legacy key list", () => {
+	assert.equal(
+		decideFirstTimeUser({
+			onboardingComplete: false,
+			census: { status: "unavailable" },
+			legacy: { status: "ready", keys: [] },
+		}),
+		"first_time",
+	);
+	assert.equal(
+		decideFirstTimeUser({
+			onboardingComplete: false,
+			census: { status: "unavailable" },
+			legacy: { status: "ready", keys: ["OPENAI_API_KEY"] },
+		}),
+		"returning",
+	);
+});
+
+test("first-time decision: a completed onboarding is never reopened", () => {
+	assert.equal(
+		decideFirstTimeUser({
+			onboardingComplete: true,
+			census: { status: "ready", providers: [] },
+			legacy: { status: "ready", keys: [] },
+		}),
+		"returning",
+	);
+});

--- a/scripts/provider-state.test.mjs
+++ b/scripts/provider-state.test.mjs
@@ -23,7 +23,13 @@ const bundle = await build({
 	write: false,
 	tsconfig: "tsconfig.web.json",
 });
-const { providerReadiness, decideFirstTimeUser, hasConnectedProvider } =
+const {
+	providerReadiness,
+	decideFirstTimeUser,
+	hasConnectedProvider,
+	hostingProviderSelectable,
+	readyHostingIds,
+} =
 	await import(
 		`data:text/javascript;base64,${Buffer.from(bundle.outputFiles[0].text).toString("base64")}`
 	);
@@ -155,6 +161,54 @@ test("first-time decision: older backend falls back to the legacy key list", () 
 			legacy: { status: "ready", keys: ["OPENAI_API_KEY"] },
 		}),
 		"returning",
+	);
+});
+
+test("first-time decision: advertised census that 5xx'd stays pending", () => {
+	// MINOR-1: empty keys must not invent first_time when the census was
+	// offered and then failed. That is a new backend, not an unmanaged one.
+	assert.equal(
+		decideFirstTimeUser({
+			onboardingComplete: false,
+			census: { status: "failed" },
+			legacy: { status: "ready", keys: [] },
+		}),
+		"pending",
+	);
+	assert.equal(
+		decideFirstTimeUser({
+			onboardingComplete: false,
+			census: { status: "failed" },
+			legacy: { status: "error" },
+		}),
+		"pending",
+	);
+});
+
+test("hosting picker agrees with the census, not the env-file key list", () => {
+	const ready = readyHostingIds(census);
+	assert.equal(ready.has("anthropic"), true);
+	assert.equal(ready.has("openai"), true);
+	assert.equal(ready.has("google"), false);
+	assert.equal(ready.has("ollama"), true);
+	// Env-only credential (has_credential, nothing stored) is still selectable.
+	assert.equal(
+		hostingProviderSelectable({
+			local: false,
+			credential_optional: false,
+			configured: true,
+			has_credential: true,
+		}),
+		true,
+	);
+	assert.equal(
+		hostingProviderSelectable({
+			local: false,
+			credential_optional: false,
+			configured: false,
+			has_credential: false,
+		}),
+		false,
 	);
 });
 

--- a/scripts/stale-agent.test.mjs
+++ b/scripts/stale-agent.test.mjs
@@ -1,0 +1,115 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+import { build } from "esbuild";
+
+// The status predicates and the selection store are pure (zustand runs
+// outside React), so the stale-selection rule the chat page applies can be
+// exercised here with the exact error shapes the desktop relay produces.
+const bundle = await build({
+	stdin: {
+		contents: [
+			'export * from "./src/renderer/src/shared/api/local-operator/desktop-api";',
+			'export * from "./src/renderer/src/shared/store/agent-selection-store";',
+		].join("\n"),
+		resolveDir: process.cwd(),
+	},
+	bundle: true,
+	format: "esm",
+	platform: "neutral",
+	mainFields: ["module", "main"],
+	write: false,
+	tsconfig: "tsconfig.web.json",
+});
+// zustand's persist middleware reads localStorage at store creation; give it
+// a minimal one so the module loads the same way it does in the renderer.
+const storage = new Map();
+globalThis.localStorage = {
+	getItem: (key) => storage.get(key) ?? null,
+	setItem: (key, value) => storage.set(key, String(value)),
+	removeItem: (key) => storage.delete(key),
+};
+globalThis.window = globalThis;
+const {
+	DesktopControlError,
+	isAgentNotFound,
+	isServerUnreachable,
+	useAgentSelectionStore,
+} = await import(
+	`data:text/javascript;base64,${Buffer.from(bundle.outputFiles[0].text).toString("base64")}`
+);
+
+const notFound = new DesktopControlError(
+	404,
+	"Get agent execution history request failed: 404 Not Found",
+);
+const transportDown = new DesktopControlError(
+	null,
+	"Desktop controls could not reach the backend process.",
+);
+const relayDown = new DesktopControlError(
+	503,
+	"The backend could not complete this request.",
+);
+const refused = new DesktopControlError(401, "Desktop authorization is required.");
+
+test("a 404 is 'agent gone', never 'server down'", () => {
+	assert.equal(isAgentNotFound(notFound), true);
+	assert.equal(isServerUnreachable(notFound), false);
+});
+
+test("a transport failure or 503 is 'server down', never 'agent gone'", () => {
+	for (const error of [transportDown, relayDown]) {
+		assert.equal(isServerUnreachable(error), true);
+		assert.equal(isAgentNotFound(error), false);
+	}
+});
+
+test("a refusal from a running server is neither", () => {
+	assert.equal(isAgentNotFound(refused), false);
+	assert.equal(isServerUnreachable(refused), false);
+	// A bare Error (pre-typed callers) claims nothing either way.
+	assert.equal(isAgentNotFound(new Error("404")), false);
+	assert.equal(isServerUnreachable(new Error("Failed to fetch")), false);
+});
+
+/**
+ * The rule chat-page.tsx applies in its effect: a persisted id that 404s is
+ * dropped; a URL id that 404s is reported, not dropped.
+ */
+function resolveStaleSelection({ urlAgentId, error }) {
+	const store = useAgentSelectionStore.getState();
+	const effective = urlAgentId || store.getLastAgentId("chat");
+	if (isAgentNotFound(error) && !urlAgentId && effective) {
+		store.clearAgentFromAllPages(effective);
+	}
+	return useAgentSelectionStore.getState().getLastAgentId("chat");
+}
+
+test("persisted id that 404s is cleared; the page falls back to the list", () => {
+	useAgentSelectionStore.getState().setLastChatAgentId("25f49075-stale");
+	useAgentSelectionStore.getState().setLastAgentsPageAgentId("25f49075-stale");
+	assert.equal(
+		resolveStaleSelection({ urlAgentId: null, error: notFound }),
+		null,
+	);
+	assert.equal(
+		useAgentSelectionStore.getState().getLastAgentId("agents"),
+		null,
+	);
+});
+
+test("a genuine network failure keeps the selection so retry can succeed", () => {
+	useAgentSelectionStore.getState().setLastChatAgentId("25f49075-live");
+	assert.equal(
+		resolveStaleSelection({ urlAgentId: null, error: transportDown }),
+		"25f49075-live",
+	);
+});
+
+test("an explicit URL to a missing agent is reported, not silently dropped", () => {
+	useAgentSelectionStore.getState().setLastChatAgentId("25f49075-other");
+	assert.equal(
+		resolveStaleSelection({ urlAgentId: "does-not-exist", error: notFound }),
+		"25f49075-other",
+	);
+});

--- a/src/renderer/src/features/chat/components/chat-page.tsx
+++ b/src/renderer/src/features/chat/components/chat-page.tsx
@@ -866,7 +866,7 @@ Store messages: ${JSON.stringify(getMessages(conversationId || ""), null, 2)}`;
 				return (
 					<PlaceholderView
 						title="This agent no longer exists"
-						description="It may have been deleted, or the app is now pointed at a different Local Operator home. Pick another agent from the sidebar."
+						description="It may have been deleted, or the app is using a different data folder. Pick another agent from the sidebar."
 						directionText="Choose an agent from the list"
 					/>
 				);

--- a/src/renderer/src/features/chat/components/chat-page.tsx
+++ b/src/renderer/src/features/chat/components/chat-page.tsx
@@ -1,5 +1,8 @@
 import { createLocalOperatorClient } from "@shared/api/local-operator";
-import { desktopResult } from "@shared/api/local-operator/desktop-api";
+import {
+	desktopResult,
+	isServerUnreachable,
+} from "@shared/api/local-operator/desktop-api";
 import {
 	desktopFeatureEnabled,
 	useDesktopCapabilities,
@@ -136,6 +139,9 @@ export const ChatPage: FC<ChatProps> = () => {
 	const getLastAgentId = useAgentSelectionStore(
 		(state) => state.getLastAgentId,
 	);
+	const clearAgentFromAllPages = useAgentSelectionStore(
+		(state) => state.clearAgentFromAllPages,
+	);
 
 	// Use the agent ID from URL or the last selected agent ID
 	const effectiveAgentId = agentId || getLastAgentId("chat");
@@ -230,11 +236,24 @@ export const ChatPage: FC<ChatProps> = () => {
 		isLoading: isLoadingMessages,
 		isError,
 		error,
+		isAgentNotFound,
 		isFetchingMore,
 		hasMoreMessages,
 		messagesContainerRef, // Get the ref from the hook
 		refetch,
 	} = useConversationMessages(conversationId);
+
+	// A persisted selection that the backend no longer knows is a stale
+	// pointer, not an error: the agent was deleted, or the config dir changed
+	// under the app. Drop it so the page falls back to the agent list instead
+	// of a dead-end banner. Only the remembered id is dropped -- an explicit
+	// URL to a missing agent still reports that it is missing, because there
+	// the user asked for it by name.
+	useEffect(() => {
+		if (isAgentNotFound && !agentId && effectiveAgentId) {
+			clearAgentFromAllPages(effectiveAgentId);
+		}
+	}, [isAgentNotFound, agentId, effectiveAgentId, clearAgentFromAllPages]);
 
 	// Get the addMessage function from the chat store
 	const addMessage = useChatStore((state) => state.addMessage);
@@ -840,7 +859,24 @@ Store messages: ${JSON.stringify(getMessages(conversationId || ""), null, 2)}`;
 		}
 
 		if (isError) {
-			return <ErrorView message={error?.message || ""} />;
+			if (isAgentNotFound) {
+				// Reached only via a direct URL (the persisted case has already
+				// cleared itself above). The server answered, so the "local
+				// server" copy would be a false claim here.
+				return (
+					<PlaceholderView
+						title="This agent no longer exists"
+						description="It may have been deleted, or the app is now pointed at a different Local Operator home. Pick another agent from the sidebar."
+						directionText="Choose an agent from the list"
+					/>
+				);
+			}
+			return (
+				<ErrorView
+					message={error?.message || ""}
+					serverUnreachable={isServerUnreachable(error)}
+				/>
+			);
 		}
 
 		return (

--- a/src/renderer/src/features/chat/components/error-view.tsx
+++ b/src/renderer/src/features/chat/components/error-view.tsx
@@ -7,6 +7,13 @@ import type { FC } from "react";
  */
 type ErrorViewProps = {
 	message: string;
+	/**
+	 * The backend never answered. Only then may the copy say "once the local
+	 * server is running": with the server up and refusing (401, 500, ...) that
+	 * clause is a false claim about the user's machine, and a not-found is
+	 * handled by the page before this view is reached.
+	 */
+	serverUnreachable?: boolean;
 };
 
 /**
@@ -29,7 +36,17 @@ type ErrorViewProps = {
  * which is exactly the case the Alert primitive leaves to its callers. The
  * ground is `canvas`, the same as the conversation it replaces.
  */
-export const ErrorView: FC<ErrorViewProps> = ({ message }) => {
+export const ErrorView: FC<ErrorViewProps> = ({
+	message,
+	serverUnreachable = false,
+}) => {
+	const description = serverUnreachable
+		? message
+			? `${message} The agent's history is safe — try again once the local server is running.`
+			: "The local server did not answer. The agent's history is safe — try again once it is running."
+		: message
+			? `${message} The agent's history is safe — try again in a moment.`
+			: "The local server returned an error. The agent's history is safe — try again in a moment.";
 	return (
 		<div
 			className={cn(
@@ -38,11 +55,7 @@ export const ErrorView: FC<ErrorViewProps> = ({ message }) => {
 		>
 			<Alert variant="danger" role="alert" className={cn("max-w-[480px]")}>
 				<AlertTitle>Could not load this conversation</AlertTitle>
-				<AlertDescription>
-					{message
-						? `${message} The agent's history is safe — try again once the local server is running.`
-						: "The local server did not answer. The agent's history is safe — try again once it is running."}
-				</AlertDescription>
+				<AlertDescription>{description}</AlertDescription>
 			</Alert>
 		</div>
 	);

--- a/src/renderer/src/features/onboarding/components/steps/connect-provider-step.tsx
+++ b/src/renderer/src/features/onboarding/components/steps/connect-provider-step.tsx
@@ -8,16 +8,46 @@
  */
 
 import { ProviderGrid } from "@features/providers/provider-grid";
+import { useDesktopProviders } from "@shared/api/local-operator/desktop-hooks";
+import { Alert } from "@shared/components/ui";
+import { hasConnectedProvider } from "@shared/hooks/first-time-user";
 import type { FC } from "react";
+import { useMemo } from "react";
 
 export const ConnectProviderStep: FC = () => {
+	const providers = useDesktopProviders(true);
+	// Onboarding only opens when no provider is connected, so this list is
+	// normally empty on arrival. It fills when the user signs in on this step
+	// and returns to the grid, or steps Back here from a later step -- and
+	// then the step must say so, because the grid alone reads as a request
+	// to sign in to something the user is already signed in to.
+	const connected = useMemo(
+		() =>
+			(providers.data ?? [])
+				.filter((provider) => hasConnectedProvider([provider]))
+				.map((provider) => provider.name),
+		[providers.data],
+	);
+
 	return (
 		<div className="flex flex-col gap-5">
 			<p className="text-body text-ink-muted">
 				Pick the service your agents will think with. You can add or change
 				providers later in Settings.
 			</p>
+			{connected.length > 0 && (
+				<Alert variant="success">
+					Signed in to {formatList(connected)}. Nothing more is needed here:
+					choose Next to continue, or connect another provider below.
+				</Alert>
+			)}
 			<ProviderGrid />
 		</div>
 	);
 };
+
+/** "A", "A and B", "A, B and C" -- the app's copy is English sentence case. */
+function formatList(names: string[]): string {
+	if (names.length <= 1) return names.join("");
+	return `${names.slice(0, -1).join(", ")} and ${names[names.length - 1]}`;
+}

--- a/src/renderer/src/features/onboarding/components/steps/connect-provider-step.tsx
+++ b/src/renderer/src/features/onboarding/components/steps/connect-provider-step.tsx
@@ -9,7 +9,7 @@
 
 import { ProviderGrid } from "@features/providers/provider-grid";
 import { useDesktopProviders } from "@shared/api/local-operator/desktop-hooks";
-import { Alert } from "@shared/components/ui";
+import { Alert, AlertDescription, AlertTitle } from "@shared/components/ui";
 import { hasConnectedProvider } from "@shared/hooks/first-time-user";
 import type { FC } from "react";
 import { useMemo } from "react";
@@ -31,15 +31,24 @@ export const ConnectProviderStep: FC = () => {
 
 	return (
 		<div className="flex flex-col gap-5">
-			<p className="text-body text-ink-muted">
-				Pick the service your agents will think with. You can add or change
-				providers later in Settings.
-			</p>
-			{connected.length > 0 && (
-				<Alert variant="success">
-					Signed in to {formatList(connected)}. Nothing more is needed here:
-					choose Next to continue, or connect another provider below.
-				</Alert>
+			{connected.length > 0 ? (
+				<>
+					<p className="text-body text-ink-muted">
+						You can add another provider, or choose Next.
+					</p>
+					<Alert variant="success">
+						<AlertTitle>Signed in to {formatList(connected)}</AlertTitle>
+						<AlertDescription>
+							Nothing more is needed here: choose Next to continue, or connect
+							another provider below.
+						</AlertDescription>
+					</Alert>
+				</>
+			) : (
+				<p className="text-body text-ink-muted">
+					Pick the service your agents will think with. You can add or change
+					providers later in Settings.
+				</p>
 			)}
 			<ProviderGrid />
 		</div>

--- a/src/renderer/src/features/providers/provider-grid.tsx
+++ b/src/renderer/src/features/providers/provider-grid.tsx
@@ -136,31 +136,49 @@ export const ProviderGrid: FC<ProviderGridProps> = ({
 				</div>
 			) : (
 				<ul className="grid grid-cols-1 gap-3 sm:grid-cols-2">
-					{filtered.map((provider) => (
-						<li key={provider.id}>
-							<button
-								type="button"
-								onClick={() => setSelectedId(provider.id)}
-								className={cn(
-									"flex w-full flex-col gap-2 rounded-md border border-control bg-surface p-4 text-left",
-									"transition-colors duration-base ease-out-quart hover:bg-elevated",
-								)}
-							>
-								<span className="flex items-center justify-between gap-2">
-									<span className="text-body text-ink">{provider.name}</span>
-									{/* States the credential fact, which this census actually
+					{filtered.map((provider) => {
+						const readiness = providerReadiness(provider);
+						return (
+							<li key={provider.id}>
+								<button
+									type="button"
+									onClick={() => setSelectedId(provider.id)}
+									className={cn(
+										"flex w-full flex-col gap-2 rounded-md border border-control bg-surface p-4 text-left",
+										"transition-colors duration-base ease-out-quart hover:bg-elevated",
+									)}
+								>
+									{/*
+									 * Name above badge, always. They used to share one row
+									 * with `justify-between`; the badge is `shrink-0
+									 * whitespace-nowrap` by contract and the name had no
+									 * `min-w-0`, so on a ~230px card (two columns in the
+									 * 560px dialog) the two fought for the line -- the name
+									 * ran under the badge and the badge clipped at the card
+									 * edge. Wrapping only when needed left a grid where
+									 * neighbouring cards differed in layout, so every card
+									 * stacks the same way and the columns stay aligned.
+									 * 4px between name and badge is the within-component
+									 * tier; the 8px card gap separates the method line.
+									 */}
+									<span className="flex flex-col items-start gap-1">
+										<span className="min-w-0 text-body text-ink">
+											{provider.name}
+										</span>
+										{/* States the credential fact, which this census actually
 									    knows. It used to render `configured` as "Connected",
 									    asserting a reachability nothing had checked. */}
-									<Badge variant={providerReadiness(provider).tone}>
-										{providerReadiness(provider).label}
-									</Badge>
-								</span>
-								<span className="text-meta text-ink-dim">
-									{providerMethodLabel(provider.auth_methods, provider.local)}
-								</span>
-							</button>
-						</li>
-					))}
+										<Badge variant={readiness.tone} title={readiness.detail}>
+											{readiness.label}
+										</Badge>
+									</span>
+									<span className="text-meta text-ink-dim">
+										{providerMethodLabel(provider.auth_methods, provider.local)}
+									</span>
+								</button>
+							</li>
+						);
+					})}
 				</ul>
 			)}
 		</div>

--- a/src/renderer/src/features/providers/provider-labels.ts
+++ b/src/renderer/src/features/providers/provider-labels.ts
@@ -55,6 +55,14 @@ export function primaryMethod(
  */
 export type ProviderReadiness = {
 	label: string;
+	/**
+	 * The full statement when `label` had to be short. The badge cannot wrap
+	 * or shrink (it is `whitespace-nowrap` by contract), and a 300px card
+	 * cannot hold a provider name beside a seven-word badge -- the two
+	 * overlapped and the badge clipped at the card edge. The grid renders
+	 * this as the badge's `title` so the long form is still reachable.
+	 */
+	detail?: string;
 	tone: "success" | "neutral";
 	/** Grouping bucket, shared with the model picker so both surfaces agree. */
 	group: "Ready to use" | "Needs a running server" | "Needs sign-in";
@@ -70,7 +78,8 @@ export function providerReadiness(provider: {
 	// is checkable; "Connected" was not.
 	if (provider.local || provider.credential_optional) {
 		return {
-			label: "No key needed - needs a running server",
+			label: "No key needed",
+			detail: "No key needed - needs a running server",
 			tone: "neutral",
 			group: "Needs a running server",
 		};

--- a/src/renderer/src/features/providers/provider-labels.ts
+++ b/src/renderer/src/features/providers/provider-labels.ts
@@ -90,6 +90,37 @@ export function providerReadiness(provider: {
 	return { label: "Needs sign-in", tone: "neutral", group: "Needs sign-in" };
 }
 
+/**
+ * Whether the hosting picker may offer this provider without a "requires
+ * additional credentials" warning. Same fact the grid uses: anything that
+ * would not say "Needs sign-in" (signed in, or a local server that needs
+ * none). A second predicate here is how the picker drifted onto the env
+ * file and labelled Anthropic unusable while the grid said Signed in.
+ */
+export function hostingProviderSelectable(provider: {
+	local: boolean;
+	credential_optional: boolean;
+	has_credential: boolean;
+	configured: boolean;
+}): boolean {
+	return providerReadiness(provider).group !== "Needs sign-in";
+}
+
+/** Census ids the hosting picker may offer. Same predicate as the grid. */
+export function readyHostingIds(
+	census: Array<
+		{
+			id: string;
+		} & Parameters<typeof hostingProviderSelectable>[0]
+	>,
+): Set<string> {
+	return new Set(
+		census
+			.filter((provider) => hostingProviderSelectable(provider))
+			.map((provider) => provider.id),
+	);
+}
+
 /** Terminal states after which polling an auth operation must stop. */
 export function isTerminalAuthState(state: AuthOperation["state"]): boolean {
 	return (

--- a/src/renderer/src/shared/api/local-operator/agents-api.ts
+++ b/src/renderer/src/shared/api/local-operator/agents-api.ts
@@ -2,6 +2,7 @@
  * Local Operator API - Agents Endpoints
  */
 import {
+	DesktopControlError,
 	desktopControlResponse,
 	desktopMedia,
 	mediaError,
@@ -193,7 +194,14 @@ export const AgentsApi = {
 		});
 
 		if (!response.ok) {
-			throw new Error(
+			// Carries the status, not just a message with the number in it: the
+			// chat page has to tell "this agent no longer exists" (404, a normal
+			// event after a delete or a config-dir switch) from "the backend did
+			// not answer", and only the first should clear the persisted
+			// selection. Matching "404" inside the text is how `useAgent` does
+			// it, and that is the fragile pattern this avoids repeating.
+			throw new DesktopControlError(
+				response.status,
 				`Get agent execution history request failed: ${response.status} ${response.statusText}`,
 			);
 		}

--- a/src/renderer/src/shared/api/local-operator/credentials-api.ts
+++ b/src/renderer/src/shared/api/local-operator/credentials-api.ts
@@ -8,6 +8,26 @@ import type {
 	CredentialUpdate,
 } from "./types";
 
+async function readOpenCredentialList(
+	baseUrl: string,
+): Promise<CRUDResponse<CredentialListResult>> {
+	// Unmanaged / old backends serve GET /v1/credentials without a bearer.
+	// The desktop transport 503s every non-capabilities op when this app
+	// has no token, so the first-run decision cannot go through it -- it
+	// would hang in `pending` forever. Health already talks to the backend
+	// this way; this is the same open surface, not a second auth path.
+	const response = await fetch(`${baseUrl}/v1/credentials`, {
+		method: "GET",
+		headers: { Accept: "application/json" },
+	});
+	if (!response.ok) {
+		throw new Error(
+			`List credentials request failed: ${response.status} ${response.statusText}`,
+		);
+	}
+	return response.json() as Promise<CRUDResponse<CredentialListResult>>;
+}
+
 /**
  * Credentials API client for the Local Operator API
  */
@@ -31,6 +51,21 @@ export const CredentialsApi = {
 		}
 
 		return response.json() as Promise<CRUDResponse<CredentialListResult>>;
+	},
+
+	/**
+	 * List credential keys from the open (unauthenticated) route.
+	 *
+	 * Only for the first-run decision on a backend that has not advertised
+	 * desktop auth. Settings and every other caller keep using the bearer
+	 * transport above: this must not become a silent downgrade.
+	 */
+	async listOpenCredentials(baseUrl: string): Promise<CredentialListResult> {
+		const response = await readOpenCredentialList(baseUrl);
+		if (response.status >= 400 || !response.result) {
+			throw new Error(response.message || "Failed to fetch credentials");
+		}
+		return response.result;
 	},
 
 	/**

--- a/src/renderer/src/shared/api/local-operator/desktop-api.ts
+++ b/src/renderer/src/shared/api/local-operator/desktop-api.ts
@@ -110,6 +110,27 @@ export async function desktopResult<T>(request: DesktopRequest): Promise<T> {
 	return envelope?.result as T;
 }
 
+/**
+ * Whether a history failure means the agent itself is gone, as opposed to
+ * the backend being unreachable or refusing. Reads the typed status rather
+ * than the message text, so a future rewording cannot break it.
+ */
+export function isAgentNotFound(error: unknown): boolean {
+	return error instanceof DesktopControlError && error.status === 404;
+}
+
+/**
+ * Whether the failure is the backend not answering at all, which is the one
+ * case where "try again once the local server is running" is true. Same
+ * reading of the status as the compatibility banner: `null` is a transport
+ * that never produced a response, 503 is the relay saying it could not.
+ * Anything else is the server answering, and that copy would be false.
+ */
+export function isServerUnreachable(error: unknown): boolean {
+	if (!(error instanceof DesktopControlError)) return false;
+	return error.status === null || error.status === 503;
+}
+
 export async function desktopControlResponse(
 	request: DesktopRequest,
 ): Promise<Response> {

--- a/src/renderer/src/shared/components/hosting/hosting-select.tsx
+++ b/src/renderer/src/shared/components/hosting/hosting-select.tsx
@@ -5,10 +5,16 @@
  * Filters available options based on user credentials.
  */
 
+import { readyHostingIds } from "@features/providers/provider-labels";
+import {
+	desktopFeatureEnabled,
+	useDesktopCapabilities,
+	useDesktopProviders,
+} from "@shared/api/local-operator/desktop-hooks";
 import { useCredentials, useModels } from "@shared/hooks";
 import { Server } from "lucide-react";
 import type { FC } from "react";
-import { useEffect, useMemo, useRef, useState } from "react";
+import { useMemo, useState } from "react";
 import {
 	type HostingProvider,
 	getAvailableHostingProviders,
@@ -84,7 +90,9 @@ export const HostingSelect: FC<HostingSelectProps> = ({
 	allowCustom = true,
 	allowDefault = true,
 }) => {
-	// Get user credentials
+	const capabilities = useDesktopCapabilities();
+	const censusEnabled = desktopFeatureEnabled(capabilities.data, "auth");
+	const census = useDesktopProviders(censusEnabled);
 	const { data: credentialsData } = useCredentials();
 	const userCredentials = useMemo(
 		() => credentialsData?.keys || [],
@@ -93,43 +101,22 @@ export const HostingSelect: FC<HostingSelectProps> = ({
 
 	const [isSubmitting, setIsSubmitting] = useState(false);
 
-	// Refs to track credential fetch attempts and prevent excessive re-renders
-	const credentialFetchAttemptsRef = useRef<number>(0);
-	const MAX_CREDENTIAL_FETCH_ATTEMPTS = 3;
-	const lastCredentialFetchTimeRef = useRef<number | null>(null);
-	const CREDENTIAL_FETCH_THROTTLE = 2000; // 2 seconds
-
-	// Get available hosting providers based on user credentials
 	const availableHostingProviders = useMemo(() => {
-		if (!filterByCredentials) {
-			return getHostingProviders();
+		const all = getHostingProviders();
+		if (!filterByCredentials) return all;
+		if (censusEnabled) {
+			// Advertised census owns this filter even while it is still loading
+			// or has 5xx'd: falling through to the env-file list is Q3.
+			if (!census.data) return all;
+			const ready = readyHostingIds(census.data);
+			return all.filter((provider) => ready.has(provider.id));
 		}
-
-		// Prevent excessive credential fetches
-		if (credentialFetchAttemptsRef.current >= MAX_CREDENTIAL_FETCH_ATTEMPTS) {
-			console.warn(
-				`Exceeded maximum credential fetch attempts (${MAX_CREDENTIAL_FETCH_ATTEMPTS})`,
-			);
-			// Return all providers if we've exceeded the maximum attempts
-			return getHostingProviders();
-		}
-
-		// Add throttling to prevent rapid successive calls
-		const now = Date.now();
-		if (
-			lastCredentialFetchTimeRef.current &&
-			now - lastCredentialFetchTimeRef.current < CREDENTIAL_FETCH_THROTTLE
-		) {
-			// If we've fetched recently, use the last result
-			return getHostingProviders();
-		}
-
-		// Track credential fetch attempts and time
-		credentialFetchAttemptsRef.current += 1;
-		lastCredentialFetchTimeRef.current = now;
-
+		// Unmanaged / old backends have no census; the env-file list is the
+		// only remaining source. Never mix it with a live census: that is
+		// how Anthropic showed "Requires additional credentials" while the
+		// grid said Signed in.
 		return getAvailableHostingProviders(userCredentials);
-	}, [userCredentials, filterByCredentials]);
+	}, [filterByCredentials, censusEnabled, census.data, userCredentials]);
 
 	// Convert hosting providers to autocomplete options
 	const hostingOptions: HostingOption[] = useMemo(() => {
@@ -240,12 +227,6 @@ export const HostingSelect: FC<HostingSelectProps> = ({
 		);
 	}, [value, hostingOptions, allowDefault, availableHostingProviders.length]);
 
-	// Reset credential fetch attempts when component mounts
-	useEffect(() => {
-		credentialFetchAttemptsRef.current = 0;
-	}, []);
-
-	// Get access to the models refresh function
 	const { refreshModels } = useModels();
 
 	// Persist a hosting id and pull the model list that belongs to it. The
@@ -254,8 +235,6 @@ export const HostingSelect: FC<HostingSelectProps> = ({
 	const save = async (hostingId: string) => {
 		try {
 			setIsSubmitting(true);
-			// Reset credential fetch attempts when hosting provider changes
-			credentialFetchAttemptsRef.current = 0;
 
 			await onSave(hostingId);
 

--- a/src/renderer/src/shared/hooks/first-time-user.ts
+++ b/src/renderer/src/shared/hooks/first-time-user.ts
@@ -2,7 +2,7 @@
  * The first-time-user decision, as a pure function.
  *
  * Kept free of React and of the query hooks so the rule can be exercised by
- * `scripts/first-time-user.test.mjs` with the exact inputs the hook feeds it,
+ * `scripts/provider-state.test.mjs` with the exact inputs the hook feeds it,
  * and so the hook stays a thin adapter with nothing of its own to get wrong.
  *
  * Why the provider census and not the legacy `/v1/credentials` key list: that
@@ -32,6 +32,12 @@ export type CensusInput =
 	| { status: "loading" }
 	/** The backend predates the census, or the app is not paired to it. */
 	| { status: "unavailable" }
+	/**
+	 * The backend advertised the census and then failed to serve it. That is
+	 * not "no providers" and not "old backend": inventing first_time here
+	 * would open setup over a signed-in machine whose census 5xx'd.
+	 */
+	| { status: "failed" }
 	| { status: "ready"; providers: CensusProvider[] };
 
 export type LegacyCredentialsInput =
@@ -64,16 +70,21 @@ export function decideFirstTimeUser(input: {
 	if (input.onboardingComplete) return "returning";
 
 	if (input.census.status === "loading") return "pending";
+	if (input.census.status === "failed") return "pending";
 	if (input.census.status === "ready") {
 		return hasConnectedProvider(input.census.providers)
 			? "returning"
 			: "first_time";
 	}
 
-	// Older backend: fall back to the key list so it still onboards. A probe
-	// that failed is a backend that is not answering, and setup cannot run
-	// against a backend that is not answering either -- the connectivity
-	// banner owns that fact, so this stays undecided rather than guessing.
+	// Census not offered (old or unmanaged backend): the open credentials
+	// list is the only source that does not go through the desktop bearer,
+	// which 503s every non-capabilities op without a token. Empty keys is
+	// first-time; a key means they have already set something up.
+	// A probe that failed is a backend that is not answering, and setup
+	// cannot run against a backend that is not answering either -- the
+	// connectivity banner owns that fact, so this stays undecided rather
+	// than guessing.
 	if (input.legacy.status !== "ready") return "pending";
 	return input.legacy.keys.length === 0 ? "first_time" : "returning";
 }

--- a/src/renderer/src/shared/hooks/first-time-user.ts
+++ b/src/renderer/src/shared/hooks/first-time-user.ts
@@ -1,0 +1,79 @@
+/**
+ * The first-time-user decision, as a pure function.
+ *
+ * Kept free of React and of the query hooks so the rule can be exercised by
+ * `scripts/first-time-user.test.mjs` with the exact inputs the hook feeds it,
+ * and so the hook stays a thin adapter with nothing of its own to get wrong.
+ *
+ * Why the provider census and not the legacy `/v1/credentials` key list: that
+ * list is the `credentials.env` file. Since the backend moved provider auth
+ * into its own store (`~/.local-operator/auth.db`), a user signed in to
+ * OpenAI, Anthropic and Kimi through the backend's OAuth has NO key in that
+ * file -- it holds Google tokens, AWS keys, a Radient key -- so the old rule
+ * ("no keys, therefore first run") opened setup over an existing agent list
+ * and asked the user to connect providers they were already signed in to.
+ *
+ * Why three outcomes and not a boolean: "not yet known" is a real state. The
+ * old hook treated a query that had not run (the connectivity gate disables
+ * it until `/health` answers) as "no credentials", which flashed onboarding
+ * while the backend was still starting. Nothing is decided until a source
+ * has actually answered.
+ */
+
+/** The one fact about a provider the decision reads. */
+export type CensusProvider = {
+	local: boolean;
+	credential_optional: boolean;
+	configured: boolean;
+	has_credential: boolean;
+};
+
+export type CensusInput =
+	| { status: "loading" }
+	/** The backend predates the census, or the app is not paired to it. */
+	| { status: "unavailable" }
+	| { status: "ready"; providers: CensusProvider[] };
+
+export type LegacyCredentialsInput =
+	| { status: "loading" }
+	| { status: "error" }
+	| { status: "ready"; keys: string[] };
+
+export type FirstTimeDecision = "pending" | "first_time" | "returning";
+
+/**
+ * A provider counts as connected only when it is NOT a local server and
+ * carries a credential. Local providers (Ollama, LM Studio, ...) report
+ * `configured: true` unconditionally because they need no key; that is not
+ * evidence the user has set anything up, so they never satisfy "returning".
+ */
+export function hasConnectedProvider(providers: CensusProvider[]): boolean {
+	return providers.some(
+		(provider) =>
+			!provider.local &&
+			!provider.credential_optional &&
+			(provider.configured || provider.has_credential),
+	);
+}
+
+export function decideFirstTimeUser(input: {
+	onboardingComplete: boolean;
+	census: CensusInput;
+	legacy: LegacyCredentialsInput;
+}): FirstTimeDecision {
+	if (input.onboardingComplete) return "returning";
+
+	if (input.census.status === "loading") return "pending";
+	if (input.census.status === "ready") {
+		return hasConnectedProvider(input.census.providers)
+			? "returning"
+			: "first_time";
+	}
+
+	// Older backend: fall back to the key list so it still onboards. A probe
+	// that failed is a backend that is not answering, and setup cannot run
+	// against a backend that is not answering either -- the connectivity
+	// banner owns that fact, so this stays undecided rather than guessing.
+	if (input.legacy.status !== "ready") return "pending";
+	return input.legacy.keys.length === 0 ? "first_time" : "returning";
+}

--- a/src/renderer/src/shared/hooks/use-check-first-time-user.ts
+++ b/src/renderer/src/shared/hooks/use-check-first-time-user.ts
@@ -11,19 +11,22 @@
  * two data sources and the onboarding store to it.
  */
 
+import { CredentialsApi } from "@shared/api/local-operator";
 import {
 	desktopFeatureEnabled,
 	useDesktopCapabilities,
 	useDesktopProviders,
 } from "@shared/api/local-operator/desktop-hooks";
+import { apiConfig } from "@shared/config";
 import { useOnboardingStore } from "@shared/store/onboarding-store";
+import { useQuery } from "@tanstack/react-query";
 import { useEffect } from "react";
 import {
 	type CensusInput,
 	type LegacyCredentialsInput,
 	decideFirstTimeUser,
 } from "./first-time-user";
-import { useCredentials } from "./use-credentials";
+import { useConnectivityGate } from "./use-connectivity-gate";
 
 /**
  * Hook to check if the user is a first-time user and activate onboarding if needed
@@ -36,7 +39,23 @@ export const useCheckFirstTimeUser = () => {
 	// Only fetched once the backend has advertised the census; asking an older
 	// backend would 404 and the fallback below handles that case anyway.
 	const providers = useDesktopProviders(censusEnabled);
-	const credentials = useCredentials();
+	const { shouldEnableQuery } = useConnectivityGate();
+	// The desktop bearer transport 503s every non-capabilities op when this
+	// app did not start the backend. Unmanaged `/v1/credentials` is open,
+	// so the first-run fallback reads it directly rather than through
+	// `useCredentials()`. Never fetch this while the census is advertised:
+	// a 5xx there must stay pending (MINOR-1), not invent first_time from
+	// an empty env-file list.
+	const openCredentials = useQuery({
+		queryKey: ["open-credentials"],
+		enabled:
+			!censusEnabled &&
+			!capabilities.isPending &&
+			shouldEnableQuery({ bypassInternetCheck: true }),
+		queryFn: () => CredentialsApi.listOpenCredentials(apiConfig.baseUrl),
+		staleTime: 5000,
+		retry: false,
+	});
 	const {
 		isModalComplete: isOnboardingComplete,
 		isModalActive: isOnboardingActive,
@@ -53,18 +72,19 @@ export const useCheckFirstTimeUser = () => {
 	} else if (providers.isSuccess) {
 		census = { status: "ready", providers: providers.data };
 	} else if (providers.isError) {
-		// The backend advertised the census and then failed to serve it. That
-		// is not "no providers"; leave it to the legacy probe rather than
-		// invent an answer.
-		census = { status: "unavailable" };
+		// Advertised and then 5xx'd. Not "old backend", not "no providers".
+		census = { status: "failed" };
 	} else {
 		census = { status: "loading" };
 	}
 
 	let legacy: LegacyCredentialsInput;
-	if (credentials.isSuccess && credentials.data) {
-		legacy = { status: "ready", keys: credentials.data.keys };
-	} else if (credentials.isError) {
+	if (censusEnabled || capabilities.isPending) {
+		// Census path owns the decision; the open list is not consulted.
+		legacy = { status: "loading" };
+	} else if (openCredentials.isSuccess && openCredentials.data) {
+		legacy = { status: "ready", keys: openCredentials.data.keys };
+	} else if (openCredentials.isError) {
 		legacy = { status: "error" };
 	} else {
 		// Includes the connectivity-gated "pending, never fetching" shape: the

--- a/src/renderer/src/shared/hooks/use-check-first-time-user.ts
+++ b/src/renderer/src/shared/hooks/use-check-first-time-user.ts
@@ -2,12 +2,27 @@
  * Hook to check if the user is a first-time user
  *
  * Determines if the onboarding flow should be shown based on:
- * 1. Whether any credentials are set up
- * 2. Whether the onboarding has been explicitly completed before
+ * 1. Whether the onboarding has been explicitly completed before
+ * 2. Whether any non-local provider is connected, per the backend's provider
+ *    census (`GET /v1/auth/providers`), falling back to the legacy credential
+ *    key list only when the backend has no census to give.
+ *
+ * The rule itself lives in `first-time-user.ts`; this file only wires the
+ * two data sources and the onboarding store to it.
  */
 
+import {
+	desktopFeatureEnabled,
+	useDesktopCapabilities,
+	useDesktopProviders,
+} from "@shared/api/local-operator/desktop-hooks";
 import { useOnboardingStore } from "@shared/store/onboarding-store";
 import { useEffect } from "react";
+import {
+	type CensusInput,
+	type LegacyCredentialsInput,
+	decideFirstTimeUser,
+} from "./first-time-user";
 import { useCredentials } from "./use-credentials";
 
 /**
@@ -16,8 +31,12 @@ import { useCredentials } from "./use-credentials";
  * @returns Object containing isFirstTimeUser flag and functions to control onboarding
  */
 export const useCheckFirstTimeUser = () => {
-	const { data: credentialsData, isLoading: isLoadingCredentials } =
-		useCredentials();
+	const capabilities = useDesktopCapabilities();
+	const censusEnabled = desktopFeatureEnabled(capabilities.data, "auth");
+	// Only fetched once the backend has advertised the census; asking an older
+	// backend would 404 and the fallback below handles that case anyway.
+	const providers = useDesktopProviders(censusEnabled);
+	const credentials = useCredentials();
 	const {
 		isModalComplete: isOnboardingComplete,
 		isModalActive: isOnboardingActive,
@@ -26,11 +45,39 @@ export const useCheckFirstTimeUser = () => {
 		resetOnboarding,
 	} = useOnboardingStore();
 
-	// Check if user is a first-time user based on credentials and onboarding state
-	const isFirstTimeUser =
-		!isOnboardingComplete &&
-		!isLoadingCredentials &&
-		(!credentialsData || credentialsData.keys.length === 0);
+	let census: CensusInput;
+	if (capabilities.isPending) {
+		census = { status: "loading" };
+	} else if (!censusEnabled) {
+		census = { status: "unavailable" };
+	} else if (providers.isSuccess) {
+		census = { status: "ready", providers: providers.data };
+	} else if (providers.isError) {
+		// The backend advertised the census and then failed to serve it. That
+		// is not "no providers"; leave it to the legacy probe rather than
+		// invent an answer.
+		census = { status: "unavailable" };
+	} else {
+		census = { status: "loading" };
+	}
+
+	let legacy: LegacyCredentialsInput;
+	if (credentials.isSuccess && credentials.data) {
+		legacy = { status: "ready", keys: credentials.data.keys };
+	} else if (credentials.isError) {
+		legacy = { status: "error" };
+	} else {
+		// Includes the connectivity-gated "pending, never fetching" shape: the
+		// server is not yet known to be up, so nothing is decided.
+		legacy = { status: "loading" };
+	}
+
+	const decision = decideFirstTimeUser({
+		onboardingComplete: isOnboardingComplete,
+		census,
+		legacy,
+	});
+	const isFirstTimeUser = decision === "first_time";
 
 	// Automatically activate onboarding for first-time users
 	useEffect(() => {

--- a/src/renderer/src/shared/hooks/use-conversation-messages.ts
+++ b/src/renderer/src/shared/hooks/use-conversation-messages.ts
@@ -8,6 +8,7 @@
 
 import type { Message } from "@features/chat/types";
 import { createLocalOperatorClient } from "@shared/api/local-operator";
+import { isAgentNotFound } from "@shared/api/local-operator/desktop-api";
 import type { AgentExecutionRecord } from "@shared/api/local-operator/types";
 import { apiConfig } from "@shared/config";
 import { useChatStore } from "@shared/store/chat-store";
@@ -172,6 +173,9 @@ export const useConversationMessages = (
 		staleTime: 15 * 1000,
 		refetchOnWindowFocus: false,
 		refetchOnMount: false,
+		// An agent that is gone stays gone; re-asking only delays the page's
+		// recovery from a stale selection by another round trip.
+		retry: (count, error) => !isAgentNotFound(error) && count < 1,
 		queryFn: async ({ pageParam }) => {
 			try {
 				// If no conversation ID, return empty result
@@ -232,12 +236,18 @@ export const useConversationMessages = (
 					hasMore: result.page < totalPages,
 				};
 			} catch (error) {
-				const errorMessage =
-					error instanceof Error
-						? error.message
-						: "An unknown error occurred while fetching conversation messages";
+				// A missing agent is a normal event (deleted, config dir switched,
+				// reinstalled) that the chat page resolves by dropping the stale
+				// selection. A toast for it would announce an error that the user
+				// never sees a trace of once the page has recovered.
+				if (!isAgentNotFound(error)) {
+					const errorMessage =
+						error instanceof Error
+							? error.message
+							: "An unknown error occurred while fetching conversation messages";
 
-				showErrorToast(errorMessage);
+					showErrorToast(errorMessage);
+				}
 				throw error;
 			}
 		},
@@ -475,6 +485,8 @@ export const useConversationMessages = (
 		isLoading,
 		isError,
 		error,
+		/** The backend answered and said this agent does not exist. */
+		isAgentNotFound: isAgentNotFound(error),
 		isFetchingMore: isFetchingNextPage,
 		hasMoreMessages: pagination.hasMore,
 		fetchMoreMessages: fetchNextPage,

--- a/src/renderer/src/shared/store/onboarding-store.ts
+++ b/src/renderer/src/shared/store/onboarding-store.ts
@@ -117,6 +117,25 @@ export const useOnboardingStore = create<OnboardingState>()(
 		}),
 		{
 			name: "onboarding-storage",
+			// `isModalActive` is a session fact, not a preference: it is derived
+			// on every launch from whether a provider is connected. Persisting
+			// it meant one launch that (wrongly) opened setup pinned the modal
+			// open on every later launch, even after the decision was fixed --
+			// which is exactly how 0.15.0 users who saw onboarding once would
+			// keep seeing it. Only the completion flags and the step persist.
+			partialize: (state) => ({
+				isModalComplete: state.isModalComplete,
+				isTourComplete: state.isTourComplete,
+				currentStep: state.currentStep,
+			}),
+			// A 0.15.0 install already wrote `isModalActive: true`; partialize
+			// stops new writes but rehydration would still merge the old value
+			// in, so it is dropped here too.
+			merge: (persisted, current) => {
+				const { isModalActive: _stale, ...rest } = (persisted ??
+					{}) as Partial<OnboardingState>;
+				return { ...current, ...rest };
+			},
 			onRehydrateStorage: () => (state, error) => {
 				if (error) {
 					console.error("Failed to rehydrate onboarding store:", error);


### PR DESCRIPTION
# PR Description

## Summary of Changes

0.15.1 patch for four defects found after 0.15.0 shipped. Companion backend is already v0.50.0; this is UI-only.

- **Onboarding gate uses the provider census**, not the legacy env-key list. A user signed in via backend OAuth was still treated as first-time because `/v1/credentials` does not see the auth DB. Also stops persisting `isModalActive`, which pinned the modal open after one wrong launch.
- **Provider-grid badges no longer overlap the name** at narrow width: cards stack name / badge / method, and the local label shortens to "No key needed".
- **A stale persisted agent id is no longer a dead end.** 404 clears the selection and shows the list; "try again once the local server is running" is reserved for actual connection failures.
- **Regression test** pins readiness labels to a real 0.50.0 census payload.

Round-1 review/QA/design findings (unmanaged first-time hang, hosting-picker census, copy) are being remediated in this same branch before merge.

## Impact

- **No Breaking Changes.** Existing chats, transcripts and the 0.50.0 control surface are unchanged.
- **User:** returning users with OAuth credentials skip onboarding; a deleted agent no longer claims the server is down.

## Testing Details

Coder + independent reviewer/QA/designer rounds. Evidence under the PR comments. `pnpm lint` (7 pre-existing warnings), `check-types`, `check-themes` 1884/12, `test:desktop` 31/31 (13 new) on the first head; remediation will re-run.

## Checklist

- [x] Style guidelines
- [x] Self-review
- [x] Tests for the census gate, readiness labels, and stale-agent 404
- [x] Visual stills for the overlap and placeholders
