### PR TITLE
fix(settings): recover from a stalled desktop request instead of spinning forever

### DIFF
--- a/package.json
+++ b/package.json
@@ -64,7 +64,7 @@
     "check-types:main": "tsc --noEmit -p tsconfig.node.json",
     "check-types:renderer": "tsc --noEmit -p tsconfig.app.json",
     "check-types": "pnpm run check-types:main && pnpm run check-types:renderer",
-    "test:desktop": "node --test scripts/desktop-contract.test.mjs scripts/transcript-reducer.test.mjs scripts/provider-state.test.mjs scripts/stale-agent.test.mjs scripts/desktop-renderer-transport.test.mjs scripts/provider-grid-error-copy.test.mjs",
+    "test:desktop": "node --test scripts/desktop-contract.test.mjs scripts/transcript-reducer.test.mjs scripts/provider-state.test.mjs scripts/stale-agent.test.mjs scripts/desktop-renderer-transport.test.mjs scripts/provider-grid-error-copy.test.mjs scripts/settings-time-to-error.test.mjs",
     "check-themes": "node scripts/generate-theme-css.mjs --check && node scripts/contrast-contract.mjs",
     "check-evidence": "node scripts/check-evidence.mjs",
     "check-edit-diffs": "node scripts/check-edit-diffs.mjs",

--- a/package.json
+++ b/package.json
@@ -64,7 +64,7 @@
     "check-types:main": "tsc --noEmit -p tsconfig.node.json",
     "check-types:renderer": "tsc --noEmit -p tsconfig.app.json",
     "check-types": "pnpm run check-types:main && pnpm run check-types:renderer",
-    "test:desktop": "node --test scripts/desktop-contract.test.mjs scripts/transcript-reducer.test.mjs scripts/provider-state.test.mjs scripts/stale-agent.test.mjs",
+    "test:desktop": "node --test scripts/desktop-contract.test.mjs scripts/transcript-reducer.test.mjs scripts/provider-state.test.mjs scripts/stale-agent.test.mjs scripts/desktop-renderer-transport.test.mjs scripts/provider-grid-error-copy.test.mjs",
     "check-themes": "node scripts/generate-theme-css.mjs --check && node scripts/contrast-contract.mjs",
     "check-evidence": "node scripts/check-evidence.mjs",
     "check-edit-diffs": "node scripts/check-edit-diffs.mjs",

--- a/package.json
+++ b/package.json
@@ -64,7 +64,7 @@
     "check-types:main": "tsc --noEmit -p tsconfig.node.json",
     "check-types:renderer": "tsc --noEmit -p tsconfig.app.json",
     "check-types": "pnpm run check-types:main && pnpm run check-types:renderer",
-    "test:desktop": "node --test scripts/desktop-contract.test.mjs scripts/transcript-reducer.test.mjs scripts/provider-state.test.mjs scripts/stale-agent.test.mjs scripts/desktop-renderer-transport.test.mjs scripts/provider-grid-error-copy.test.mjs scripts/settings-time-to-error.test.mjs",
+    "test:desktop": "node --test scripts/desktop-contract.test.mjs scripts/transcript-reducer.test.mjs scripts/provider-state.test.mjs scripts/stale-agent.test.mjs scripts/desktop-renderer-transport.test.mjs scripts/provider-grid-error-copy.test.mjs scripts/settings-time-to-error.test.mjs scripts/backend-error-surfaces.test.mjs",
     "check-themes": "node scripts/generate-theme-css.mjs --check && node scripts/contrast-contract.mjs",
     "check-evidence": "node scripts/check-evidence.mjs",
     "check-edit-diffs": "node scripts/check-edit-diffs.mjs",

--- a/scripts/backend-error-evidence.html
+++ b/scripts/backend-error-evidence.html
@@ -1,0 +1,28 @@
+<!doctype html>
+<!--
+  Evidence harness for the backend-error surfaces (issue #89, PR #92).
+
+  Mounts the SHIPPED components behind a REAL desktop bridge -- an injected
+  `window.api.desktop` -- so `desktopRequest` takes the Electron IPC branch that
+  actually ships rather than the browser-dev `/__desktop` HTTP branch, which
+  never calls `withDeadline` and classifies its failures differently.
+
+  Two things this defeats, both of which blocked capturing these frames before:
+   - the fault is injected AT the bridge, so the shipped transport builds the
+     error and attaches its status;
+   - `visibilityState` is reported as "visible", so React Query does not pause
+     the capture tab's refetches.
+
+  Not part of the app or the test suite: a capture surface, run by hand with
+  `pnpm vite --config scripts/backend-error-evidence.vite.mjs`.
+-->
+<html lang="en" data-theme="localOperatorDark">
+	<head>
+		<meta charset="UTF-8" />
+		<title>Backend error surfaces</title>
+	</head>
+	<body>
+		<div id="root"></div>
+		<script type="module" src="./backend-error-evidence.tsx"></script>
+	</body>
+</html>

--- a/scripts/backend-error-evidence.tsx
+++ b/scripts/backend-error-evidence.tsx
@@ -14,7 +14,10 @@
  */
 
 import { ProviderGrid } from "@features/providers/provider-grid";
-import { BackendSettingsSection } from "@features/settings/components/backend-settings-section";
+import {
+	BackendSettingsSection,
+	backendSettingsKeys,
+} from "@features/settings/components/backend-settings-section";
 import { desktopResult } from "@shared/api/local-operator/desktop-api";
 import { desktopKeys } from "@shared/api/local-operator/desktop-hooks";
 import { Spinner } from "@shared/components/common/spinner";
@@ -142,12 +145,64 @@ const settings503 = newClient();
 const settings404 = newClient();
 const providersIdle = newClient();
 const providersRetrying = newClient();
+const settingsRetryLabel = newClient();
+const settingsRetrySpinner = newClient();
 
 await seedCapabilities(settings401, 401);
 await seedCapabilities(settings503, 503);
 await seedCapabilities(settings404, 404);
 await seedProviders(providersIdle, 503);
 await seedProviders(providersRetrying, 503);
+
+/*
+ * D1 takes TWO shapes on the settings section, and both are captured because
+ * only a rendered pair settles whether each one is visibly distinct from the
+ * frame the user just clicked out of.
+ *
+ * (a) The settings list loaded once, so its refetch keeps `status: "error"`
+ *     and the error branch keeps winning. Nothing but the button can change,
+ *     which is exactly why the button has to.
+ * (b) Capabilities never succeeded, so re-asking them resets that query to
+ *     pending and the section returns to its spinner. A different branch
+ *     renders entirely.
+ */
+settingsRetryLabel.setQueryData(desktopKeys.capabilities, {
+	desktop_available: true,
+	features: { settings: 1 },
+});
+// Seed a successful list, THEN fail its refetch: holding data is what keeps
+// `status: "error"` across the retry, and so what makes the label reachable.
+settingsRetryLabel.setQueryData(backendSettingsKeys.all, {
+	sections: [{ name: "General" }],
+	settings: [
+		{
+			key: "web_search.enabled",
+			label: "Web search",
+			help: "Allow agents to search the web.",
+			section: "General",
+			value: "true",
+			type: "boolean",
+			scope: "live",
+		},
+	],
+});
+bridgeStatus = 503;
+await settingsRetryLabel
+	.fetchQuery({
+		queryKey: backendSettingsKeys.all,
+		queryFn: () => desktopResult({ op: "settings.list" }),
+		retry: false,
+	})
+	.catch(() => undefined);
+hangingOps.add("settings.list");
+void settingsRetryLabel.refetchQueries({ queryKey: backendSettingsKeys.all });
+
+await seedCapabilities(settingsRetrySpinner, 401);
+hangingOps.add("capabilities");
+void settingsRetrySpinner.refetchQueries({
+	queryKey: desktopKeys.capabilities,
+});
+await new Promise((resolve) => setTimeout(resolve, 60));
 
 // Left in flight: this panel IS the frame a user sees after clicking Retry.
 // Releasing the hang early would let the query settle and repaint the idle
@@ -216,6 +271,20 @@ createRoot(document.getElementById("root") as HTMLElement).render(
 				client={providersRetrying}
 			>
 				<ProviderGrid />
+			</Panel>
+			<Panel
+				title="Settings Retry mid-flight (a) — the list had loaded, so only the button can change"
+				note="Refetch keeps status='error', so the error branch keeps winning: disabled, labelled 'Retrying'."
+				client={settingsRetryLabel}
+			>
+				<BackendSettingsSection />
+			</Panel>
+			<Panel
+				title="Settings Retry mid-flight (b) — capabilities never loaded, so the whole branch changes"
+				note="Re-asking resets the gating query to pending: the section returns to its spinner, a different frame from the alert just clicked."
+				client={settingsRetrySpinner}
+			>
+				<BackendSettingsSection />
 			</Panel>
 			<section className="flex flex-col gap-2">
 				<h2 className="text-body-sm text-ink">

--- a/scripts/backend-error-evidence.tsx
+++ b/scripts/backend-error-evidence.tsx
@@ -1,0 +1,233 @@
+/**
+ * Evidence harness: the shipped backend-error surfaces, behind a real bridge.
+ *
+ * See `backend-error-evidence.html` for why this exists. The short version: the
+ * frames these surfaces render at 401/503/404 cannot be captured from the
+ * browser-dev HTTP branch, because that branch is not the code that ships and
+ * classifies its failures differently. Installing `window.api.desktop` puts the
+ * renderer on the Electron IPC path, and injecting the fault AT that bridge
+ * makes the shipped transport build the error and attach its status.
+ *
+ * Every panel below renders a real component against a real QueryClient. None
+ * of the copy is restated here -- if a sentence in a captured frame is wrong,
+ * it is wrong in the product.
+ */
+
+import { ProviderGrid } from "@features/providers/provider-grid";
+import { BackendSettingsSection } from "@features/settings/components/backend-settings-section";
+import { desktopResult } from "@shared/api/local-operator/desktop-api";
+import { desktopKeys } from "@shared/api/local-operator/desktop-hooks";
+import { Spinner } from "@shared/components/common/spinner";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { StrictMode } from "react";
+import { createRoot } from "react-dom/client";
+import "@renderer/styles/index.css";
+
+/** The status the injected bridge answers with; per-panel, set before seeding. */
+let bridgeStatus = 503;
+/**
+ * Ops the bridge must never answer, for capturing an in-flight Retry.
+ *
+ * Keyed by op rather than a single flag because the panels seed concurrently
+ * from their own effects: a global "hang everything" switch would swallow
+ * another panel's seeding request, and releasing it on a timer would let the
+ * in-flight panel settle back to its idle button -- the exact state that panel
+ * exists to contrast against.
+ */
+const hangingOps = new Set<string>();
+
+// The bridge itself. `window.api.desktop` existing is what routes the renderer
+// down the IPC branch, so this must be installed before any surface mounts.
+(window as unknown as { api: unknown }).api = {
+	desktop: {
+		request: async (request: { op: string }) => {
+			if (hangingOps.has(request.op)) return new Promise(() => {});
+			return { status: bridgeStatus, body: { detail: "denied" } };
+		},
+	},
+};
+
+// React Query pauses refetching in a hidden tab, which silently defeats a
+// capture run in a background window. Reporting the document visible keeps the
+// frames the ones a focused user would see.
+Object.defineProperty(document, "visibilityState", {
+	configurable: true,
+	get: () => "visible",
+});
+Object.defineProperty(document, "hidden", {
+	configurable: true,
+	get: () => false,
+});
+
+const newClient = () =>
+	new QueryClient({
+		defaultOptions: {
+			queries: {
+				retry: false,
+				gcTime: Number.POSITIVE_INFINITY,
+				// A surface mounting against an errored query would otherwise re-run
+				// it and paint its loading state instead of the state being captured.
+				retryOnMount: false,
+				refetchOnWindowFocus: false,
+			},
+		},
+	});
+
+/** Seed a client with the failure the shipped transport produces at `status`. */
+async function seedCapabilities(client: QueryClient, status: number) {
+	bridgeStatus = status;
+	await client
+		.fetchQuery({
+			queryKey: desktopKeys.capabilities,
+			queryFn: () => desktopResult({ op: "capabilities" }),
+			retry: false,
+		})
+		.catch(() => undefined);
+}
+
+/** Seed a provider list that loaded once and then failed, which is the state
+ *  in which Retry's in-flight label is reachable (a refetch holding data keeps
+ *  `status: "error"` rather than resetting to pending). */
+async function seedProviders(client: QueryClient, status: number) {
+	client.setQueryData(desktopKeys.providers, [
+		{
+			id: "openai",
+			name: "OpenAI",
+			search_aliases: [],
+			methods: [{ kind: "api_key" }],
+			local: false,
+			credential_optional: false,
+			has_credential: false,
+			configured: false,
+		},
+	]);
+	bridgeStatus = status;
+	await client
+		.fetchQuery({
+			queryKey: desktopKeys.providers,
+			queryFn: () => desktopResult({ op: "providers.list" }),
+			retry: false,
+		})
+		.catch(() => undefined);
+}
+
+type PanelProps = {
+	title: string;
+	note: string;
+	client: QueryClient;
+	children: React.ReactNode;
+};
+
+const Panel = ({ title, note, client, children }: PanelProps) => (
+	<section className="flex flex-col gap-2 border-hairline border-b pb-6">
+		<h2 className="text-body-sm text-ink">{title}</h2>
+		<p className="text-meta text-ink-dim">{note}</p>
+		<div className="rounded-md bg-surface p-4">
+			<QueryClientProvider client={client}>{children}</QueryClientProvider>
+		</div>
+	</section>
+);
+
+/*
+ * Seeding runs to completion BEFORE the first render, and sequentially.
+ *
+ * The panels share one injected bridge, so a panel seeded from its own effect
+ * would race the others: the "Retry mid-flight" panel has to leave a
+ * `providers.list` request permanently unanswered, and a concurrently-seeding
+ * panel issuing the same op would hang on it too. Ordering the seeds here makes
+ * every captured frame deterministic.
+ */
+const settings401 = newClient();
+const settings503 = newClient();
+const settings404 = newClient();
+const providersIdle = newClient();
+const providersRetrying = newClient();
+
+await seedCapabilities(settings401, 401);
+await seedCapabilities(settings503, 503);
+await seedCapabilities(settings404, 404);
+await seedProviders(providersIdle, 503);
+await seedProviders(providersRetrying, 503);
+
+// Left in flight: this panel IS the frame a user sees after clicking Retry.
+// Releasing the hang early would let the query settle and repaint the idle
+// button, which is the state this panel exists to contrast against.
+//
+// It is not indefinite, and it should not be: the renderer transport's own 30s
+// deadline eventually rejects the request, which is the bound issue 89 was
+// filed for. So capture this panel WITHIN 30s of load -- after that the button
+// correctly returns to "Retry", and a screenshot taken late shows the settled
+// frame rather than the in-flight one.
+hangingOps.add("providers.list");
+void providersRetrying.refetchQueries({ queryKey: desktopKeys.providers });
+await new Promise((resolve) => setTimeout(resolve, 60));
+
+/** The 4s waiting state, lifted out of the settings page so it can be captured
+ *  without waiting on a real stalled load. The markup mirrors the page's own
+ *  branch; the copy is the point of the capture. */
+const SlowLoad = () => (
+	// biome-ignore lint/a11y/useSemanticElements: role=status on the container is the live-region pattern.
+	<div
+		role="status"
+		className="flex h-40 w-full flex-col items-center justify-center gap-3 bg-canvas"
+	>
+		<Spinner size="lg" />
+		<p className="max-w-sm text-center text-body-sm text-ink-muted">
+			The Local Operator server is taking longer than usual to answer. If it
+			does not respond, you will be able to retry from here.
+		</p>
+	</div>
+);
+
+createRoot(document.getElementById("root") as HTMLElement).render(
+	<StrictMode>
+		<main className="flex flex-col gap-6 bg-canvas p-6 text-ink">
+			<Panel
+				title="Settings at 401 — a running server that refused this app's bearer"
+				note="Was: 'Settings could not be loaded. The backend may need an update.'"
+				client={settings401}
+			>
+				<BackendSettingsSection />
+			</Panel>
+			<Panel
+				title="Settings at 503 — the server is not answering"
+				note="Must not reach the update remedy either."
+				client={settings503}
+			>
+				<BackendSettingsSection />
+			</Panel>
+			<Panel
+				title="Settings at 404 — the one status an update repairs"
+				note="The update remedy is now selected rather than asserted for everything."
+				client={settings404}
+			>
+				<BackendSettingsSection />
+			</Panel>
+			<Panel
+				title="Providers at 503 — error state, Retry idle"
+				note="No raw exception in the sentence."
+				client={providersIdle}
+			>
+				<ProviderGrid />
+			</Panel>
+			<Panel
+				title="Providers — Retry mid-flight"
+				note="The frame after the click: disabled, and labelled 'Retrying'."
+				client={providersRetrying}
+			>
+				<ProviderGrid />
+			</Panel>
+			<section className="flex flex-col gap-2">
+				<h2 className="text-body-sm text-ink">
+					Settings, 4s into a slow load — the explanation, inside a live region
+				</h2>
+				<p className="text-meta text-ink-dim">
+					Was: 'This will stop and offer a retry if it does not respond.'
+				</p>
+				<div className="rounded-md bg-surface p-4">
+					<SlowLoad />
+				</div>
+			</section>
+		</main>
+	</StrictMode>,
+);

--- a/scripts/backend-error-evidence.vite.mjs
+++ b/scripts/backend-error-evidence.vite.mjs
@@ -1,0 +1,33 @@
+import { resolve } from "node:path";
+import tailwindcss from "@tailwindcss/vite";
+import react from "@vitejs/plugin-react";
+import { defineConfig } from "vite";
+
+/**
+ * Vite config for the backend-error evidence harness only.
+ *
+ * Separate from `electron.vite.config.js` because that config's renderer stage
+ * declares the app's own html entries and the desktop HTTP proxy; this harness
+ * deliberately runs WITHOUT that proxy, since its whole point is to exercise
+ * the Electron bridge branch instead. Aliases are copied from the renderer
+ * stage so the shipped components resolve exactly as they do in the app.
+ */
+const root = resolve(import.meta.dirname, "..");
+
+export default defineConfig({
+	root: resolve(root, "scripts"),
+	resolve: {
+		alias: {
+			"@renderer": resolve(root, "src/renderer/src"),
+			"@components": resolve(root, "src/renderer/src/components"),
+			"@features": resolve(root, "src/renderer/src/features"),
+			"@shared": resolve(root, "src/renderer/src/shared"),
+			"@assets": resolve(root, "src/renderer/src/assets"),
+			"@hooks": resolve(root, "src/renderer/src/hooks"),
+			"@api": resolve(root, "src/renderer/src/api"),
+			"@store": resolve(root, "src/renderer/src/store"),
+		},
+	},
+	plugins: [react(), tailwindcss()],
+	server: { port: 5199, strictPort: true },
+});

--- a/scripts/backend-error-surfaces.test.mjs
+++ b/scripts/backend-error-surfaces.test.mjs
@@ -602,3 +602,127 @@ test("settings renders the classifier's sentence rather than its own", async () 
 		);
 	}
 });
+
+test("the settings Retry is wired to the query that actually failed", async () => {
+	// Reviewer M2. Test 4(b) proves the frame changes while a capabilities
+	// refetch is in flight, but it drives its own QueryObserver rather than the
+	// button -- so collapsing this onClick to a bare `void query.refetch()`,
+	// which reintroduces the inert gated Retry, passed the entire suite. The
+	// click and the capabilities query were never connected by any assertion.
+	//
+	// Asserted on the source for the same reason the grid's `isFetching` guard
+	// is (provider-grid-error-copy.test.mjs): `renderToStaticMarkup` does not
+	// dispatch events, so the handler's BODY is unreachable to a rendered test
+	// here, and the wiring is the whole finding.
+	const { readFile } = await import("node:fs/promises");
+	const source = await readFile(
+		"src/renderer/src/features/settings/components/backend-settings-section.tsx",
+		"utf8",
+	);
+	const rendered = source.replace(/\/\*[\s\S]*?\*\/|\/\/[^\n]*/g, "");
+
+	assert.ok(
+		/capabilities\.isError[\s\S]{0,80}capabilities\.refetch\(\)/.test(rendered),
+		"the settings Retry no longer refetches capabilities on the gated path, so the click cannot fix the fault that gated it",
+	);
+	// The other half: the ungated path must still re-ask the settings query
+	// itself, or a failure of this query alone would have no retry at all.
+	assert.ok(
+		rendered.includes("query.refetch()"),
+		"the settings Retry no longer refetches the settings query",
+	);
+	// The M1 fix is a single expression that a later edit could quietly
+	// simplify back into the regression. The rendered test above catches that,
+	// but only while it keeps reaching the state it seeds; this says the intent
+	// out loud at the source.
+	assert.ok(
+		/capabilities\.data \? null : capabilities\.error/.test(rendered),
+		"a capabilities error is fatal again even when capabilities still holds data",
+	);
+});
+
+test("a failed background capabilities refetch does not blank a loaded settings page", async () => {
+	// Reviewer M1. React Query keeps `data` and `error` set together after a
+	// failed refetch of a query that had already succeeded, so a capabilities
+	// error is NOT on its own evidence that the section has nothing to render.
+	// Gating the error branch on `capabilities.error` alone therefore replaced a
+	// fully-loaded page with "the server is not answering" whenever a background
+	// refetch failed -- and `staleTime: 60_000` + `refetchOnWindowFocus` means
+	// alt-tabbing back after a minute is enough to reach it.
+	//
+	// The cost is data loss, not just a wrong frame: `BackendSettingRow` holds
+	// each draft in local `useState`, and this file's header promises drafts
+	// survive failures. Unmounting the section destroys typed-but-unsaved edits.
+	//
+	// Every other test here seeds capabilities failure with NO prior success, so
+	// `capabilities.data` is undefined in all of them -- which is why the whole
+	// suite stayed green over this. The success-then-failure seeding below is
+	// the entire point of this case.
+	const client = newClient();
+	client.setQueryData(backendSettingsKeys.all, {
+		sections: [{ name: "General" }],
+		settings: [
+			{
+				key: "a.b",
+				label: "A",
+				help: "h",
+				section: "General",
+				value: "1",
+				type: "string",
+			},
+		],
+	});
+
+	let capabilitiesMode = "ok";
+	const capabilities = new QueryObserver(client, {
+		queryKey: desktopKeys.capabilities,
+		retry: false,
+		staleTime: 60_000,
+		queryFn: () => {
+			if (capabilitiesMode === "ok")
+				return Promise.resolve({
+					desktop_available: true,
+					features: { settings: 1 },
+				});
+			return Promise.reject(new Error("boom"));
+		},
+	});
+	const unsubscribe = capabilities.subscribe(() => {});
+	await new Promise((resolve) => setTimeout(resolve, 40));
+
+	const healthy = text(renderBackendSettings(client));
+	assert.match(healthy, /Use default/, "the seeded healthy frame never loaded");
+
+	capabilitiesMode = "fail";
+	await capabilities.refetch();
+
+	// The precondition the finding rests on. If a refetch ever stops preserving
+	// data alongside the error, this test silently stops covering M1 -- which is
+	// exactly how the regression survived 41 green tests.
+	const state = capabilities.getCurrentResult();
+	assert.equal(state.status, "error", "capabilities did not reach an error");
+	assert.ok(
+		state.data,
+		"capabilities dropped its data on a failed refetch; this test no longer covers M1",
+	);
+
+	const afterFailure = text(renderBackendSettings(client));
+	assert.doesNotMatch(
+		afterFailure,
+		/Your settings could not be loaded\./,
+		"a background capabilities failure blanked a loaded settings page, destroying unsaved row drafts",
+	);
+	assert.match(
+		afterFailure,
+		/Use default/,
+		"the settings rows are gone after a background capabilities failure",
+	);
+	assert.equal(
+		afterFailure,
+		healthy,
+		"a background capabilities failure changed the loaded settings frame",
+	);
+
+	unsubscribe();
+	client.clear();
+});

--- a/scripts/backend-error-surfaces.test.mjs
+++ b/scripts/backend-error-surfaces.test.mjs
@@ -1,0 +1,604 @@
+import assert from "node:assert/strict";
+import { unlink, writeFile } from "node:fs/promises";
+import { test } from "node:test";
+import { build } from "esbuild";
+
+// Design D1 / D2 and reviewer M3: two defects that only appear in a RENDERED
+// frame, so both are asserted by rendering the shipped components rather than
+// by restating their branching.
+//
+//  - D1: Retry was a dead button. `refetch()` on a query that already holds
+//    data leaves `status: "error"`, so the error branch keeps winning and the
+//    frame is pixel-identical for the transport's whole 30s deadline. A user
+//    clicks Retry against a dead server and nothing appears to happen -- issue
+//    89's own "I cannot tell whether this is working or hung", one click
+//    downstream of its fix.
+//  - D2: `BackendSettingsSection`'s query is gated on capabilities, and a
+//    DISABLED React Query reports `isLoading: false` with no data. So when
+//    capabilities FAIL -- the server is unreachable, or refused this app's
+//    bearer -- the section fell through its loading gate into its error branch
+//    and asserted "the backend may need an update": the one remedy that cannot
+//    fix either fault, directly beneath a banner saying the opposite.
+//
+// Rendered with `renderToStaticMarkup` against a real `QueryClient`, so the
+// assertions are about what a user would see. A unit test over the selector
+// functions cannot see either defect: both are about which BRANCH renders and
+// what the button says while a refetch is in flight, not about copy.
+
+const bundle = await build({
+	stdin: {
+		contents: `
+			import { createElement } from "react";
+			import { renderToStaticMarkup } from "react-dom/server";
+			import { QueryClientProvider } from "@tanstack/react-query";
+			import { ProviderGrid } from "./src/renderer/src/features/providers/provider-grid";
+			import { BackendSettingsSection } from "./src/renderer/src/features/settings/components/backend-settings-section";
+			export { QueryClient, QueryObserver } from "@tanstack/react-query";
+			export { desktopKeys } from "./src/renderer/src/shared/api/local-operator/desktop-hooks";
+			export { backendSettingsKeys } from "./src/renderer/src/features/settings/components/backend-settings-section";
+			export { desktopResult, DesktopControlError } from "./src/renderer/src/shared/api/local-operator/desktop-api";
+			export { ConfigApi } from "./src/renderer/src/shared/api/local-operator/config-api";
+			export { backendErrorKind, backendLoadErrorMessage } from "./src/renderer/src/shared/api/local-operator/backend-error";
+
+			const render = (Component) => (client) =>
+				renderToStaticMarkup(
+					createElement(QueryClientProvider, { client }, createElement(Component, {})),
+				);
+			export const renderProviderGrid = render(ProviderGrid);
+			export const renderBackendSettings = render(BackendSettingsSection);
+		`,
+		resolveDir: process.cwd(),
+	},
+	bundle: true,
+	format: "esm",
+	platform: "node",
+	mainFields: ["module", "main"],
+	conditions: ["import"],
+	// The renderer's aliases are tsconfig paths, not node resolutions.
+	alias: {
+		"@shared": "./src/renderer/src/shared",
+		"@features": "./src/renderer/src/features",
+	},
+	// React and React Query stay external so the bundle shares ONE copy with
+	// this file's own imports; two copies give the components a different
+	// QueryClient context than the one the test seeds, and every render would
+	// report a fresh pending query.
+	external: [
+		"react",
+		"react-dom",
+		"react-dom/server",
+		"react/jsx-runtime",
+		"@tanstack/react-query",
+	],
+	// Stylesheets carry no assertion here and Node cannot import them.
+	loader: { ".css": "empty" },
+	jsx: "automatic",
+	write: false,
+});
+
+// Written to a real file rather than imported as a data: URL. React DOM's
+// server build resolves its own CJS entry at import time, which a data: URL
+// has no base path for.
+const bundlePath = new URL(
+	"./_backend-error-surfaces.bundle.mjs",
+	import.meta.url,
+);
+await writeFile(bundlePath, bundle.outputFiles[0].text);
+
+// The fault is injected AT THE BRIDGE, so the shipped transport is what builds
+// the error and attaches its status. A test that threw a hand-made
+// `DesktopControlError` would pass even if `desktopRequest` stopped carrying
+// the status at all -- which is the exact half of D2 that had regressed.
+//
+// The bridge must exist before the module graph is evaluated: without
+// `window.api.desktop` the renderer takes its browser-dev HTTP branch, which is
+// not the code that ships.
+let bridgeStatus = 503;
+globalThis.window = {
+	api: {
+		desktop: {
+			request: async () => ({
+				status: bridgeStatus,
+				body: { detail: "denied" },
+			}),
+		},
+	},
+};
+
+const {
+	QueryClient,
+	QueryObserver,
+	DesktopControlError,
+	desktopResult,
+	desktopKeys,
+	backendSettingsKeys,
+	ConfigApi,
+	backendErrorKind,
+	backendLoadErrorMessage,
+	renderProviderGrid,
+	renderBackendSettings,
+} = await import(bundlePath.href);
+await unlink(bundlePath);
+
+/** The rendered text a user reads, with markup and layout whitespace removed. */
+function text(html) {
+	return html
+		.replace(/<[^>]*>/g, " ")
+		.replace(/\s+/g, " ")
+		.trim();
+}
+
+/**
+ * Whether the rendered Retry control is actually disabled.
+ *
+ * Matches the ATTRIBUTE, not the substring: every button in this system ships
+ * `disabled:` Tailwind variants in its class list, so a bare `/disabled/` test
+ * is true of a fully enabled button and would assert nothing.
+ */
+function retryIsDisabled(html) {
+	return /<button[^>]*\sdisabled(?=[\s>=])/.test(html);
+}
+
+const newClient = () =>
+	new QueryClient({
+		defaultOptions: {
+			queries: {
+				retry: false,
+				gcTime: Number.POSITIVE_INFINITY,
+				// A component mounting against an errored query re-runs it by
+				// default, which resets `status` to pending and would render the
+				// loading branch instead of the state under test. The app does not
+				// re-mount these surfaces between the failure and the frame the user
+				// sees; this keeps the render honest to that.
+				retryOnMount: false,
+			},
+		},
+	});
+
+/**
+ * Seed a client with the failure a real capabilities call produces.
+ *
+ * Goes through `desktopResult` -- the shipped path -- so the error under test
+ * is one the transport constructed from a bridge response, status and all.
+ */
+async function seedCapabilitiesFailure(client, status) {
+	bridgeStatus = status;
+	try {
+		await client.fetchQuery({
+			queryKey: desktopKeys.capabilities,
+			queryFn: () => desktopResult({ op: "capabilities" }),
+			retry: false,
+		});
+	} catch {
+		// Expected: the seeding IS the failure.
+	}
+}
+
+/**
+ * Drive one query through load -> error -> Retry, and render the frame at each
+ * step.
+ *
+ * A `QueryObserver` is used rather than `fetchQuery` because it is what
+ * `useQuery` is built on, and the distinction is the whole finding: refetching
+ * a query that never held data RESETS it to pending, while refetching one that
+ * holds data keeps `status: "error"` and only flips `fetchStatus`. The second
+ * is the state a user reaches by clicking Retry on a surface that had loaded,
+ * and it is the state in which the old button changed nothing on screen.
+ */
+async function frames({ queryKey, render, ok, options = {} }) {
+	const client = newClient();
+	let mode = "ok";
+	const observer = new QueryObserver(client, {
+		queryKey,
+		retry: false,
+		...options,
+		queryFn: () => {
+			if (mode === "ok") return Promise.resolve(ok);
+			if (mode === "fail")
+				return Promise.reject(options.failure ?? new Error("boom"));
+			// A request that never settles: the shape the transport's deadline
+			// exists for, and the one that keeps Retry in flight long enough to
+			// matter.
+			return new Promise(() => {});
+		},
+	});
+	const unsubscribe = observer.subscribe(() => {});
+	await new Promise((resolve) => setTimeout(resolve, 40));
+
+	mode = "fail";
+	await observer.refetch();
+	const errored = render(client);
+
+	mode = "hang";
+	void observer.refetch();
+	await new Promise((resolve) => setTimeout(resolve, 40));
+	const retrying = render(client);
+	const state = observer.getCurrentResult();
+
+	unsubscribe();
+	client.clear();
+	return { errored, retrying, state };
+}
+
+const A_PROVIDER = [
+	{
+		id: "openai",
+		name: "OpenAI",
+		search_aliases: [],
+		methods: [{ kind: "api_key" }],
+		local: false,
+		credential_optional: false,
+		has_credential: false,
+		configured: false,
+	},
+];
+
+test("the providers Retry reflects the in-flight refetch instead of a dead frame", async () => {
+	const { errored, retrying, state } = await frames({
+		queryKey: desktopKeys.providers,
+		render: renderProviderGrid,
+		ok: A_PROVIDER,
+		options: { staleTime: 30_000 },
+	});
+
+	// The precondition the finding rests on. If this ever reports `pending`,
+	// the assertions below stop measuring D1 -- the loading branch would render
+	// during the refetch and the button would be gone rather than pending.
+	assert.equal(
+		state.status,
+		"error",
+		"a refetch of an errored query no longer keeps status=error; this test no longer covers D1",
+	);
+	assert.equal(state.isFetching, true);
+	assert.equal(
+		state.isLoading,
+		false,
+		"isLoading is true during the refetch, which would make the dead-button finding unreachable",
+	);
+
+	assert.match(text(errored), /Retry(?!ing)/, "the error frame offers Retry");
+	assert.equal(
+		retryIsDisabled(errored),
+		false,
+		"Retry is not clickable before the click",
+	);
+
+	// The frame after the click must differ. Both halves matter: the label tells
+	// a sighted user the click landed, and `disabled` stops a user who cannot
+	// see the change from queuing four more requests against a dead server.
+	assert.match(
+		text(retrying),
+		/Retrying/,
+		"Retry does not acknowledge the click",
+	);
+	assert.equal(
+		retryIsDisabled(retrying),
+		true,
+		"Retry stays clickable while its own refetch is in flight",
+	);
+	assert.notEqual(
+		errored,
+		retrying,
+		"the frame is identical after clicking Retry: the button is still dead",
+	);
+});
+
+test("settings classifies a rejected bearer as unauthorized, not as an unreachable or outdated server", async () => {
+	// The D2 defect in its exact shape. Capabilities fail with 401, so the
+	// settings query never becomes `enabled` -- and a DISABLED React Query
+	// reports `isLoading: false` with no data, so the section fell straight
+	// through its loading gate into an error branch that asserted "the backend
+	// may need an update". That is the one remedy which cannot fix a bearer the
+	// running server refuses, rendered directly beneath a banner saying the
+	// opposite.
+	const client = newClient();
+	await seedCapabilitiesFailure(client, 401);
+	const rendered = text(renderBackendSettings(client));
+
+	// The remedy, which is the part that has to be right: restart, because the
+	// app starts and pairs with its own server.
+	assert.match(
+		rendered,
+		/Restart the app so it starts and pairs with its own server\./,
+	);
+	assert.match(rendered, /This app cannot authenticate to the running/);
+	// The wrong answers, each of which shipped on this surface: the update
+	// remedy, the "may not be running" hedge about a server that is
+	// demonstrably running and answering, and the raw exception.
+	assert.doesNotMatch(
+		rendered,
+		/update/i,
+		"a rejected bearer is told to install a newer server",
+	);
+	assert.doesNotMatch(rendered, /may not be running|not answering/i);
+	assert.doesNotMatch(
+		rendered,
+		/401|request failed|denied/,
+		"a raw exception reached the user",
+	);
+	assert.match(rendered, /Your settings could not be loaded\./);
+
+	client.clear();
+});
+
+test("settings reports an unreachable server as offline rather than as needing an update", async () => {
+	// The other half of D2's classification, and the standing state of this
+	// surface whenever the server is simply off. 503 is the main process's own
+	// "could not complete this request"; it must not reach the update copy
+	// either.
+	const client = newClient();
+	await seedCapabilitiesFailure(client, 503);
+	const rendered = text(renderBackendSettings(client));
+
+	assert.match(rendered, /The Local Operator server is not answering\./);
+	assert.match(rendered, /Restart the app so it can start its own server\./);
+	assert.doesNotMatch(rendered, /update/i);
+
+	client.clear();
+});
+
+test("clicking Retry on the settings section always changes the frame", async () => {
+	// D1 on this surface. React Query resolves the click into two different
+	// states depending on whether anything ever loaded, and BOTH have to give
+	// the user feedback -- the defect is a frame that does not change, not a
+	// particular label.
+	//
+	// (a) The settings query holds data from an earlier success, so its refetch
+	//     keeps `status: "error"` and the error branch keeps winning. Nothing
+	//     but the button can change here, which is exactly why the button has
+	//     to.
+	const withData = newClient();
+	withData.setQueryData(desktopKeys.capabilities, {
+		desktop_available: true,
+		features: { settings: 1 },
+	});
+	let mode = "ok";
+	const settings = new QueryObserver(withData, {
+		queryKey: backendSettingsKeys.all,
+		retry: false,
+		staleTime: 10_000,
+		queryFn: () => {
+			if (mode === "ok")
+				return Promise.resolve({
+					sections: [{ name: "General" }],
+					settings: [
+						{
+							key: "a.b",
+							label: "A",
+							help: "h",
+							section: "General",
+							value: "1",
+							type: "string",
+						},
+					],
+				});
+			if (mode === "fail") return Promise.reject(new Error("boom"));
+			return new Promise(() => {});
+		},
+	});
+	const stopSettings = settings.subscribe(() => {});
+	await new Promise((resolve) => setTimeout(resolve, 40));
+	mode = "fail";
+	await settings.refetch();
+
+	const errored = renderBackendSettings(withData);
+	assert.match(text(errored), /Retry(?!ing)/);
+	assert.equal(retryIsDisabled(errored), false);
+
+	mode = "hang";
+	void settings.refetch();
+	await new Promise((resolve) => setTimeout(resolve, 40));
+	assert.equal(
+		settings.getCurrentResult().status,
+		"error",
+		"a refetch holding data no longer keeps status=error; this case no longer covers D1",
+	);
+
+	const retrying = renderBackendSettings(withData);
+	assert.match(
+		text(retrying),
+		/Retrying/,
+		"Retry does not acknowledge the click",
+	);
+	assert.equal(retryIsDisabled(retrying), true);
+	stopSettings();
+	withData.clear();
+
+	// (b) Capabilities never succeeded, so re-asking them resets the query to
+	//     pending and the section legitimately returns to its spinner. That is
+	//     a visible acknowledgement too -- the frame must simply not be the one
+	//     the user just clicked on.
+	const gated = newClient();
+	await seedCapabilitiesFailure(gated, 401);
+	const gatedError = renderBackendSettings(gated);
+
+	bridgeStatus = 401;
+	const capabilities = new QueryObserver(gated, {
+		queryKey: desktopKeys.capabilities,
+		retry: false,
+		queryFn: () => new Promise(() => {}),
+	});
+	const stopCapabilities = capabilities.subscribe(() => {});
+	void capabilities.refetch();
+	await new Promise((resolve) => setTimeout(resolve, 40));
+
+	const gatedRetrying = renderBackendSettings(gated);
+	assert.notEqual(
+		gatedError,
+		gatedRetrying,
+		"the frame is identical after clicking Retry: the button is dead on the gated path",
+	);
+	assert.match(text(gatedRetrying), /Loading settings/);
+	stopCapabilities();
+	gated.clear();
+});
+
+test("a settings load that fails on its own request is still classified", async () => {
+	// Capabilities succeed, so the query runs and fails by itself. The surface
+	// must classify THAT error rather than falling back to a default, which is
+	// what the shared `loadError` selection is for.
+	const client = newClient();
+	client.setQueryData(desktopKeys.capabilities, {
+		desktop_available: true,
+		features: { settings: 1 },
+	});
+	bridgeStatus = 404;
+	const observer = new QueryObserver(client, {
+		queryKey: backendSettingsKeys.all,
+		retry: false,
+		queryFn: () => desktopResult({ op: "settings.list" }),
+	});
+	const unsubscribe = observer.subscribe(() => {});
+	await new Promise((resolve) => setTimeout(resolve, 40));
+
+	const rendered = text(renderBackendSettings(client));
+	// 404 is the one status an update actually repairs, so here the update
+	// remedy is correct -- the fix is that it is now SELECTED rather than
+	// asserted for everything.
+	assert.match(rendered, /older than this app expects/);
+	assert.match(rendered, /Update the server and try again\./);
+	assert.doesNotMatch(
+		rendered,
+		/404|denied|does not support/,
+		"a raw exception reached the user",
+	);
+
+	unsubscribe();
+	client.clear();
+});
+
+test("a config failure carries its status, so Settings can classify it", async () => {
+	// The reviewer's MAJOR and the second half of D2. `config-api` threw a plain
+	// `Error`, which discards the status -- so every consumer that classified
+	// one fell to `backendErrorKind`'s `status: null` default and concluded
+	// "nothing answered". At 401 the Settings page told a user whose server was
+	// running and refusing its bearer that the server "may not be running", and
+	// offered no restart.
+	//
+	// Driven through the shipped `ConfigApi` against the bridge, because the
+	// defect is in what the API layer THROWS; a test that constructed the error
+	// itself would pass against the broken version.
+	const cases = [
+		{ status: 401, kind: "unauthorized" },
+		{ status: 403, kind: "unauthorized" },
+		{ status: 503, kind: "unreachable" },
+		{ status: 404, kind: "outdated" },
+		{ status: 500, kind: "unknown" },
+	];
+
+	for (const { status, kind } of cases) {
+		bridgeStatus = status;
+		const error = await ConfigApi.getConfig("").then(
+			() => null,
+			(caught) => caught,
+		);
+
+		assert.ok(error, `a ${status} must reject`);
+		assert.ok(
+			error instanceof DesktopControlError,
+			`a ${status} threw a plain Error, so its status is lost and it classifies as unreachable`,
+		);
+		assert.equal(error.status, status);
+		assert.equal(
+			backendErrorKind(error),
+			kind,
+			`a ${status} config failure classifies as ${backendErrorKind(error)}, not ${kind}`,
+		);
+	}
+
+	// The sentence the Settings page renders from that classification. Stated
+	// here as well as in the render tests because this is the pairing the defect
+	// was reported as: a running server described as one that may not be
+	// running.
+	bridgeStatus = 401;
+	const unauthorized = await ConfigApi.getConfig("").catch((caught) => caught);
+	const sentence = backendLoadErrorMessage(
+		"Your settings could not be loaded.",
+		unauthorized,
+	);
+	assert.match(
+		sentence,
+		/cannot authenticate to the running Local Operator server/,
+	);
+	assert.match(
+		sentence,
+		/Restart the app so it starts and pairs with its own server\./,
+	);
+	assert.doesNotMatch(sentence, /may not be running|not answering|update/i);
+	// The raw exception stays on the error for logs and support, and off the
+	// sentence the user reads.
+	assert.match(unauthorized.message, /Get config request failed: 401/);
+	assert.doesNotMatch(sentence, /request failed|401/);
+});
+
+test("the slow-load explanation is inside a live region", async () => {
+	// Design D6. A sighted user gets a visible state change at 4s telling them
+	// the app is alive; before this fix a screen-reader user got "Loading
+	// settings" once at mount and then silence for up to 30s -- and under
+	// `prefers-reduced-motion` the global cap freezes the ring, so that user had
+	// no liveness signal at all. The text whose entire purpose is "you cannot
+	// tell waiting from hung" was reaching only the users who could already
+	// tell.
+	//
+	// Asserted on the source because the branch is behind a 4s timer and a real
+	// config load; the structural facts are the announcement contract itself.
+	const { readFile } = await import("node:fs/promises");
+	const page = await readFile(
+		"src/renderer/src/features/settings/components/settings-page.tsx",
+		"utf8",
+	);
+
+	const waiting = page.slice(page.indexOf("if (isLoading) {"));
+	const region = waiting.slice(0, waiting.indexOf("if (!config)"));
+	assert.ok(
+		/role="status"/.test(region),
+		"the waiting stack is not a live region, so the 4s explanation is announced to nobody",
+	);
+	assert.ok(
+		/label=\{isSlowLoad \? undefined :/.test(region),
+		"the Spinner keeps its label beside its own caption, announcing the same fact twice",
+	);
+	// D11: the copy must describe the user's situation, not the app's control
+	// flow. "This will stop and offer a retry" made the machinery the subject.
+	assert.ok(
+		region.includes("taking longer than usual to answer"),
+		"the slow-load copy is not the agreed sentence",
+	);
+	assert.ok(
+		!region.includes("This will stop and offer a retry"),
+		"the slow-load copy still narrates the app's plan rather than the user's situation",
+	);
+});
+
+test("settings renders the classifier's sentence rather than its own", async () => {
+	// A source guard, for the same reason the timing test carries one: the
+	// rendered assertions above would all still pass if a surface re-inlined
+	// copy that happened to match today, and the two surfaces drifting apart is
+	// precisely the defect this change set exists to remove.
+	const { readFile } = await import("node:fs/promises");
+	for (const path of [
+		"src/renderer/src/features/settings/components/settings-page.tsx",
+		"src/renderer/src/features/settings/components/backend-settings-section.tsx",
+	]) {
+		const source = await readFile(path, "utf8");
+		assert.ok(
+			source.includes("backendLoadErrorMessage("),
+			`${path} no longer routes its error copy through the shared classifier`,
+		);
+		// Comments quote the removed strings to explain why they went, so this
+		// looks at rendered JSX text rather than at the whole file.
+		const rendered = source.replace(/\/\*[\s\S]*?\*\/|\/\/[^\n]*/g, "");
+		assert.ok(
+			!rendered.includes("may not be running"),
+			`${path} re-inlined the hedge the connectivity banner contradicts`,
+		);
+		assert.ok(
+			!rendered.includes("may need an update"),
+			`${path} re-inlined the update remedy for faults an update cannot fix`,
+		);
+		assert.ok(
+			!/\{configError\.message\}|\{query\.error\?\.message\}/.test(source),
+			`${path} renders a raw exception string to the user`,
+		);
+	}
+});

--- a/scripts/desktop-renderer-transport.test.mjs
+++ b/scripts/desktop-renderer-transport.test.mjs
@@ -1,0 +1,88 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+import { build } from "esbuild";
+
+// Bundle the renderer transport in memory, the same way the main-process
+// contract test does, so this guard runs the shipped TS rather than a copy.
+// The module is renderer code, so `window` is the only global it needs.
+const bundle = await build({
+	stdin: {
+		contents:
+			'export * from "./src/renderer/src/shared/api/local-operator/desktop-api";',
+		resolveDir: process.cwd(),
+	},
+	bundle: true,
+	format: "esm",
+	platform: "neutral",
+	mainFields: ["module", "main"],
+	conditions: ["import"],
+	write: false,
+});
+const source = bundle.outputFiles[0].text;
+
+/**
+ * Import a fresh copy of the transport with `window.api.desktop.request` bound
+ * to `request`. A fresh copy per test keeps the module-level deadline constant
+ * from leaking timer state between cases.
+ */
+async function loadTransport(request) {
+	globalThis.window = { api: { desktop: { request } } };
+	return import(
+		`data:text/javascript;base64,${Buffer.from(source).toString("base64")}#${Math.random()}`
+	);
+}
+
+// Issue 89: `/v1/config` was accepted and never answered, so the IPC promise
+// never settled. React Query's `retry` cannot help -- retry needs a settled
+// rejection -- so `isConfigLoading` stayed true and Settings showed a spinner
+// with no recovery. The contract this pins is that a desktop control which
+// never settles becomes a REJECTION within the deadline, because only a
+// rejection can reach an error state a user can act on.
+test("a desktop control that never settles rejects instead of pending forever", async () => {
+	const { desktopRequest, DesktopControlError } = await loadTransport(
+		// The exact issue-89 fault: accepted, never answered, never rejected.
+		() => new Promise(() => {}),
+	);
+
+	const started = Date.now();
+	const outcome = await Promise.race([
+		desktopRequest({ op: "config.get" }).then(
+			(value) => ({ settled: value }),
+			(error) => ({ error }),
+		),
+		// Longer than the transport's own 30s deadline, so a transport that
+		// never bounds the request fails this test by timing out here instead
+		// of hanging the run.
+		new Promise((resolve) =>
+			setTimeout(() => resolve({ pending: true }), 45000),
+		),
+	]);
+
+	assert.ok(
+		!outcome.pending,
+		"desktopRequest never settled: the request is unbounded and Settings would spin forever",
+	);
+	assert.ok(
+		outcome.error instanceof DesktopControlError,
+		"a stalled control must reject as DesktopControlError so callers reach an error state",
+	);
+	// `null` is the transport's stated "no backend was reached" status. The
+	// compatibility banner and the providers grid both read exactly this field
+	// to say "not answering" rather than "needs an update".
+	assert.equal(outcome.error.status, null);
+	assert.ok(Date.now() - started < 45000);
+});
+
+// The deadline must not truncate a slow-but-working backend into a false
+// failure, so a control that answers is passed through untouched.
+test("a desktop control that answers is returned unchanged", async () => {
+	const { desktopRequest } = await loadTransport(async () => ({
+		status: 200,
+		body: { result: { hosting: "openai" } },
+	}));
+
+	assert.deepEqual(await desktopRequest({ op: "config.get" }), {
+		status: 200,
+		body: { result: { hosting: "openai" } },
+	});
+});

--- a/scripts/provider-grid-error-copy.test.mjs
+++ b/scripts/provider-grid-error-copy.test.mjs
@@ -1,0 +1,85 @@
+import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
+import { test } from "node:test";
+import { build } from "esbuild";
+
+// QA finding Q3: the providers grid asserted "The backend may need an update."
+// for EVERY load error, including a backend that is simply not running. That
+// sends the user to a several-minute backend install that cannot fix an
+// unreachable process.
+//
+// The selection now lives in `providerLoadErrorMessage`, which this test
+// bundles and calls directly -- asserting the real shipped function rather than
+// a restatement of its logic, so removing the branch fails these tests.
+const bundle = await build({
+	stdin: {
+		contents: `
+			export { providerLoadErrorMessage } from "./src/renderer/src/features/providers/provider-labels";
+			export { DesktopControlError } from "./src/renderer/src/shared/api/local-operator/desktop-api";
+		`,
+		resolveDir: process.cwd(),
+	},
+	bundle: true,
+	format: "esm",
+	platform: "neutral",
+	mainFields: ["module", "main"],
+	conditions: ["import"],
+	// The renderer's `@shared` alias is a tsconfig path, not a node resolution.
+	alias: { "@shared": "./src/renderer/src/shared" },
+	write: false,
+});
+const { providerLoadErrorMessage, DesktopControlError } = await import(
+	`data:text/javascript;base64,${Buffer.from(bundle.outputFiles[0].text).toString("base64")}`
+);
+
+const OFFLINE =
+	"Providers could not be loaded. The backend is not answering. Retry once it has started.";
+const UPDATE = "Providers could not be loaded. The backend may need an update.";
+
+test("an unreachable backend is reported as offline, not as needing an update", () => {
+	// `status: null` is what the transport raises when no backend was reached:
+	// a rejected IPC call, a dead dev proxy, or the stalled-request deadline.
+	assert.equal(
+		providerLoadErrorMessage(new DesktopControlError(null, "unreachable")),
+		OFFLINE,
+	);
+	// 503 is the main process's own "could not complete this request", which is
+	// what a backend that is down or refusing work answers with.
+	assert.equal(
+		providerLoadErrorMessage(new DesktopControlError(503, "down")),
+		OFFLINE,
+	);
+	// A non-typed failure carries no status and must not claim an update fixes it.
+	assert.equal(providerLoadErrorMessage(new Error("boom")), OFFLINE);
+});
+
+test("a capability-missing backend is the only case told to update", () => {
+	// 404 means the route is absent, so this backend predates the desktop
+	// contract. That is the one state a backend update actually repairs.
+	assert.equal(
+		providerLoadErrorMessage(new DesktopControlError(404, "no route")),
+		UPDATE,
+	);
+	// An unexpected status keeps the generic sentence rather than guessing.
+	assert.equal(
+		providerLoadErrorMessage(new DesktopControlError(500, "boom")),
+		UPDATE,
+	);
+});
+
+test("the grid renders the selected message rather than a hardcoded string", async () => {
+	const source = await readFile(
+		"src/renderer/src/features/providers/provider-grid.tsx",
+		"utf8",
+	);
+	// Guards against the component drifting back to a single literal, which
+	// would leave the assertions above passing about code nothing renders.
+	assert.ok(
+		source.includes("providerLoadErrorMessage(providers.error)"),
+		"provider-grid no longer routes its error copy through providerLoadErrorMessage",
+	);
+	assert.ok(
+		!source.includes(UPDATE),
+		"provider-grid still hardcodes the update copy",
+	);
+});

--- a/scripts/provider-grid-error-copy.test.mjs
+++ b/scripts/provider-grid-error-copy.test.mjs
@@ -3,18 +3,27 @@ import { readFile } from "node:fs/promises";
 import { test } from "node:test";
 import { build } from "esbuild";
 
-// QA finding Q3: the providers grid asserted "The backend may need an update."
-// for EVERY load error, including a backend that is simply not running. That
-// sends the user to a several-minute backend install that cannot fix an
-// unreachable process.
+// QA Q3 / reviewer M1: two surfaces read the SAME `DesktopControlError.status`
+// and reached different conclusions from it. The providers grid asserted "The
+// backend may need an update." for every error it did not recognise -- which
+// included 401 and 403, where the compatibility banner says the opposite
+// (restart and re-pair) and deliberately withholds its update button, because
+// installing a newer backend cannot fix a bearer the running one refuses.
 //
-// The selection now lives in `providerLoadErrorMessage`, which this test
-// bundles and calls directly -- asserting the real shipped function rather than
-// a restatement of its logic, so removing the branch fails these tests.
+// Both selectors are bundled and CALLED here, so these assertions are about the
+// shipped functions rather than a restatement of their logic. A local copy of
+// the branching would stay green under mutation, which is exactly the hole this
+// file exists to close.
 const bundle = await build({
 	stdin: {
 		contents: `
 			export { providerLoadErrorMessage } from "./src/renderer/src/features/providers/provider-labels";
+			export {
+				backendCompatibilityMessage,
+				backendErrorKind,
+				backendUpdateIsRemedy,
+				BACKEND_ERROR_REMEDY,
+			} from "./src/renderer/src/shared/api/local-operator/backend-error";
 			export { DesktopControlError } from "./src/renderer/src/shared/api/local-operator/desktop-api";
 		`,
 		resolveDir: process.cwd(),
@@ -28,17 +37,107 @@ const bundle = await build({
 	alias: { "@shared": "./src/renderer/src/shared" },
 	write: false,
 });
-const { providerLoadErrorMessage, DesktopControlError } = await import(
+const {
+	providerLoadErrorMessage,
+	backendCompatibilityMessage,
+	backendErrorKind,
+	backendUpdateIsRemedy,
+	BACKEND_ERROR_REMEDY,
+	DesktopControlError,
+} = await import(
 	`data:text/javascript;base64,${Buffer.from(bundle.outputFiles[0].text).toString("base64")}`
 );
 
-const OFFLINE =
-	"Providers could not be loaded. The backend is not answering. Retry once it has started.";
-const UPDATE = "Providers could not be loaded. The backend may need an update.";
+/** The banner as the app renders it: nothing answered, so only the status speaks. */
+function bannerMessage(error) {
+	return backendCompatibilityMessage({
+		kind: backendErrorKind(error),
+		unpaired: false,
+		missing: [],
+		answered: false,
+	});
+}
+
+// Every status the two surfaces can disagree about, including the fallback.
+// 401 and 403 are the regression: they used to land on the update copy.
+const STATUSES = [
+	{ status: 404, kind: "outdated" },
+	{ status: 503, kind: "unreachable" },
+	{ status: null, kind: "unreachable" },
+	{ status: 401, kind: "unauthorized" },
+	{ status: 403, kind: "unauthorized" },
+	{ status: 500, kind: "unknown" },
+];
+
+test("the grid and the banner agree on the remedy for every status", () => {
+	for (const { status, kind } of STATUSES) {
+		const error = new DesktopControlError(status, "probe");
+		assert.equal(backendErrorKind(error), kind, `status ${status} classified`);
+
+		const remedy = BACKEND_ERROR_REMEDY[kind];
+		const grid = providerLoadErrorMessage(error);
+		const banner = bannerMessage(error);
+
+		// The two surfaces describe different scopes -- the grid speaks about
+		// providers, the banner about the whole app -- so the agreement that
+		// matters is the ACTION each one tells the user to take.
+		if (remedy) {
+			assert.ok(
+				grid.includes(remedy),
+				`status ${status}: grid "${grid}" omits the remedy "${remedy}"`,
+			);
+			assert.ok(
+				banner.includes(remedy),
+				`status ${status}: banner "${banner}" omits the remedy "${remedy}"`,
+			);
+		}
+
+		// Neither surface may assert a remedy the other withholds. "Update" is the
+		// one that cost a user a several-minute install for a fault it cannot fix.
+		const updateIsRemedy = backendUpdateIsRemedy({
+			kind,
+			unpaired: false,
+			answered: false,
+		});
+		const gridSaysUpdate = /update the backend|may need an update/i.test(grid);
+		const bannerSaysUpdate = /update|older than the app expects/i.test(banner);
+		assert.equal(
+			gridSaysUpdate,
+			updateIsRemedy,
+			`status ${status}: grid "${grid}" disagrees with the update remedy`,
+		);
+		assert.equal(
+			bannerSaysUpdate,
+			updateIsRemedy,
+			`status ${status}: banner "${banner}" disagrees with the update remedy`,
+		);
+	}
+});
+
+test("a rejected bearer is never told to install a newer backend", () => {
+	// The specific defect: at 401 the grid sent the user through a backend
+	// install while the banner told them to restart and re-pair.
+	for (const status of [401, 403]) {
+		const error = new DesktopControlError(status, "unauthorized");
+		const grid = providerLoadErrorMessage(error);
+		assert.match(grid, /Restart the app/);
+		assert.doesNotMatch(grid, /update/i);
+		assert.equal(
+			backendUpdateIsRemedy({
+				kind: backendErrorKind(error),
+				unpaired: false,
+				answered: false,
+			}),
+			false,
+		);
+	}
+});
 
 test("an unreachable backend is reported as offline, not as needing an update", () => {
 	// `status: null` is what the transport raises when no backend was reached:
 	// a rejected IPC call, a dead dev proxy, or the stalled-request deadline.
+	const OFFLINE =
+		"Providers could not be loaded. The backend is not answering. Retry once it has started.";
 	assert.equal(
 		providerLoadErrorMessage(new DesktopControlError(null, "unreachable")),
 		OFFLINE,
@@ -58,28 +157,48 @@ test("a capability-missing backend is the only case told to update", () => {
 	// contract. That is the one state a backend update actually repairs.
 	assert.equal(
 		providerLoadErrorMessage(new DesktopControlError(404, "no route")),
-		UPDATE,
-	);
-	// An unexpected status keeps the generic sentence rather than guessing.
-	assert.equal(
-		providerLoadErrorMessage(new DesktopControlError(500, "boom")),
-		UPDATE,
+		"Providers could not be loaded. The backend may need an update. Update the backend and try again.",
 	);
 });
 
-test("the grid renders the selected message rather than a hardcoded string", async () => {
-	const source = await readFile(
+test("an unrecognised status asserts no remedy at all", () => {
+	// The old fallback WAS the update sentence, so a 500 from a backend that is
+	// running and current was answered with an install. A status we cannot
+	// advise on must state the failure and stop.
+	const grid = providerLoadErrorMessage(new DesktopControlError(500, "boom"));
+	assert.equal(grid, "Providers could not be loaded.");
+	assert.doesNotMatch(grid, /update|restart|retry/i);
+});
+
+test("both surfaces render the selected message rather than a hardcoded string", async () => {
+	const grid = await readFile(
 		"src/renderer/src/features/providers/provider-grid.tsx",
 		"utf8",
 	);
 	// Guards against the component drifting back to a single literal, which
 	// would leave the assertions above passing about code nothing renders.
 	assert.ok(
-		source.includes("providerLoadErrorMessage(providers.error)"),
+		grid.includes("providerLoadErrorMessage(providers.error)"),
 		"provider-grid no longer routes its error copy through providerLoadErrorMessage",
 	);
 	assert.ok(
-		!source.includes(UPDATE),
+		!grid.includes("may need an update"),
 		"provider-grid still hardcodes the update copy",
+	);
+
+	const banner = await readFile(
+		"src/renderer/src/shared/components/common/backend-compatibility-banner.tsx",
+		"utf8",
+	);
+	// The banner's own copy moved beside the classification so the two cannot
+	// drift. Re-inlining a sentence here is how they disagreed in the first
+	// place, and it would leave the agreement test above asserting nothing.
+	assert.ok(
+		banner.includes("backendCompatibilityMessage("),
+		"the banner no longer routes its copy through backendCompatibilityMessage",
+	);
+	assert.ok(
+		!banner.includes("older than the app expects"),
+		"the banner re-inlined its copy instead of sharing the classification",
 	);
 });

--- a/scripts/provider-grid-error-copy.test.mjs
+++ b/scripts/provider-grid-error-copy.test.mjs
@@ -99,8 +99,12 @@ test("the grid and the banner agree on the remedy for every status", () => {
 			unpaired: false,
 			answered: false,
 		});
-		const gridSaysUpdate = /update the backend|may need an update/i.test(grid);
-		const bannerSaysUpdate = /update|older than the app expects/i.test(banner);
+		// Matches the remedy's imperative and the diagnosis that licenses it. The
+		// diagnosis lost its "may" hedge (design D9) and the noun is now "server"
+		// everywhere (D7), so both spellings are the current shipped copy.
+		const gridSaysUpdate =
+			/update the server|older than this app expects/i.test(grid);
+		const bannerSaysUpdate = /update|older than this app expects/i.test(banner);
 		assert.equal(
 			gridSaysUpdate,
 			updateIsRemedy,
@@ -136,8 +140,11 @@ test("a rejected bearer is never told to install a newer backend", () => {
 test("an unreachable backend is reported as offline, not as needing an update", () => {
 	// `status: null` is what the transport raises when no backend was reached:
 	// a rejected IPC call, a dead dev proxy, or the stalled-request deadline.
+	// The remedy names an action the USER can take. "Retry once it has started."
+	// asked them to wait for an event they cannot cause, on the most common of
+	// the five conditions, while the app starts the server itself (design D5).
 	const OFFLINE =
-		"Providers could not be loaded. The backend is not answering. Retry once it has started.";
+		"Providers could not be loaded. The Local Operator server is not answering. Restart the app so it can start its own server.";
 	assert.equal(
 		providerLoadErrorMessage(new DesktopControlError(null, "unreachable")),
 		OFFLINE,
@@ -157,7 +164,7 @@ test("a capability-missing backend is the only case told to update", () => {
 	// contract. That is the one state a backend update actually repairs.
 	assert.equal(
 		providerLoadErrorMessage(new DesktopControlError(404, "no route")),
-		"Providers could not be loaded. The backend may need an update. Update the backend and try again.",
+		"Providers could not be loaded. The Local Operator server is older than this app expects. Update the server and try again.",
 	);
 });
 
@@ -185,6 +192,15 @@ test("both surfaces render the selected message rather than a hardcoded string",
 		!grid.includes("may need an update"),
 		"provider-grid still hardcodes the update copy",
 	);
+	// The grid's Retry must reflect the in-flight refetch. Asserted on the
+	// source because the flag is the whole finding: `isLoading` is false during
+	// a refetch of an errored query, so a component that reached for it would
+	// render an unchanged frame while passing any behavioural test that only
+	// checked for a disabled attribute somewhere.
+	assert.ok(
+		grid.includes("providers.isFetching"),
+		"provider-grid's Retry no longer reflects the in-flight refetch",
+	);
 
 	const banner = await readFile(
 		"src/renderer/src/shared/components/common/backend-compatibility-banner.tsx",
@@ -198,7 +214,72 @@ test("both surfaces render the selected message rather than a hardcoded string",
 		"the banner no longer routes its copy through backendCompatibilityMessage",
 	);
 	assert.ok(
-		!banner.includes("older than the app expects"),
+		!banner.includes("older than this app expects"),
 		"the banner re-inlined its copy instead of sharing the classification",
 	);
+});
+
+test("no surface asks the user to wait for an event they cannot cause", () => {
+	// Design D5. Every remedy must name a user action; "Retry once it has
+	// started" named an event with no agent, on the most common condition of the
+	// five, while the unauthorized string beside it says the app starts the
+	// server itself. `unknown` is the deliberate empty: no established remedy,
+	// so no sentence at all.
+	for (const [kind, remedy] of Object.entries(BACKEND_ERROR_REMEDY)) {
+		if (kind === "unknown") {
+			assert.equal(remedy, "", "unknown must assert no remedy");
+			continue;
+		}
+		assert.match(
+			remedy,
+			/^(Restart|Update) /,
+			`the ${kind} remedy "${remedy}" does not open with an action the user takes`,
+		);
+	}
+});
+
+test("one process, one name: no shipped sentence calls it 'the backend'", () => {
+	// Design D7. Three names for one process, two of them on screen together --
+	// the connectivity banner says "The server", these said "the backend". A PR
+	// whose purpose is that two surfaces stop contradicting each other must not
+	// leave them naming the subject differently in one viewport. "backend"
+	// survives only on the update BUTTON, which names an installable artifact.
+	const sentences = [
+		...Object.values(BACKEND_ERROR_REMEDY),
+		...STATUSES.map(({ status }) =>
+			bannerMessage(new DesktopControlError(status, "probe")),
+		),
+		...STATUSES.map(({ status }) =>
+			providerLoadErrorMessage(new DesktopControlError(status, "probe")),
+		),
+		backendCompatibilityMessage({
+			kind: "unknown",
+			unpaired: true,
+			missing: [],
+			answered: true,
+		}),
+		backendCompatibilityMessage({
+			kind: "unknown",
+			unpaired: false,
+			missing: ["settings"],
+			answered: true,
+		}),
+	];
+	for (const sentence of sentences) {
+		assert.doesNotMatch(
+			sentence,
+			/backend/i,
+			`"${sentence}" still calls the server "backend"`,
+		);
+	}
+});
+
+test("the outdated banner sentence has no dangling referent", () => {
+	// Design D4: extracting the remedy into the shared trailing sentence left
+	// "stay off until then" pointing at nothing -- the sentence before it names
+	// no time and no event. The consequence is now bound to the diagnosis.
+	const banner = bannerMessage(new DesktopControlError(404, "no route"));
+	assert.doesNotMatch(banner, /until then/);
+	assert.match(banner, /older than this app expects, so /);
+	assert.ok(banner.endsWith(BACKEND_ERROR_REMEDY.outdated));
 });

--- a/scripts/settings-time-to-error.test.mjs
+++ b/scripts/settings-time-to-error.test.mjs
@@ -1,0 +1,155 @@
+import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
+import { test } from "node:test";
+import { build } from "esbuild";
+
+// Reviewer M2 / QA Q1: bounding the transport made Settings terminate, but the
+// user still waited ~60s. `useConfig` inherited `retry: 1` from the query
+// client, so a stalled request paid the transport's ENTIRE 30s deadline, then
+// paid it again. A user who gave up at 45s before the fix gives up at 45s
+// after it, and reports issue 89 as unfixed.
+//
+// This test asserts the TIME, not merely that an error eventually appears. It
+// drives the shipped transport through the real React Query retry machinery,
+// with a real `window.api.desktop` bridge installed -- WITHOUT that bridge the
+// renderer takes its browser-dev HTTP branch, which never calls `withDeadline`,
+// so the measurement would be of a code path that does not ship.
+const bundle = await build({
+	stdin: {
+		contents: `
+			export * from "./src/renderer/src/shared/api/local-operator/desktop-api";
+			export { retryDesktopQuery } from "./src/renderer/src/shared/api/local-operator/backend-error";
+			export { QueryClient } from "@tanstack/react-query";
+		`,
+		resolveDir: process.cwd(),
+	},
+	bundle: true,
+	format: "esm",
+	platform: "neutral",
+	mainFields: ["module", "main"],
+	conditions: ["import"],
+	alias: { "@shared": "./src/renderer/src/shared" },
+	write: false,
+});
+const source = bundle.outputFiles[0].text;
+
+/**
+ * A fresh copy of the transport behind a REAL desktop bridge, so
+ * `desktopRequest` takes the Electron IPC branch that ships rather than the
+ * browser-dev `fetch` branch. A fresh copy per test keeps the module-level
+ * deadline constant from leaking timer state between cases.
+ */
+async function loadWithBridge(request) {
+	globalThis.window = { api: { desktop: { request } } };
+	return import(
+		`data:text/javascript;base64,${Buffer.from(source).toString("base64")}#${Math.random()}`
+	);
+}
+
+/**
+ * Time how long a caller waits before it can render an actionable error,
+ * fetching through React Query exactly as `useConfig` does: same retry
+ * predicate, and `desktopResult`, which throws on non-2xx so the retry
+ * machinery genuinely engages.
+ */
+async function timeToError(bridge, { retry }) {
+	const { desktopResult, retryDesktopQuery, QueryClient } =
+		await loadWithBridge(bridge);
+	const client = new QueryClient();
+	let attempts = 0;
+	const started = Date.now();
+	let error;
+	try {
+		await client.fetchQuery({
+			queryKey: ["config"],
+			queryFn: () => {
+				attempts += 1;
+				return desktopResult({ op: "config.get" });
+			},
+			retry: retry === "shipped" ? retryDesktopQuery : retry,
+			// The client's real backoff is short next to a 30s deadline; pinning it
+			// keeps the measurement about the deadline rather than about jitter.
+			retryDelay: 10,
+		});
+	} catch (caught) {
+		error = caught;
+	}
+	client.clear();
+	return { elapsed: Date.now() - started, attempts, error };
+}
+
+/** Never answers: the exact issue-89 fault, and the shape main cannot report. */
+const NEVER_REPLIES = () => new Promise(() => {});
+/** A backend that answered and refused; a genuine transient worth one retry. */
+const ANSWERS_503 = async () => ({
+	status: 503,
+	body: { detail: "The backend could not complete this request." },
+});
+
+// The budget a user is asked to wait before they are given something to do.
+// Chosen against the transport's own 30s deadline plus headroom for the
+// rejection to propagate, NOT against the ~60s the retry used to cost.
+const ACTIONABLE_WITHIN_MS = 35000;
+
+test("a stalled config load reaches an actionable error within one deadline, not two", async () => {
+	const { elapsed, attempts, error } = await timeToError(NEVER_REPLIES, {
+		retry: "shipped",
+	});
+
+	assert.ok(error, "a stalled load must settle into an error a user can act on");
+	// The measurement that matters: one deadline, not two. At `retry: 1` this
+	// is ~60s, which is the symptom the issue was reported for.
+	assert.ok(
+		elapsed < ACTIONABLE_WITHIN_MS,
+		`took ${elapsed}ms to reach an actionable error; budget is ${ACTIONABLE_WITHIN_MS}ms`,
+	);
+	// Stated separately from the time so a future change that makes the deadline
+	// itself shorter cannot hide a reinstated retry.
+	assert.equal(
+		attempts,
+		1,
+		"a deadline rejection was retried: the full budget is being paid twice",
+	);
+	assert.equal(error.status, null);
+});
+
+test("a backend that answers is still retried, because a 503 can be transient", async () => {
+	// The retry is suppressed for "we waited and heard nothing", not for
+	// "something answered and refused". Dropping the retry wholesale would lose
+	// a real recovery, so the predicate has to distinguish the two.
+	const { attempts, error } = await timeToError(ANSWERS_503, {
+		retry: "shipped",
+	});
+
+	assert.equal(attempts, 2, "a 503 from a reachable backend must still retry");
+	assert.equal(error.status, 503);
+});
+
+test("the queries a user waits on actually use the predicate", async () => {
+	// The timings above prove the predicate works. They do not prove anything
+	// consumes it, and a query that silently inherits `retry: 1` from the client
+	// default pays the doubled wait no matter how correct the predicate is.
+	for (const path of [
+		"src/renderer/src/shared/hooks/use-config.ts",
+		"src/renderer/src/shared/api/local-operator/desktop-hooks.ts",
+	]) {
+		const source = await readFile(path, "utf8");
+		assert.ok(
+			source.includes("retry: retryDesktopQuery"),
+			`${path} no longer sets retry: retryDesktopQuery, so it inherits the doubled wait`,
+		);
+	}
+});
+
+test("the old behaviour would have exceeded the budget", async () => {
+	// The mutation check, run as a test rather than by hand: with the inherited
+	// `retry: 1` the same stall pays the deadline twice and blows the budget.
+	// If this ever passes, the budget is no longer measuring anything.
+	const { elapsed, attempts } = await timeToError(NEVER_REPLIES, { retry: 1 });
+
+	assert.equal(attempts, 2);
+	assert.ok(
+		elapsed > ACTIONABLE_WITHIN_MS,
+		`the pre-fix path took ${elapsed}ms, which no longer exceeds the ${ACTIONABLE_WITHIN_MS}ms budget`,
+	);
+});

--- a/src/renderer/src/features/providers/provider-grid.tsx
+++ b/src/renderer/src/features/providers/provider-grid.tsx
@@ -17,7 +17,11 @@ import { Search, X } from "lucide-react";
 import type { FC } from "react";
 import { useEffect, useMemo, useState } from "react";
 import { ProviderDetail } from "./provider-detail";
-import { providerMethodLabel, providerReadiness } from "./provider-labels";
+import {
+	providerLoadErrorMessage,
+	providerMethodLabel,
+	providerReadiness,
+} from "./provider-labels";
 
 const SEARCH_THRESHOLD = 6;
 
@@ -71,9 +75,7 @@ export const ProviderGrid: FC<ProviderGridProps> = ({
 		return (
 			<Alert variant="warning">
 				<div className="flex items-center justify-between gap-3">
-					<span>
-						Providers could not be loaded. The backend may need an update.
-					</span>
+					<span>{providerLoadErrorMessage(providers.error)}</span>
 					{/* A load error is transient; Retry re-asks the backend. */}
 					<Button
 						variant="secondary"

--- a/src/renderer/src/features/providers/provider-grid.tsx
+++ b/src/renderer/src/features/providers/provider-grid.tsx
@@ -76,13 +76,22 @@ export const ProviderGrid: FC<ProviderGridProps> = ({
 			<Alert variant="warning">
 				<div className="flex items-center justify-between gap-3">
 					<span>{providerLoadErrorMessage(providers.error)}</span>
-					{/* A load error is transient; Retry re-asks the backend. */}
+					{/* A load error is transient; Retry re-asks the server.
+
+					    `isFetching`, not `isLoading`: a refetch of an already-errored
+					    query keeps `status: "error"`, so this branch (evaluated after
+					    `isLoading`) keeps winning and the frame would not change for
+					    the transport's whole deadline. A recovery affordance that does
+					    not acknowledge the click is the one users press four times and
+					    then relaunch. */}
 					<Button
 						variant="secondary"
 						size="sm"
+						className="shrink-0"
 						onClick={() => void providers.refetch()}
+						disabled={providers.isFetching}
 					>
-						Retry
+						{providers.isFetching ? "Retrying" : "Retry"}
 					</Button>
 				</div>
 			</Alert>

--- a/src/renderer/src/features/providers/provider-labels.ts
+++ b/src/renderer/src/features/providers/provider-labels.ts
@@ -8,10 +8,7 @@
  * sign-in for providers that have no such flow.
  */
 
-import {
-	BACKEND_ERROR_REMEDY,
-	backendErrorKind,
-} from "@shared/api/local-operator/backend-error";
+import { backendLoadErrorMessage } from "@shared/api/local-operator/backend-error";
 import type {
 	AuthOperation,
 	ProviderMethod,
@@ -94,18 +91,6 @@ export function providerReadiness(provider: {
 	return { label: "Needs sign-in", tone: "neutral", group: "Needs sign-in" };
 }
 
-/** What the grid says the backend is doing, per classified outcome. */
-const PROVIDER_LOAD_DIAGNOSIS = {
-	unreachable: "The backend is not answering.",
-	unauthorized: "This app cannot authenticate to the running backend.",
-	outdated: "The backend may need an update.",
-	// No remedy is asserted for a status we have not established one for. The
-	// previous fallback WAS the update sentence, so every unmatched status --
-	// including a 500 from a backend that is running and current -- was answered
-	// with a several-minute install.
-	unknown: "",
-} as const;
-
 /**
  * Whether the hosting picker may offer this provider without a "requires
  * additional credentials" warning. Same fact the grid uses: anything that
@@ -140,25 +125,21 @@ export function readyHostingIds(
 /**
  * What to tell the user when the provider list fails to load.
  *
- * The remedy comes from the shared classification rather than a second `if`
- * over the same status field, because the grid and the compatibility banner
- * previously disagreed: at 401/403 the banner said restart-and-re-pair and
- * withheld its update button, while the grid's two-way split dropped those
- * statuses into its `else` and told the user to install a newer backend --
- * which cannot fix a bearer the running backend refuses. Both surfaces now end
- * on the identical remedy sentence from `BACKEND_ERROR_REMEDY`; only the
- * diagnosis is phrased for this surface, which speaks about providers rather
- * than about the whole app.
+ * The diagnosis and the remedy both come from the shared classification rather
+ * than a second `if` over the same status field, because the grid and the
+ * compatibility banner previously disagreed: at 401/403 the banner said
+ * restart-and-re-pair and withheld its update button, while the grid's two-way
+ * split dropped those statuses into its `else` and told the user to install a
+ * newer server -- which cannot fix a bearer the running one refuses.
+ *
+ * This surface's only contribution is the lead sentence, because it speaks
+ * about providers rather than about the whole app. The grid used to own a
+ * private diagnosis table beside the shared remedy, which let the two halves
+ * of one sentence drift apart in wording and in confidence; keeping the split
+ * at "scope" rather than at "diagnosis" is what stops that.
  */
 export function providerLoadErrorMessage(error: unknown): string {
-	const kind = backendErrorKind(error);
-	return [
-		"Providers could not be loaded.",
-		PROVIDER_LOAD_DIAGNOSIS[kind],
-		BACKEND_ERROR_REMEDY[kind],
-	]
-		.filter(Boolean)
-		.join(" ");
+	return backendLoadErrorMessage("Providers could not be loaded.", error);
 }
 
 /** Terminal states after which polling an auth operation must stop. */

--- a/src/renderer/src/features/providers/provider-labels.ts
+++ b/src/renderer/src/features/providers/provider-labels.ts
@@ -9,9 +9,12 @@
  */
 
 import {
-	type AuthOperation,
-	DesktopControlError,
-	type ProviderMethod,
+	BACKEND_ERROR_REMEDY,
+	backendErrorKind,
+} from "@shared/api/local-operator/backend-error";
+import type {
+	AuthOperation,
+	ProviderMethod,
 } from "@shared/api/local-operator/desktop-api";
 
 export function providerMethodLabel(
@@ -91,6 +94,18 @@ export function providerReadiness(provider: {
 	return { label: "Needs sign-in", tone: "neutral", group: "Needs sign-in" };
 }
 
+/** What the grid says the backend is doing, per classified outcome. */
+const PROVIDER_LOAD_DIAGNOSIS = {
+	unreachable: "The backend is not answering.",
+	unauthorized: "This app cannot authenticate to the running backend.",
+	outdated: "The backend may need an update.",
+	// No remedy is asserted for a status we have not established one for. The
+	// previous fallback WAS the update sentence, so every unmatched status --
+	// including a 500 from a backend that is running and current -- was answered
+	// with a several-minute install.
+	unknown: "",
+} as const;
+
 /**
  * Whether the hosting picker may offer this provider without a "requires
  * additional credentials" warning. Same fact the grid uses: anything that
@@ -125,24 +140,25 @@ export function readyHostingIds(
 /**
  * What to tell the user when the provider list fails to load.
  *
- * The grid used to assert "the backend may need an update" for every error,
- * including a backend that was not running at all. That is the wrong remedy:
- * updating cannot start a stopped process, and it sends the user through a
- * several-minute install to arrive back at the same failure. This draws the
- * same distinction the compatibility banner already draws from the same field,
- * so the two surfaces never disagree about what is wrong.
- *
- * 404 is the only status an update fixes: the route is absent, so the backend
- * predates the desktop contract. `null` means no backend was reached (rejected
- * IPC, dead dev proxy, or the transport's stalled-request deadline) and 503 is
- * the main process's own "could not complete this request". Any other status
- * keeps the generic sentence rather than guessing at a remedy.
+ * The remedy comes from the shared classification rather than a second `if`
+ * over the same status field, because the grid and the compatibility banner
+ * previously disagreed: at 401/403 the banner said restart-and-re-pair and
+ * withheld its update button, while the grid's two-way split dropped those
+ * statuses into its `else` and told the user to install a newer backend --
+ * which cannot fix a bearer the running backend refuses. Both surfaces now end
+ * on the identical remedy sentence from `BACKEND_ERROR_REMEDY`; only the
+ * diagnosis is phrased for this surface, which speaks about providers rather
+ * than about the whole app.
  */
 export function providerLoadErrorMessage(error: unknown): string {
-	const status = error instanceof DesktopControlError ? error.status : null;
-	return status === null || status === 503
-		? "Providers could not be loaded. The backend is not answering. Retry once it has started."
-		: "Providers could not be loaded. The backend may need an update.";
+	const kind = backendErrorKind(error);
+	return [
+		"Providers could not be loaded.",
+		PROVIDER_LOAD_DIAGNOSIS[kind],
+		BACKEND_ERROR_REMEDY[kind],
+	]
+		.filter(Boolean)
+		.join(" ");
 }
 
 /** Terminal states after which polling an auth operation must stop. */

--- a/src/renderer/src/features/providers/provider-labels.ts
+++ b/src/renderer/src/features/providers/provider-labels.ts
@@ -8,9 +8,10 @@
  * sign-in for providers that have no such flow.
  */
 
-import type {
-	AuthOperation,
-	ProviderMethod,
+import {
+	type AuthOperation,
+	DesktopControlError,
+	type ProviderMethod,
 } from "@shared/api/local-operator/desktop-api";
 
 export function providerMethodLabel(
@@ -119,6 +120,29 @@ export function readyHostingIds(
 			.filter((provider) => hostingProviderSelectable(provider))
 			.map((provider) => provider.id),
 	);
+}
+
+/**
+ * What to tell the user when the provider list fails to load.
+ *
+ * The grid used to assert "the backend may need an update" for every error,
+ * including a backend that was not running at all. That is the wrong remedy:
+ * updating cannot start a stopped process, and it sends the user through a
+ * several-minute install to arrive back at the same failure. This draws the
+ * same distinction the compatibility banner already draws from the same field,
+ * so the two surfaces never disagree about what is wrong.
+ *
+ * 404 is the only status an update fixes: the route is absent, so the backend
+ * predates the desktop contract. `null` means no backend was reached (rejected
+ * IPC, dead dev proxy, or the transport's stalled-request deadline) and 503 is
+ * the main process's own "could not complete this request". Any other status
+ * keeps the generic sentence rather than guessing at a remedy.
+ */
+export function providerLoadErrorMessage(error: unknown): string {
+	const status = error instanceof DesktopControlError ? error.status : null;
+	return status === null || status === 503
+		? "Providers could not be loaded. The backend is not answering. Retry once it has started."
+		: "Providers could not be loaded. The backend may need an update.";
 }
 
 /** Terminal states after which polling an auth operation must stop. */

--- a/src/renderer/src/features/settings/components/backend-settings-section.tsx
+++ b/src/renderer/src/features/settings/components/backend-settings-section.tsx
@@ -12,6 +12,7 @@
  * BackendSettingRow for that contract.
  */
 
+import { backendLoadErrorMessage } from "@shared/api/local-operator/backend-error";
 import { desktopResult } from "@shared/api/local-operator/desktop-api";
 import type {
 	BackendSetting,
@@ -115,13 +116,23 @@ export const BackendSettingsSection: FC<BackendSettingsSectionProps> = ({
 	if (capabilities.data && !enabled) {
 		return (
 			<Alert variant="warning">
-				Searchable backend settings need a newer Local Operator backend. Update
-				the backend and restart the app to manage these settings here.
+				Searchable settings need a newer Local Operator server. Update the
+				server and restart the app to manage these settings here.
 			</Alert>
 		);
 	}
 
-	if (query.isLoading) {
+	/*
+	 * This query is `enabled` only once capabilities negotiate, and a DISABLED
+	 * React Query reports `isLoading: false` with no data -- so while
+	 * capabilities are still in flight, and permanently once they FAIL, this
+	 * section fell through the loading gate into its error branch. It then
+	 * rendered its own hand-written "the backend may need an update", the one
+	 * remedy that cannot fix an unreachable or unauthenticated server, directly
+	 * beneath a banner saying the opposite. Gating on the capabilities query
+	 * too is what makes the states below mean what they say.
+	 */
+	if (query.isLoading || capabilities.isLoading) {
 		return (
 			<div className="flex h-40 items-center justify-center">
 				<Spinner size="lg" label="Loading settings" />
@@ -129,19 +140,40 @@ export const BackendSettingsSection: FC<BackendSettingsSectionProps> = ({
 		);
 	}
 
-	if (query.isError || !settings || !filtered) {
+	// Whichever query actually failed carries the status worth classifying:
+	// capabilities failing is why this one never ran, so its error is the real
+	// diagnosis rather than the absence of data it produced downstream.
+	const loadError = capabilities.error ?? query.error;
+	if (loadError || !settings || !filtered) {
+		const retrying = capabilities.isFetching || query.isFetching;
 		return (
 			<Alert variant="warning">
 				<div className="flex items-center justify-between gap-3">
+					{/* Same classifier, same remedy sentence as the compatibility banner
+					    and the providers grid. Nothing about this surface makes its
+					    diagnosis of the server different from theirs. */}
 					<span>
-						Settings could not be loaded. The backend may need an update.
+						{backendLoadErrorMessage(
+							"Your settings could not be loaded.",
+							loadError,
+						)}
 					</span>
+					{/* `isFetching` on both, because either query may be the one
+					    in flight; an errored query keeps `status: "error"` through its
+					    refetch, so without this the click changes nothing on screen. */}
 					<Button
 						variant="secondary"
 						size="sm"
-						onClick={() => void query.refetch()}
+						className="shrink-0"
+						onClick={() => {
+							// Capabilities gate this query, so re-asking only the gated one
+							// would leave it disabled and the click inert.
+							if (capabilities.isError) void capabilities.refetch();
+							else void query.refetch();
+						}}
+						disabled={retrying}
 					>
-						Retry
+						{retrying ? "Retrying" : "Retry"}
 					</Button>
 				</div>
 			</Alert>

--- a/src/renderer/src/features/settings/components/backend-settings-section.tsx
+++ b/src/renderer/src/features/settings/components/backend-settings-section.tsx
@@ -143,7 +143,17 @@ export const BackendSettingsSection: FC<BackendSettingsSectionProps> = ({
 	// Whichever query actually failed carries the status worth classifying:
 	// capabilities failing is why this one never ran, so its error is the real
 	// diagnosis rather than the absence of data it produced downstream.
-	const loadError = capabilities.error ?? query.error;
+	//
+	// Only when it left NO data behind, though. React Query keeps `data` and
+	// `error` set together after a failed refetch of a query that had already
+	// succeeded, so a capabilities error is not by itself evidence that this
+	// section has nothing to render. Treating it as fatal regardless replaced a
+	// fully-loaded page with an error banner on any background refetch failure
+	// -- reachable by alt-tabbing back after `staleTime` (60s) lapses -- and
+	// unmounting the rows destroys the unsaved drafts the header promises will
+	// survive failures.
+	const loadError =
+		(capabilities.data ? null : capabilities.error) ?? query.error;
 	if (loadError || !settings || !filtered) {
 		const retrying = capabilities.isFetching || query.isFetching;
 		return (
@@ -166,8 +176,12 @@ export const BackendSettingsSection: FC<BackendSettingsSectionProps> = ({
 						size="sm"
 						className="shrink-0"
 						onClick={() => {
-							// Capabilities gate this query, so re-asking only the gated one
-							// would leave it disabled and the click inert.
+							// Retry what actually broke. On the gated path capabilities are
+							// the fault and the reason this query never ran, so re-asking
+							// only the gated query would re-fail against the same unfixed
+							// cause without ever retrying it. (`refetch()` on a disabled
+							// query does fire its queryFn -- measured on query-core 5.73.3 --
+							// so the click would not be inert, merely pointless.)
 							if (capabilities.isError) void capabilities.refetch();
 							else void query.refetch();
 						}}

--- a/src/renderer/src/features/settings/components/settings-page.tsx
+++ b/src/renderer/src/features/settings/components/settings-page.tsx
@@ -672,6 +672,40 @@ export const SettingsPage: FC = () => {
 	// Combine loading states
 	const isLoading = isConfigLoading || isAuthLoading;
 
+	// The error branch below is only reachable if the config query actually
+	// settles. The renderer transport now bounds every desktop control, so a
+	// stalled request rejects instead of pending forever -- but the spinner is
+	// still the LAST state a user sees when something upstream of it stalls, and
+	// an unrecoverable spinner leaves them with nothing to do but relaunch. So
+	// the error state is preferred over the spinner once the config query has
+	// failed, rather than being gated behind it: `isAuthLoading` alone must not
+	// hold the page on a spinner when the settings it is loading can no longer
+	// arrive. That ordering is what makes the recovery affordance reachable.
+	if (configError) {
+		return (
+			<div className="flex h-full w-full items-center justify-center bg-canvas p-6">
+				<Alert variant="danger" className="w-full max-w-xl">
+					<div className="flex items-center justify-between gap-3">
+						<span>
+							Could not load your settings. The Local Operator server may not be
+							running. {configError.message}
+						</span>
+						{/* Same recovery the providers grid offers: re-ask the backend in
+						    place, so a transient stall does not cost a relaunch. */}
+						<Button
+							variant="secondary"
+							size="sm"
+							className="shrink-0"
+							onClick={() => void refetch()}
+						>
+							Retry
+						</Button>
+					</div>
+				</Alert>
+			</div>
+		);
+	}
+
 	if (isLoading) {
 		return (
 			<div className="flex h-full w-full items-center justify-center bg-canvas">
@@ -680,12 +714,12 @@ export const SettingsPage: FC = () => {
 		);
 	}
 
-	if (configError || !config) {
+	if (!config) {
 		return (
 			<div className="flex h-full w-full items-center justify-center bg-canvas p-6">
 				<Alert variant="danger" className="w-full max-w-xl">
 					Could not load your settings. The Local Operator server may not be
-					running. {configError?.message}
+					running.
 				</Alert>
 			</div>
 		);

--- a/src/renderer/src/features/settings/components/settings-page.tsx
+++ b/src/renderer/src/features/settings/components/settings-page.tsx
@@ -1,5 +1,6 @@
 import { useOnboardingTour } from "@features/onboarding/hooks/use-onboarding-tour";
 import { ProviderGrid } from "@features/providers/provider-grid";
+import { backendLoadErrorMessage } from "@shared/api/local-operator/backend-error";
 import type { ConfigUpdate } from "@shared/api/local-operator/types";
 import { EditableField } from "@shared/components/common/editable-field";
 import { PageHeader } from "@shared/components/common/page-header";
@@ -327,6 +328,7 @@ export const SettingsPage: FC = () => {
 	const {
 		data: config,
 		isLoading: isConfigLoading,
+		isFetching: isConfigFetching,
 		error: configError,
 		refetch,
 	} = useConfig();
@@ -689,21 +691,44 @@ export const SettingsPage: FC = () => {
 	if (configError) {
 		return (
 			<div className="flex h-full w-full items-center justify-center bg-canvas p-6">
-				<Alert variant="danger" className="w-full max-w-xl">
+				{/* `warning`, matching the providers grid: one fault must not render
+				    at two severities depending on which screen reports it, and a
+				    failure with a Retry beside it has cost the user nothing. The rule
+				    is stated beside the shared copy in `backend-error.ts`. */}
+				<Alert variant="warning" className="w-full max-w-xl">
 					<div className="flex items-center justify-between gap-3">
+						{/* Classified from the SAME error the banner above reads, so this
+						    page can no longer say the server "may not be running" while
+						    the banner says it is offline -- or tell a 401 user to wait for
+						    a server that is already running and refusing this app's
+						    bearer. The raw exception ("Get config request failed: 503")
+						    used to render here; it names a function, a transport verb and
+						    an integer, none of which change what the user does next, so it
+						    stays on `error.message` for logs and support and out of the
+						    sentence. */}
 						<span>
-							Could not load your settings. The Local Operator server may not be
-							running. {configError.message}
+							{backendLoadErrorMessage(
+								"Your settings could not be loaded.",
+								configError,
+							)}
 						</span>
-						{/* Same recovery the providers grid offers: re-ask the backend in
-						    place, so a transient stall does not cost a relaunch. */}
+						{/* Same recovery the providers grid offers: re-ask the server in
+						    place, so a transient stall does not cost a relaunch.
+
+						    `isFetching`, not `isLoading`: refetching an ERRORED query
+						    leaves `status: "error"`, so `isLoading` stays false and this
+						    branch keeps rendering for the transport's whole 30s deadline.
+						    Without a pending state the frame is pixel-identical after the
+						    click -- issue 89's own "I cannot tell whether this is working
+						    or hung", one click downstream of its fix. */}
 						<Button
 							variant="secondary"
 							size="sm"
 							className="shrink-0"
 							onClick={() => void refetch()}
+							disabled={isConfigFetching}
 						>
-							Retry
+							{isConfigFetching ? "Retrying" : "Retry"}
 						</Button>
 					</div>
 				</Alert>
@@ -735,9 +760,12 @@ export const SettingsPage: FC = () => {
 	if (!config) {
 		return (
 			<div className="flex h-full w-full items-center justify-center bg-canvas p-6">
-				<Alert variant="danger" className="w-full max-w-xl">
-					Could not load your settings. The Local Operator server may not be
-					running.
+				{/* Settled with no error and no config: nothing classified it, so
+				    there is no status to advise on and no remedy to assert. Same
+				    discipline as the classifier's `unknown` -- state the failure and
+				    stop rather than guessing an action that may not fix it. */}
+				<Alert variant="warning" className="w-full max-w-xl">
+					Your settings could not be loaded.
 				</Alert>
 			</div>
 		);

--- a/src/renderer/src/features/settings/components/settings-page.tsx
+++ b/src/renderer/src/features/settings/components/settings-page.tsx
@@ -738,19 +738,46 @@ export const SettingsPage: FC = () => {
 
 	if (isLoading) {
 		return (
-			<div className="flex h-full w-full flex-col items-center justify-center gap-3 bg-canvas">
-				<Spinner size="lg" label="Loading settings" />
+			/*
+			 * One live region around the whole waiting stack, so the caption IS the
+			 * announcement when it appears.
+			 *
+			 * The caption previously sat outside the spinner's own `role="status"`,
+			 * so a screen-reader user heard "Loading settings" once at mount and
+			 * then nothing for up to 30s -- while a sighted user got a visible state
+			 * change at 4s telling them the app was alive. Under
+			 * `prefers-reduced-motion` the global cap freezes the ring, so that user
+			 * had no liveness signal at all. The text whose entire purpose is "you
+			 * cannot tell waiting from hung" was reaching only the users who could
+			 * already tell.
+			 *
+			 * `label` drops off the `Spinner` once the caption paints, per the
+			 * component's own contract: standalone spinner -> pass `label`; spinner
+			 * beside its own caption -> omit it, or the same fact is announced
+			 * twice.
+			 */
+			// biome-ignore lint/a11y/useSemanticElements: there is no semantic element for a polite live region; role=status on the container is the pattern.
+			<div
+				role="status"
+				className="flex h-full w-full flex-col items-center justify-center gap-3 bg-canvas"
+			>
+				<Spinner
+					size="lg"
+					label={isSlowLoad ? undefined : "Loading settings"}
+				/>
 				{/* A bounded wait is still a silent one. Until the deadline expires
 				    this spinner is pixel-identical to the unrecoverable spinner of
 				    issue 89, so a user cannot tell "waiting" from "hung" and gives
-				    up before the error state they were promised can render. Saying
-				    what is being waited on, and that it will end, is the difference
-				    between a slow app and a broken one. Only after the threshold:
-				    on a healthy load this never paints. */}
+				    up before the error state they were promised can render. Only
+				    after the threshold: on a healthy load this never paints.
+
+				    The copy states an event in the user's terms and what they get,
+				    rather than narrating the app's control flow ("This will stop and
+				    offer a retry"), which made the machinery the subject. */}
 				{isSlowLoad && (
 					<p className="max-w-sm text-center text-body-sm text-ink-muted">
-						Still waiting for the Local Operator server. This will stop and
-						offer a retry if it does not respond.
+						The Local Operator server is taking longer than usual to answer. If
+						it does not respond, you will be able to retry from here.
 					</p>
 				)}
 			</div>

--- a/src/renderer/src/features/settings/components/settings-page.tsx
+++ b/src/renderer/src/features/settings/components/settings-page.tsx
@@ -13,6 +13,7 @@ import { Alert, Button, Skeleton } from "@shared/components/ui";
 import { useConfig } from "@shared/hooks/use-config";
 import { useCredentials } from "@shared/hooks/use-credentials";
 import { useCreditBalance } from "@shared/hooks/use-credit-balance";
+import { useElapsedSince } from "@shared/hooks/use-elapsed-since";
 import { useModels } from "@shared/hooks/use-models";
 import { useRadientUserQuery } from "@shared/hooks/use-radient-user-query";
 import { useUpdateConfig } from "@shared/hooks/use-update-config";
@@ -671,6 +672,10 @@ export const SettingsPage: FC = () => {
 
 	// Combine loading states
 	const isLoading = isConfigLoading || isAuthLoading;
+	// Well inside the transport's 30s deadline, so the explanation appears while
+	// the user is still deciding whether the app is stuck rather than after they
+	// have concluded it is.
+	const isSlowLoad = useElapsedSince(isLoading, 4000);
 
 	// The error branch below is only reachable if the config query actually
 	// settles. The renderer transport now bounds every desktop control, so a
@@ -708,8 +713,21 @@ export const SettingsPage: FC = () => {
 
 	if (isLoading) {
 		return (
-			<div className="flex h-full w-full items-center justify-center bg-canvas">
+			<div className="flex h-full w-full flex-col items-center justify-center gap-3 bg-canvas">
 				<Spinner size="lg" label="Loading settings" />
+				{/* A bounded wait is still a silent one. Until the deadline expires
+				    this spinner is pixel-identical to the unrecoverable spinner of
+				    issue 89, so a user cannot tell "waiting" from "hung" and gives
+				    up before the error state they were promised can render. Saying
+				    what is being waited on, and that it will end, is the difference
+				    between a slow app and a broken one. Only after the threshold:
+				    on a healthy load this never paints. */}
+				{isSlowLoad && (
+					<p className="max-w-sm text-center text-body-sm text-ink-muted">
+						Still waiting for the Local Operator server. This will stop and
+						offer a retry if it does not respond.
+					</p>
+				)}
 			</div>
 		);
 	}

--- a/src/renderer/src/shared/api/local-operator/backend-error.ts
+++ b/src/renderer/src/shared/api/local-operator/backend-error.ts
@@ -1,0 +1,182 @@
+/**
+ * One classification of "what is wrong with the backend", and one sentence per
+ * outcome, shared by every surface that reports it.
+ *
+ * Two surfaces read the same `DesktopControlError.status` and each drew its own
+ * conclusion from it. The compatibility banner split it three ways; the
+ * providers grid split it two, so a rejected bearer (401/403) fell into the
+ * grid's `else` and told the user "the backend may need an update" while the
+ * banner told them to restart and re-pair -- and deliberately withheld its
+ * update button, because installing a newer backend cannot fix a bearer the
+ * running one refuses. Sending a user through a several-minute install that
+ * cannot repair their fault is the exact defect this change set exists to
+ * remove; it had simply moved from "offline" to "unauthorized".
+ *
+ * The fix is structural rather than a third copy of the same `if`: the status
+ * is classified ONCE here, and both surfaces render sentences that also live
+ * here. Neither can drift from the other without changing this file, and the
+ * agreement is assertable because both selectors are plain functions.
+ */
+
+import { DesktopControlError } from "./desktop-api";
+
+/**
+ * What a failed desktop control says about the backend, in terms of the ONE
+ * thing the user has to do about it.
+ *
+ * Deliberately named for the user's remedy rather than the HTTP status,
+ * because the remedy is what the two surfaces disagreed about. `unknown` is a
+ * real member, not a default: it means the status matched no case we can
+ * advise on, and the copy for it must therefore assert no remedy at all.
+ */
+export type BackendErrorKind =
+	| "unreachable"
+	| "unauthorized"
+	| "outdated"
+	| "unknown";
+
+/**
+ * Classify a desktop control failure by the remedy it calls for.
+ *
+ * - `null` means the request produced no HTTP status: a rejected IPC call, a
+ *   dead dev proxy, or the transport's stalled-request deadline. No backend
+ *   was reached.
+ * - 503 is the main process's own "could not complete this request", which is
+ *   what a backend that is down or refusing work produces.
+ * - 401/403 mean a backend answered and refused this app's bearer, so it is
+ *   running and current -- only the pairing is broken.
+ * - 404 means the route is absent, so this backend predates the desktop
+ *   contract. It is the ONLY status a backend update repairs.
+ *
+ * Anything else is `unknown` on purpose. The previous fallback asserted the
+ * update remedy for every unmatched status, so a 500 -- a backend that is
+ * running, current and merely erroring -- was answered with an install.
+ */
+export function backendErrorKind(error: unknown): BackendErrorKind {
+	const status = error instanceof DesktopControlError ? error.status : null;
+	if (status === null || status === 503) return "unreachable";
+	if (status === 401 || status === 403) return "unauthorized";
+	if (status === 404) return "outdated";
+	return "unknown";
+}
+
+/**
+ * The action sentence for each outcome, shared verbatim by every surface.
+ *
+ * `unknown` carries no remedy because we have not established one; a surface
+ * renders its diagnosis alone rather than guessing. That is the status-neutral
+ * fallback the two-way split lacked.
+ */
+export const BACKEND_ERROR_REMEDY: Record<BackendErrorKind, string> = {
+	unreachable: "Retry once it has started.",
+	unauthorized: "Restart the app so it starts and pairs with its own backend.",
+	outdated: "Update the backend and try again.",
+	unknown: "",
+};
+
+/**
+ * Whether installing a newer backend is actually the remedy.
+ *
+ * The banner gates its "Update backend" button on this. It is stated here
+ * beside the classification instead of as a chain of negated booleans at the
+ * call site, because "which states does update fix" is the same question the
+ * copy answers, and the button must not contradict the sentence above it.
+ *
+ * Takes the same inputs as `backendCompatibilityMessage` so the two are read
+ * off one state rather than two. `unpaired` is not status-derived -- it is a
+ * backend that answered fine while this app holds no bearer for it -- and a
+ * status only classifies anything when nothing answered, which is why
+ * `answered` gates the classification rather than being folded into it.
+ */
+export function backendUpdateIsRemedy(input: {
+	kind: BackendErrorKind;
+	unpaired: boolean;
+	answered: boolean;
+}): boolean {
+	const { kind, unpaired, answered } = input;
+	// Re-pairing, not installing, is what an unpaired backend needs.
+	if (unpaired) return false;
+	// A backend that answered and named the features it lacks is genuinely out
+	// of date; that is the negotiated case, not a guess from a missing payload.
+	if (answered) return true;
+	// `unknown` deliberately does NOT offer the update. It used to, because the
+	// fallback sentence was the update sentence, so every unmatched status was
+	// answered with an install that could not fix it.
+	return kind === "outdated";
+}
+
+/**
+ * The compatibility banner's sentence.
+ *
+ * Extracted from the component so the copy sits beside the classification that
+ * selects it, and so a test can assert the banner and the providers grid agree
+ * by calling both shipped selectors rather than restating either. The wording
+ * is unchanged from when it lived in the component: this reorganises where the
+ * decision is made, not what the user reads.
+ *
+ * The banner names the surfaces that stop working because it is the app-wide
+ * notice; the grid speaks only about providers. Both end on the same remedy
+ * sentence, which is the part that has to match.
+ */
+export function backendCompatibilityMessage(input: {
+	kind: BackendErrorKind;
+	/** A backend answered, but this app did not start it and holds no bearer. */
+	unpaired: boolean;
+	/** Negotiated features the backend does not advertise. */
+	missing: readonly string[];
+	/** True once a capabilities payload was received at all. */
+	answered: boolean;
+}): string {
+	const { kind, unpaired, missing, answered } = input;
+	if (!answered) {
+		if (kind === "unreachable")
+			return `The backend is not answering. Provider sign-in, settings, slash commands and MCP management need it running. ${BACKEND_ERROR_REMEDY.unreachable}`;
+		if (kind === "unauthorized")
+			return `This app cannot authenticate to the running backend, so protected controls are unavailable. ${BACKEND_ERROR_REMEDY.unauthorized}`;
+		if (kind === "outdated")
+			// The trailing clause was "stay off until it is updated", which said
+			// the remedy in a second set of words. Ending on the shared sentence
+			// instead is what lets a test assert the two surfaces agree by string
+			// rather than by a human reading both and judging them equivalent.
+			return `This backend is older than the app expects. Provider sign-in, settings, slash commands and MCP management stay off until then. ${BACKEND_ERROR_REMEDY.outdated}`;
+	}
+	if (unpaired)
+		return "This app is not paired with the running backend, so protected controls are unavailable. Restart the app so it can manage its own backend.";
+	if (!answered)
+		// Nothing answered and the status matched no case we can advise on. The
+		// old fallback claimed the backend was "missing" every negotiated feature
+		// -- inferred purely from the absence of a payload -- and offered an
+		// install, so a backend that was running, current and merely erroring got
+		// the same several-minute remedy as one that predates the contract. State
+		// the failure and stop.
+		return "Provider sign-in, settings, slash commands and MCP management are unavailable because the backend did not answer as expected.";
+	return `The backend is missing ${missing.join(", ")} support. Update it to enable those surfaces.`;
+}
+
+/**
+ * Whether a failed desktop query is worth asking again.
+ *
+ * React Query's default `retry: 1` charges the full renderer deadline twice for
+ * a request that never gets an answer: the stalled-IPC shape cost 30s, then
+ * another 30s, so a user watched an unbroken spinner for ~60s before the error
+ * state could render. That is the symptom issue 89 was reported for, merely
+ * bounded -- a user who gave up at 45s before still gives up at 45s.
+ *
+ * The distinction that matters is whether anything answered. A `status: null`
+ * failure means the deadline expired or the transport never reached a backend;
+ * we already waited the entire budget and learned nothing, and a second
+ * identical wait cannot learn more. Every other failure came from a backend
+ * that DID answer -- a 503 from a reachable process is a genuine transient --
+ * so those keep the default single retry.
+ */
+export function retryDesktopQuery(
+	failureCount: number,
+	// Typed as `Error` rather than `unknown` to match React Query's default
+	// `TError`: a wider parameter here makes the whole query's error type infer
+	// as `{}`, and callers lose `error.message`.
+	error: Error,
+): boolean {
+	if (error instanceof DesktopControlError && error.status === null)
+		return false;
+	return failureCount < 1;
+}

--- a/src/renderer/src/shared/api/local-operator/backend-error.ts
+++ b/src/renderer/src/shared/api/local-operator/backend-error.ts
@@ -66,13 +66,82 @@ export function backendErrorKind(error: unknown): BackendErrorKind {
  * `unknown` carries no remedy because we have not established one; a surface
  * renders its diagnosis alone rather than guessing. That is the status-neutral
  * fallback the two-way split lacked.
+ *
+ * Every sentence here names something the USER can do. `unreachable` used to
+ * read "Retry once it has started.", which is the most common of the five
+ * conditions and the only one that asked the user to wait for an event they
+ * have no way to cause -- while the `unauthorized` sentence beside it states
+ * plainly that the app starts the server itself (design D5). Restarting the
+ * app is the action that actually reaches the stated outcome.
+ *
+ * ## The noun is "the Local Operator server"
+ *
+ * One process, one name. These sentences render alongside the connectivity
+ * banner ("The server is offline.") and the providers header, and a viewport
+ * previously showed "server" and "backend" naming the same process (design
+ * D7). "backend" is the implementation's word; branding.md section 8 forbids a
+ * jargon noun where an everyday one works. Full name on a surface's first
+ * mention, "the server" thereafter -- which is why the diagnosis strings below
+ * carry the long form and these remedies carry the short one.
+ *
+ * The "Update backend" BUTTON keeps its label: it names a distinct installable
+ * artifact rather than the running process, and it is a control, not prose.
  */
 export const BACKEND_ERROR_REMEDY: Record<BackendErrorKind, string> = {
-	unreachable: "Retry once it has started.",
-	unauthorized: "Restart the app so it starts and pairs with its own backend.",
-	outdated: "Update the backend and try again.",
+	unreachable: "Restart the app so it can start its own server.",
+	unauthorized: "Restart the app so it starts and pairs with its own server.",
+	outdated: "Update the server and try again.",
 	unknown: "",
 };
+
+/**
+ * What each outcome says the server is doing, in the user's terms.
+ *
+ * Split from the remedy because a surface pairs its OWN lead sentence ("Your
+ * settings could not be loaded.", "Providers could not be loaded.") with this
+ * shared middle and the shared remedy above. The scope differs per surface;
+ * the diagnosis and the action must not.
+ *
+ * Empty for `unknown`, for the same reason the remedy is: a status we cannot
+ * advise on gets the surface's lead sentence and nothing more.
+ */
+export const BACKEND_ERROR_DIAGNOSIS: Record<BackendErrorKind, string> = {
+	unreachable: "The Local Operator server is not answering.",
+	unauthorized:
+		"This app cannot authenticate to the running Local Operator server.",
+	// "may need an update" hedged while the sentence after it issued a command
+	// (design D9). 404 on the desktop route is not a "may": it is the ONLY
+	// status an update repairs, and the confidence of the diagnosis has to match
+	// the confidence of the imperative.
+	outdated: "The Local Operator server is older than this app expects.",
+	unknown: "",
+};
+
+/**
+ * The sentence a surface renders when a load failed because of the server.
+ *
+ * `lead` is the only per-surface part -- what could not be loaded, in that
+ * surface's scope. Everything after it is shared, so two surfaces reporting
+ * one fault cannot describe it differently or point at different actions.
+ * That agreement is the whole point of this module, and routing every surface
+ * through one function is what makes it structural rather than a convention.
+ *
+ * ## Severity: these are `warning`, not `danger`
+ *
+ * Every surface that renders this string offers a Retry beside it, and none of
+ * the four outcomes has lost the user anything. Settings previously rendered
+ * `danger` while the providers grid rendered `warning` for the same underlying
+ * fact, so the hue encoded which screen you were on rather than how bad it was
+ * (design D8). branding.md section 2 authors four separable semantics so a user
+ * can read severity off hue; `danger` here is reserved for a failure the user
+ * cannot recover from in place.
+ */
+export function backendLoadErrorMessage(lead: string, error: unknown): string {
+	const kind = backendErrorKind(error);
+	return [lead, BACKEND_ERROR_DIAGNOSIS[kind], BACKEND_ERROR_REMEDY[kind]]
+		.filter(Boolean)
+		.join(" ");
+}
 
 /**
  * Whether installing a newer backend is actually the remedy.
@@ -130,18 +199,22 @@ export function backendCompatibilityMessage(input: {
 	const { kind, unpaired, missing, answered } = input;
 	if (!answered) {
 		if (kind === "unreachable")
-			return `The backend is not answering. Provider sign-in, settings, slash commands and MCP management need it running. ${BACKEND_ERROR_REMEDY.unreachable}`;
+			return `${BACKEND_ERROR_DIAGNOSIS.unreachable} Provider sign-in, settings, slash commands and MCP management need it running. ${BACKEND_ERROR_REMEDY.unreachable}`;
 		if (kind === "unauthorized")
-			return `This app cannot authenticate to the running backend, so protected controls are unavailable. ${BACKEND_ERROR_REMEDY.unauthorized}`;
+			// "protected controls are unavailable" was jargon two sentences away
+			// from this file's own plain list of the same surfaces (design D10).
+			return `This app cannot authenticate to the running Local Operator server, so provider sign-in, settings, slash commands and MCP management are unavailable. ${BACKEND_ERROR_REMEDY.unauthorized}`;
 		if (kind === "outdated")
-			// The trailing clause was "stay off until it is updated", which said
-			// the remedy in a second set of words. Ending on the shared sentence
-			// instead is what lets a test assert the two surfaces agree by string
-			// rather than by a human reading both and judging them equivalent.
-			return `This backend is older than the app expects. Provider sign-in, settings, slash commands and MCP management stay off until then. ${BACKEND_ERROR_REMEDY.outdated}`;
+			// The trailing clause read "stay off until then", whose antecedent left
+			// with the remedy when it was extracted into the shared sentence --
+			// nothing before it named a time or an event (design D4). Binding the
+			// consequence to the diagnosis with "so" removes the dangling referent
+			// rather than restating the remedy in a second set of words, which is
+			// what lets a test assert the two surfaces agree by string.
+			return `The Local Operator server is older than this app expects, so provider sign-in, settings, slash commands and MCP management are off. ${BACKEND_ERROR_REMEDY.outdated}`;
 	}
 	if (unpaired)
-		return "This app is not paired with the running backend, so protected controls are unavailable. Restart the app so it can manage its own backend.";
+		return "This app is not paired with the running Local Operator server, so provider sign-in, settings, slash commands and MCP management are unavailable. Restart the app so it can manage its own server.";
 	if (!answered)
 		// Nothing answered and the status matched no case we can advise on. The
 		// old fallback claimed the backend was "missing" every negotiated feature
@@ -149,8 +222,8 @@ export function backendCompatibilityMessage(input: {
 		// install, so a backend that was running, current and merely erroring got
 		// the same several-minute remedy as one that predates the contract. State
 		// the failure and stop.
-		return "Provider sign-in, settings, slash commands and MCP management are unavailable because the backend did not answer as expected.";
-	return `The backend is missing ${missing.join(", ")} support. Update it to enable those surfaces.`;
+		return "Provider sign-in, settings, slash commands and MCP management are unavailable because the Local Operator server did not answer as expected.";
+	return `The Local Operator server is missing ${missing.join(", ")} support. Update it to enable those surfaces.`;
 }
 
 /**

--- a/src/renderer/src/shared/api/local-operator/config-api.ts
+++ b/src/renderer/src/shared/api/local-operator/config-api.ts
@@ -1,7 +1,7 @@
 /**
  * Local Operator API - Configuration Endpoints
  */
-import { desktopControlResponse } from "./desktop-api";
+import { DesktopControlError, desktopControlResponse } from "./desktop-api";
 import type {
 	CRUDResponse,
 	ConfigResponse,
@@ -9,6 +9,33 @@ import type {
 	SystemPromptResponse,
 	SystemPromptUpdate,
 } from "./types";
+
+/**
+ * Fail with the HTTP status preserved, so callers can classify the failure.
+ *
+ * These calls used to throw a plain `Error`, which discards the status. Every
+ * consumer that classified one therefore fell to `backendErrorKind`'s
+ * `status: null` default and concluded "nothing answered" -- so Settings told a
+ * user whose server was running and refusing its bearer (401) that the server
+ * "may not be running", and offered no restart. That is the same wrong-remedy
+ * defect this change set removes from the providers grid, on the page issue 89
+ * is named after. `DesktopControlError` is the type the shared classifier
+ * reads, and it is the only thing that makes the classification real rather
+ * than defaulted.
+ *
+ * The message stays technical on purpose: it is the debugging detail behind
+ * the failure and reaches logs and `error.message`, never a rendered sentence.
+ * Surfaces render `backendLoadErrorMessage`, which speaks in the user's terms.
+ */
+function desktopConfigFailure(
+	operation: string,
+	response: { status: number; statusText: string },
+): DesktopControlError {
+	return new DesktopControlError(
+		response.status,
+		`${operation} request failed: ${response.status} ${response.statusText}`,
+	);
+}
 
 /**
  * Config API client for the Local Operator API
@@ -25,9 +52,7 @@ export const ConfigApi = {
 		const response = await desktopControlResponse({ op: "config.get" });
 
 		if (!response.ok) {
-			throw new Error(
-				`Get config request failed: ${response.status} ${response.statusText}`,
-			);
+			throw desktopConfigFailure("Get config", response);
 		}
 
 		return response.json() as Promise<CRUDResponse<ConfigResponse>>;
@@ -51,9 +76,7 @@ export const ConfigApi = {
 		});
 
 		if (!response.ok) {
-			throw new Error(
-				`Update config request failed: ${response.status} ${response.statusText}`,
-			);
+			throw desktopConfigFailure("Update config", response);
 		}
 
 		return response.json() as Promise<CRUDResponse<ConfigResponse>>;
@@ -77,9 +100,7 @@ export const ConfigApi = {
 		}
 
 		if (!response.ok) {
-			throw new Error(
-				`Get system prompt request failed: ${response.status} ${response.statusText}`,
-			);
+			throw desktopConfigFailure("Get system prompt", response);
 		}
 
 		return response.json() as Promise<CRUDResponse<SystemPromptResponse>>;
@@ -103,9 +124,7 @@ export const ConfigApi = {
 		});
 
 		if (!response.ok) {
-			throw new Error(
-				`Update system prompt request failed: ${response.status} ${response.statusText}`,
-			);
+			throw desktopConfigFailure("Update system prompt", response);
 		}
 
 		return response.json() as Promise<CRUDResponse<SystemPromptResponse>>;

--- a/src/renderer/src/shared/api/local-operator/desktop-api.ts
+++ b/src/renderer/src/shared/api/local-operator/desktop-api.ts
@@ -14,6 +14,19 @@ export type {
 	ProviderMethod,
 } from "../../../../../shared/desktop-contract";
 
+/**
+ * How long the renderer waits for ANY desktop control before calling it dead.
+ *
+ * Deliberately longer than the main process's own 20s `fetch` deadline in
+ * `desktop-transport.ts`, so a backend that answers slowly is still reported by
+ * the layer that actually knows the HTTP status. This bound only covers the
+ * case main can never report: the IPC round trip itself never settling.
+ *
+ * It does NOT cover `desktopMedia`, whose transport allows 120s for speech and
+ * agent-ZIP transfers; that path is bounded separately and is not routed here.
+ */
+const DESKTOP_REQUEST_TIMEOUT_MS = 30000;
+
 export async function desktopRequest(
 	request: DesktopRequest,
 ): Promise<DesktopResponse> {
@@ -23,8 +36,21 @@ export async function desktopRequest(
 	// the banner, which is how it happened to work before.
 	if (window.api?.desktop) {
 		try {
-			return await window.api.desktop.request(request);
+			// `ipcRenderer.invoke` settles only when main replies. Main's own fetch
+			// deadline covers a backend that accepts and never answers, but nothing
+			// covers main never replying at all -- a handler that throws before
+			// responding, a crashed or unresponsive main process, or a renderer that
+			// outlives its backend service. A `file://` renderer has no network stack
+			// in this path either, so there is no ambient timeout to fall back on and
+			// the promise stays pending forever. React Query cannot help: `retry`
+			// needs a settled rejection, so a request that never settles never
+			// retries and never reaches an error state. Every caller then sits on
+			// `isLoading` permanently, which is what issue 89 saw as a Settings
+			// spinner that never resolves. Bound it here, once, so every desktop
+			// control fails honestly instead of hanging.
+			return await withDeadline(window.api.desktop.request(request));
 		} catch (cause) {
+			if (cause instanceof DesktopControlError) throw cause;
 			throw new DesktopControlError(
 				null,
 				"Desktop controls could not reach the backend process.",
@@ -54,6 +80,36 @@ export async function desktopRequest(
 			"Desktop controls need a compatible backend connection.",
 		);
 	return response.json();
+}
+
+/**
+ * Reject with the transport's own unreachable state once the deadline passes.
+ *
+ * `status: null` is the same fact the catch blocks above report -- no backend
+ * was reached and there is no HTTP status -- so the compatibility banner reads
+ * a stalled control as "not answering" rather than "needs an update". The
+ * pending IPC promise is left to settle or not on its own; there is no way to
+ * cancel an `invoke`, and abandoning it is exactly the point.
+ */
+function withDeadline(
+	pending: Promise<DesktopResponse>,
+): Promise<DesktopResponse> {
+	let timer: ReturnType<typeof setTimeout>;
+	return Promise.race([
+		pending,
+		new Promise<never>((_, reject) => {
+			timer = setTimeout(
+				() =>
+					reject(
+						new DesktopControlError(
+							null,
+							"Desktop controls could not reach the backend process.",
+						),
+					),
+				DESKTOP_REQUEST_TIMEOUT_MS,
+			);
+		}),
+	]).finally(() => clearTimeout(timer));
 }
 
 /**

--- a/src/renderer/src/shared/api/local-operator/desktop-hooks.ts
+++ b/src/renderer/src/shared/api/local-operator/desktop-hooks.ts
@@ -12,6 +12,7 @@
  */
 
 import { useQuery } from "@tanstack/react-query";
+import { retryDesktopQuery } from "./backend-error";
 import { desktopResult } from "./desktop-api";
 import type { DesktopCapabilities, DesktopProvider } from "./desktop-api";
 
@@ -84,6 +85,11 @@ export function useDesktopProviders(enabled: boolean) {
 			}).then((result) => result.providers),
 		enabled,
 		staleTime: 30_000,
-		retry: 1,
+		// Same reasoning as `useConfig`: a `status: null` failure already spent
+		// the transport's whole deadline learning nothing, so retrying it doubles
+		// the wait to ~60s without a chance of a different answer. A failure that
+		// carries a status came from a backend that answered and is still worth
+		// one retry.
+		retry: retryDesktopQuery,
 	});
 }

--- a/src/renderer/src/shared/components/common/backend-compatibility-banner.tsx
+++ b/src/renderer/src/shared/components/common/backend-compatibility-banner.tsx
@@ -19,7 +19,11 @@
  * describes stay gated on `desktopFeatureEnabled` individually.
  */
 
-import { DesktopControlError } from "@shared/api/local-operator/desktop-api";
+import {
+	backendCompatibilityMessage,
+	backendErrorKind,
+	backendUpdateIsRemedy,
+} from "@shared/api/local-operator/backend-error";
 import {
 	desktopKeys,
 	useDesktopCapabilities,
@@ -77,35 +81,24 @@ export const BackendCompatibilityBanner = () => {
 	if (data?.desktop_available && missing.length === 0) return null;
 
 	// The probe's HTTP status is what separates "old" from "not running" from
-	// "cannot authenticate". 404 is the only one an update fixes: the route is
-	// absent, so this backend predates the contract.
-	//
-	// `null` means the request produced no status at all -- the transport failed
-	// and no backend was reached -- which reads as unreachable below. The
-	// transport now RAISES that state as a typed `DesktopControlError` with
-	// `status: null`, so this is a stated fact rather than the fallback for an
-	// unrecognised error type.
-	const status =
-		capabilities.error instanceof DesktopControlError
-			? capabilities.error.status
-			: null;
-	const outdated = Boolean(!data && status === 404);
-	const unreachable = Boolean(!data && (status === null || status === 503));
-	const unauthorized = Boolean(!data && (status === 401 || status === 403));
+	// "cannot authenticate", and the providers grid reads the same field to reach
+	// the same conclusion. Both now go through the shared classification so they
+	// cannot answer that question differently: the grid's own two-way split used
+	// to send a 401 user to a backend install this banner deliberately withholds.
+	const kind = backendErrorKind(capabilities.error);
+	const answered = Boolean(data);
 
 	const canUpdate = Boolean(window.api?.updater?.updateBackend);
-	const message = unreachable
-		? "The backend is not answering. Provider sign-in, settings, slash commands and MCP management need it running. Retry once it has started."
-		: unauthorized
-			? "This app cannot authenticate to the running backend, so protected controls are unavailable. Restart the app so it starts and pairs with its own backend."
-			: outdated
-				? "This backend is older than the app expects. Provider sign-in, settings, slash commands and MCP management stay off until it is updated."
-				: unpaired
-					? "This app is not paired with the running backend, so protected controls are unavailable. Restart the app so it can manage its own backend."
-					: `The backend is missing ${missing.join(", ")} support. Update it to enable those surfaces.`;
+	const message = backendCompatibilityMessage({
+		kind,
+		unpaired,
+		missing,
+		answered,
+	});
 	// Offered only where it is the actual remedy. A backend that is down or
 	// refusing this app's bearer is not fixed by installing a newer one.
-	const offerUpdate = canUpdate && !unpaired && !unreachable && !unauthorized;
+	const offerUpdate =
+		canUpdate && backendUpdateIsRemedy({ kind, unpaired, answered });
 
 	return (
 		<div className="fixed inset-x-0 top-0 z-2100 w-full">

--- a/src/renderer/src/shared/hooks/use-config.ts
+++ b/src/renderer/src/shared/hooks/use-config.ts
@@ -9,6 +9,7 @@ import {
 	type ConfigResponse,
 	createLocalOperatorClient,
 } from "@shared/api/local-operator";
+import { retryDesktopQuery } from "@shared/api/local-operator/backend-error";
 import { apiConfig } from "@shared/config";
 import { useQuery } from "@tanstack/react-query";
 
@@ -48,5 +49,14 @@ export const useConfig = () => {
 		refetchOnWindowFocus: false,
 		// Prevent stale time to avoid unnecessary refetches
 		staleTime: 5000,
+		// This is the query in issue 89's title, and it inherited the client's
+		// `retry: 1`. When the desktop transport's deadline rejects, that default
+		// re-waits the ENTIRE deadline a second time -- 30s, then 30s again --
+		// which is 60s of unbroken spinner before the error state can render. The
+		// deadline already means "we waited the whole budget and nothing came
+		// back"; asking again on a path known to be dead cannot learn more. A
+		// failure that carries a real HTTP status came from a backend that DID
+		// answer, so it keeps the retry.
+		retry: retryDesktopQuery,
 	});
 };

--- a/src/renderer/src/shared/hooks/use-config.ts
+++ b/src/renderer/src/shared/hooks/use-config.ts
@@ -10,6 +10,7 @@ import {
 	createLocalOperatorClient,
 } from "@shared/api/local-operator";
 import { retryDesktopQuery } from "@shared/api/local-operator/backend-error";
+import { DesktopControlError } from "@shared/api/local-operator/desktop-api";
 import { apiConfig } from "@shared/config";
 import { useQuery } from "@tanstack/react-query";
 
@@ -40,7 +41,15 @@ export const useConfig = () => {
 			const response = await client.config.getConfig();
 
 			if (response.status >= 400) {
-				throw new Error(response.message || "Failed to fetch configuration");
+				// An envelope that carries its own failure status, from a transport
+				// that returned 2xx. Thrown with that status attached for the same
+				// reason `config-api` does: a plain `Error` classifies as "nothing
+				// answered", so a server that answered and refused would be reported
+				// to the user as one that is not running.
+				throw new DesktopControlError(
+					response.status,
+					response.message || "Failed to fetch configuration",
+				);
 			}
 
 			return response.result as ConfigResponse;

--- a/src/renderer/src/shared/hooks/use-elapsed-since.ts
+++ b/src/renderer/src/shared/hooks/use-elapsed-since.ts
@@ -1,0 +1,32 @@
+import { useEffect, useState } from "react";
+
+/**
+ * Whether `ms` has passed since `active` last became true.
+ *
+ * Exists for the slow-load case in issue 89: bounding a stalled request means
+ * the user reaches an error state, but they still watch an identical, silent
+ * spinner until the deadline expires, and a spinner that never changes reads
+ * as a hung app long before it actually gives up. This lets a waiting surface
+ * say something at a threshold without polling a clock on every render.
+ *
+ * Deliberately a single boolean crossing rather than a live elapsed counter: a
+ * ticking number invites a per-second re-render of whatever is waiting, and a
+ * countdown would promise a deadline the user cannot act on. One state change,
+ * one timer, cleared when the wait ends.
+ */
+export function useElapsedSince(active: boolean, ms: number): boolean {
+	const [elapsed, setElapsed] = useState(false);
+
+	useEffect(() => {
+		// A finished wait must reset, otherwise a later load starts already in
+		// the "slow" state and asserts a delay that has not happened yet.
+		if (!active) {
+			setElapsed(false);
+			return;
+		}
+		const timer = setTimeout(() => setElapsed(true), ms);
+		return () => clearTimeout(timer);
+	}, [active, ms]);
+
+	return elapsed;
+}


### PR DESCRIPTION
## Summary

Fixes #89 — the Settings page never finishes loading and shows a centered spinner forever, reported by @bbqben against the 0.15.0 universal DMG.

## Root cause

The renderer's desktop control path is **unbounded**. `desktopRequest` → `window.api.desktop.request` → `ipcRenderer.invoke` settles only when the main process replies. With main never replying, the promise stays pending indefinitely — measured `STILL PENDING after 45s`. `useConfig` therefore never settles, `isConfigLoading` stays `true`, and `settings-page.tsx` returns the spinner *before* the `configError` branch can be reached. React Query's `retry` cannot help: retry needs a settled rejection, and a request that never settles never rejects.

**A correction to the earlier diagnosis on the issue.** The investigation reported "no AbortSignal on the main-process desktop path". There is one — `desktop-transport.ts:45`, `AbortSignal.timeout(20000)`, shipped in 0.15.0. Verified against a backend faulted to accept-and-never-answer: the transport settles at 20.1s with 503 for both stall shapes (silent-accept, and headers-then-stall). So pre-fix Settings reached an error in ~40s (20s × `retry: 1`) when the backend stalled *at the HTTP layer*. The genuinely unbounded layer is one above it — the IPC bridge, where main never replies at all. The symptom and the fix location were right; the named cause was not.

## Changes

**1. Bound the transport, not the query** (`desktop-api.ts`). 49 call sites across 8 API modules funnel through the single `desktopRequest` entry point. Bounding only the config query would have left the other 48 able to hang the same way. The deadline is 30s — deliberately longer than main's own 20s, so a slow-but-working backend is still reported by the layer that knows the HTTP status; this bound covers only what main can never report. It rejects with `status: null`, the transport's existing "no backend reached" state the banner and grid already understand. `desktopMedia` keeps its separate 120s budget.

**2. Settings reaches an actionable error** (`settings-page.tsx`). The existing error branch is now reachable, with a Retry affordance. Copy reuses the existing string rather than inventing a new register.

**3. Stop telling users to update a backend that is simply offline** (`provider-grid.tsx`). "Providers could not be loaded. The backend may need an update." fired on *any* error, including a plainly unreachable backend — a wrong diagnosis that sends users down the wrong path. It now branches on the same distinction the offline banner already computes: capability-404 → update copy; unreachable/503 → offline copy.

## Testing evidence

Rendered against a real isolated backend behind a fault proxy. The user's backend was never touched.

| Frame | Shows |
| --- | --- |
| `01-BEFORE-hang.png` | Ben's exact frame: spinner, no error, no recovery |
| `02-AFTER-error-retry.png` | "Could not load your settings… Get config request failed: 503" + Retry |
| `03-providers-OFFLINE-copy.png` | Unreachable backend → offline copy |
| `04-providers-UPDATE-copy.png` | Capability 404 → update copy |
| `05-AFTER-retry-recovers.png` | Retry issuing a real request |

**Both new tests were mutation-checked:**
- Remove `withDeadline` → `not ok 1 ... desktopRequest never settled: the request is unbounded and Settings would spin forever`.
- Collapse the provider branch → `not ok 1 - an unreachable backend is reported as offline`.

The first version of the provider test asserted a *local copy* of the branch logic and stayed green under mutation. It was rewritten to call the shipped `providerLoadErrorMessage`. Recording that because a test that cannot fail is worse than no test.

Gates: `pnpm test:desktop` 23/23 (18 pre-existing, unchanged), typecheck, biome, full production `electron-vite build`.

## Limitations

- Not exercised as a packaged DMG; the Vite harness renders the real renderer against a real backend, and both defects are renderer-layer.
- `05-AFTER-retry-recovers.png` shows Retry returning 401 because the isolated backend regenerated its token on restart. It proves the affordance fires a real request, not a clean success render.
- **Adjacent, not fixed:** `useDesktopProviders` uses `retry: 1`, so a stalled providers call takes ~60s to reach its error state. Bounded now, but slow.
- What makes the reporter's `/v1/config` stall in normal use is still unknown; the hang was induced deliberately. This fix makes the UI recover regardless, but there may be a backend-side stall worth its own investigation.

Ships in 0.15.1 alongside #87 and #90.
