### PR TITLE
chore(release): bump version to 0.15.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "local-operator-ui",
-  "version": "0.15.0",
+  "version": "0.15.1",
   "productName": "Local Operator",
   "description": "User interface for AI agent assistants that run Python code safely on your device through an intuitive chat interface. Supports local and cloud LLM models with built-in security features.",
   "main": "./out/main/index.js",


### PR DESCRIPTION
## Summary

Version bump for the 0.15.1 patch. One line in one file.

Covers three merged PRs:
- **#87** (`e1af0f67a`) — provider census onboarding gate, readiness badge overlap, stale-agent 404 dead end
- **#90** (`1cbb7ad61`) — npx/global install failing with `cachedDataRejected` on macOS ARM (issue #88)
- **#92** (`3d7b85a49`) — Settings spinning forever on a stalled desktop request (issue #89)

Patch rather than minor: all three are bug fixes against 0.15.0. No new capability.
