### PR TITLE
fix(providers): stop offering every provider when the census failed

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -65,6 +65,81 @@ jobs:
           node scripts/test-validate-release.mjs
           node --test scripts/test-release-safety.mjs scripts/test-publish-workflow.mjs
 
+  test:
+    # The desktop test suite -- the regression guards for issues 87, 92 and 93,
+    # every one of which is the same defect class (a surface treating "we could
+    # not find out" as an answer).
+    #
+    # This job exists because until it did, `pnpm test:desktop` ran in NO
+    # workflow: the whole suite was local-only, so three consecutive fixes in
+    # one defect class landed with their guards unenforced on every subsequent
+    # PR. A guard nothing runs is indistinguishable from no guard, which is the
+    # failure this suite is largely about.
+    #
+    # `--frozen-lockfile` is what keeps the invocation CI-safe. Running
+    # `pnpm test:desktop` on a cold tree makes pnpm resolve first, and that
+    # resolution is what writes an `allowBuilds:` block into
+    # `pnpm-workspace.yaml`; installing explicitly and frozen beforehand means
+    # the test step only runs node, and pnpm fails loudly rather than mutating
+    # the lockfile if either file is out of date.
+    name: Desktop Tests
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Install pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          version: '10'
+
+      - name: Setup Node.js 22
+        uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+          cache: 'pnpm'
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Run desktop tests
+        run: pnpm test:desktop
+
+      # A job that silently runs zero tests is the same vacuous check this job
+      # was added to undo, and it is the likeliest way this one rots: a renamed
+      # script or a glob that matches nothing still exits 0. Assert the suite
+      # actually executed a plausible number of tests, and that none failed.
+      - name: Assert the suite actually ran
+        run: |
+          pnpm test:desktop 2>&1 | tee /tmp/desktop-tests.log
+          PASS=$(grep -E '^# pass ' /tmp/desktop-tests.log | awk '{print $3}')
+          FAIL=$(grep -E '^# fail ' /tmp/desktop-tests.log | awk '{print $3}')
+          echo "desktop suite: pass=$PASS fail=$FAIL"
+          if [ -z "$PASS" ] || [ "$PASS" -lt 60 ]; then
+            echo "Desktop suite reported $PASS passing tests; expected at least 60."
+            echo "Either tests were dropped or the runner matched no files."
+            exit 1
+          fi
+          if [ "$FAIL" != "0" ]; then
+            echo "Desktop suite reported $FAIL failing tests."
+            exit 1
+          fi
+
+      # The suite must not mutate tracked files. `pnpm test:desktop` on a cold
+      # tree has been observed writing an `allowBuilds:` block into
+      # pnpm-workspace.yaml via pnpm's own resolution, which would land in a
+      # later commit as unexplained churn.
+      - name: Assert the run left the tree clean
+        run: |
+          if [ -n "$(git status --porcelain)" ]; then
+            echo "Desktop tests modified tracked files:"
+            git status --porcelain
+            git diff
+            exit 1
+          fi
+          echo "Working tree clean after the desktop suite."
+
   audit:
     name: Security Audit
     runs-on: ubuntu-latest

--- a/scripts/hosting-census-evidence.html
+++ b/scripts/hosting-census-evidence.html
@@ -1,0 +1,27 @@
+<!doctype html>
+<!--
+  Evidence harness for the hosting picker's census states (issue 93).
+
+  Mounts the SHIPPED `HostingSelect` and the SHIPPED `ProviderGrid` side by
+  side, behind a REAL desktop bridge (an injected `window.api.desktop`), so
+  `desktopRequest` takes the Electron IPC branch that actually ships rather
+  than the browser-dev `/__desktop` HTTP branch, which classifies its failures
+  differently.
+
+  Both surfaces are captured against the SAME injected fault, because the
+  property under test is that they agree: the picker must not offer a provider
+  the grid is simultaneously unable to vouch for.
+
+  Not part of the app or the test suite: a capture surface, run by hand with
+  `pnpm vite --config scripts/hosting-census-evidence.vite.mjs`.
+-->
+<html lang="en" data-theme="localOperatorDark">
+	<head>
+		<meta charset="UTF-8" />
+		<title>Hosting picker census states</title>
+	</head>
+	<body>
+		<div id="root"></div>
+		<script type="module" src="/scripts/hosting-census-evidence.tsx"></script>
+	</body>
+</html>

--- a/scripts/hosting-census-evidence.tsx
+++ b/scripts/hosting-census-evidence.tsx
@@ -1,0 +1,230 @@
+/**
+ * Evidence harness: the hosting picker's three census states, beside the grid.
+ *
+ * See `hosting-census-evidence.html` for why this exists. The property being
+ * captured is issue 93's: the picker must not offer every provider when the
+ * census FAILED, and what it does instead has to agree with what the
+ * onboarding grid says about the same fault. Rendering both shipped components
+ * against ONE injected fault is what makes that agreement visible rather than
+ * asserted -- neither component's copy is restated here, so a wrong sentence in
+ * a captured frame is wrong in the product.
+ */
+
+import { ProviderGrid } from "@features/providers/provider-grid";
+import { desktopResult } from "@shared/api/local-operator/desktop-api";
+import { desktopKeys } from "@shared/api/local-operator/desktop-hooks";
+import { HostingSelect } from "@shared/components/hosting/hosting-select";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { StrictMode } from "react";
+import { createRoot } from "react-dom/client";
+import { useModelsStore } from "@shared/store/models-store";
+import censusFixture from "./fixtures/auth-providers-0.50.0.json";
+import "@renderer/styles/index.css";
+
+/**
+ * Which census state this page load captures, from `?state=`.
+ *
+ * ONE state per load, deliberately. The first version of this harness rendered
+ * all three panels together against a single module-level "fail providers"
+ * flag, and the panels' own mounts re-ran `providers.list` AFTER seeding -- so
+ * whichever value the flag happened to hold last was the answer every panel
+ * got, and the healthy panel captured a failure while captioned as ready. A
+ * shared mutable fault is not a per-panel fault; binding the state to the page
+ * load makes each frame a picture of exactly one condition.
+ *
+ * `capabilities` must always SUCCEED: the picker only consults the census when
+ * the backend advertises the `auth` feature, so a harness that failed
+ * capabilities too would capture the unmanaged-backend branch (the env-file key
+ * list) and caption it as a census failure -- a frame of the wrong code path.
+ */
+const STATE = new URLSearchParams(location.search).get("state") ?? "ready";
+
+const CAPABILITIES = {
+	desktop_available: true,
+	features: { auth: 1, settings: 1, commands: 1 },
+};
+
+// The bridge itself. `window.api.desktop` existing is what routes the renderer
+// down the IPC branch that ships, so it is installed before any surface mounts.
+(window as unknown as { api: unknown }).api = {
+	desktop: {
+		request: async (request: { op: string }) => {
+			if (request.op === "capabilities")
+				return { status: 200, body: { result: CAPABILITIES } };
+			if (request.op === "providers.list") {
+				// The loading frame needs a request that never settles, and it has
+				// to hang HERE rather than in a seeded queryFn: the component's own
+				// mount refetch would otherwise resolve against the bridge and
+				// settle the state the frame is meant to show.
+				if (STATE === "loading") return new Promise(() => {});
+				if (STATE === "failed")
+					return { status: 503, body: { detail: "server unavailable" } };
+				return { status: 200, body: { result: { providers: CENSUS } } };
+			}
+			return { status: 503, body: { detail: "denied" } };
+		},
+	},
+};
+
+// React Query pauses refetching in a hidden tab, which silently defeats a
+// capture run in a background window.
+Object.defineProperty(document, "visibilityState", {
+	configurable: true,
+	get: () => "visible",
+});
+Object.defineProperty(document, "hidden", { configurable: true, get: () => false });
+
+/**
+ * The census the healthy panel renders.
+ *
+ * The VERBATIM `GET /v1/auth/providers` body already committed as a fixture and
+ * already used by `scripts/provider-state.test.mjs`, rather than a shape
+ * hand-written here. A hand-written one was wrong on first try -- it named the
+ * methods array `methods` where the backend sends `auth_methods`, which threw
+ * inside the grid and produced an empty frame. A fixture that the shipped
+ * components can actually consume is the only kind that proves anything.
+ */
+
+const CENSUS = censusFixture.result.providers;
+
+/**
+ * The manifest the picker filters, seeded into the models store.
+ *
+ * `getHostingProviders()` reads `useModelsStore`, NOT the census, and returns
+ * `[]` until that store is initialised. Without this seed the picker renders
+ * empty in all three states -- which would have made the failed frame look
+ * exactly like the healthy one and proved nothing at all. Seeding it is what
+ * makes "the census removed these rows" an observable difference between the
+ * frames rather than an invisible one.
+ *
+ * The rows are the census's own ids, so the two surfaces are talking about the
+ * same providers and the picker has something to drop.
+ *
+ * Called AFTER an explicit rehydrate rather than at module top level: the store
+ * is `persist`ed, and its rehydration from localStorage lands in a microtask
+ * that overwrote a seed written before it -- silently, leaving the picker empty
+ * in a frame captioned as healthy.
+ */
+function seedManifest() {
+	useModelsStore.setState({
+		providers: CENSUS.map((provider) => ({
+			id: provider.id,
+			name: provider.name,
+			description: provider.base_url ?? "Model provider",
+			url: provider.base_url ?? "",
+			requiredCredentials: provider.credential_name
+				? [provider.credential_name]
+				: [],
+		})),
+		models: [],
+		isInitialized: true,
+		lastFetched: Date.now(),
+	});
+}
+
+const newClient = () =>
+	new QueryClient({
+		defaultOptions: {
+			queries: {
+				retry: false,
+				gcTime: Number.POSITIVE_INFINITY,
+				// A surface mounting against an errored query would otherwise re-run
+				// it and paint its loading state instead of the state being captured.
+				retryOnMount: false,
+				refetchOnWindowFocus: false,
+			},
+		},
+	});
+
+/**
+ * Settle capabilities before mounting, so the surfaces do not paint a
+ * capabilities spinner over the census state being captured. The census itself
+ * is deliberately NOT seeded: the components issue it themselves against the
+ * bridge above, which is the path that ships.
+ */
+async function seedCapabilities(client: QueryClient) {
+	await client
+		.fetchQuery({
+			queryKey: desktopKeys.capabilities,
+			queryFn: () => desktopResult({ op: "capabilities" }),
+			retry: false,
+		})
+		.catch(() => undefined);
+}
+
+const Panel = ({
+	title,
+	note,
+	client,
+}: {
+	title: string;
+	note: string;
+	client: QueryClient;
+}) => (
+	<QueryClientProvider client={client}>
+		<section className="flex w-[520px] shrink-0 flex-col gap-3 rounded-md border border-hairline bg-surface p-4">
+			<div className="flex flex-col gap-1">
+				<h2 className="text-heading text-ink">{title}</h2>
+				<p className="text-meta text-ink-muted">{note}</p>
+			</div>
+			{/* The defect is what the OPEN list contains, so the frame has to show
+			    it open. `?open=1` clicks the combobox after mount rather than
+			    reaching into the component, so the list is opened the way a user
+			    opens it. */}
+			<div className="rounded-md border border-hairline bg-sunken p-3">
+				<p className="mb-2 text-meta text-ink-dim">Hosting picker (Settings)</p>
+				<HostingSelect
+					value=""
+					onSave={async () => {}}
+					filterByCredentials={true}
+					allowCustom={true}
+					allowDefault={false}
+					emptyHelperText="No hosting providers available. Add one in API credentials, in the list on the left."
+				/>
+			</div>
+			<div className="rounded-md border border-hairline bg-sunken p-3">
+				<p className="mb-2 text-meta text-ink-dim">Onboarding providers grid</p>
+				<ProviderGrid />
+			</div>
+		</section>
+	</QueryClientProvider>
+);
+
+const NOTES: Record<string, { title: string; note: string }> = {
+	loading: {
+		title: "Census loading",
+		note: "Filtering suppressed on purpose: the answer is moments away and blanking a populated control reads as it breaking.",
+	},
+	ready: {
+		title: "Census ready",
+		note: "Census owns the filter. Google and Mistral are absent (need sign-in); the local servers stay (no key needed).",
+	},
+	failed: {
+		title: "Census failed (503)",
+		note: "Issue 93: offered every provider before this fix. Now offers none, and says why in the grid's own words.",
+	},
+};
+
+const client = newClient();
+await seedCapabilities(client);
+await useModelsStore.persist?.rehydrate();
+seedManifest();
+
+const { title, note } = NOTES[STATE] ?? NOTES.ready;
+
+createRoot(document.getElementById("root") as HTMLElement).render(
+	<StrictMode>
+		<div className="flex min-h-screen justify-center bg-canvas p-6">
+			<Panel title={title} note={note} client={client} />
+		</div>
+	</StrictMode>,
+);
+
+// Open the picker's list the way a user would, when asked. Done from outside
+// the component so nothing about the captured list is stage-managed: whatever
+// the combobox shows here is what it shows on a click in the app.
+if (new URLSearchParams(location.search).get("open") === "1") {
+	setTimeout(() => {
+		document.querySelector<HTMLInputElement>('input[role="combobox"]')?.click();
+	}, 400);
+}

--- a/scripts/hosting-census-evidence.vite.mjs
+++ b/scripts/hosting-census-evidence.vite.mjs
@@ -1,0 +1,44 @@
+import { resolve } from "node:path";
+import tailwindcss from "@tailwindcss/vite";
+import react from "@vitejs/plugin-react";
+import { defineConfig } from "vite";
+
+/**
+ * Vite config for the hosting-picker census evidence harness only (issue 93).
+ *
+ * Aliases are copied from the renderer stage so the shipped components resolve
+ * exactly as they do in the app.
+ *
+ * ## `root` is the REPOSITORY, not `scripts/`
+ *
+ * The backend-error harness set `root: scripts/`, which put Tailwind v4's
+ * automatic source detection under `scripts/` -- so it never scanned
+ * `src/renderer` and every frame captured through it came out with no utility
+ * classes at all. An achromatic frame cannot show the state its caption claims,
+ * and the failure is silent: the harness boots, React mounts, the components
+ * render their real text, and only the colour is missing.
+ *
+ * Rooting at the repository puts `src/renderer` inside the scanned tree, and
+ * the html entry is addressed by its path under that root. `assertFramePaints`
+ * from `check-evidence.mjs` is run over every captured frame afterwards as the
+ * actual proof, since a config that looks right is not evidence that it was.
+ */
+const root = resolve(import.meta.dirname, "..");
+
+export default defineConfig({
+	root,
+	resolve: {
+		alias: {
+			"@renderer": resolve(root, "src/renderer/src"),
+			"@components": resolve(root, "src/renderer/src/components"),
+			"@features": resolve(root, "src/renderer/src/features"),
+			"@shared": resolve(root, "src/renderer/src/shared"),
+			"@assets": resolve(root, "src/renderer/src/assets"),
+			"@hooks": resolve(root, "src/renderer/src/hooks"),
+			"@api": resolve(root, "src/renderer/src/api"),
+			"@store": resolve(root, "src/renderer/src/store"),
+		},
+	},
+	plugins: [react(), tailwindcss()],
+	server: { port: 5198, strictPort: true },
+});

--- a/scripts/provider-state.test.mjs
+++ b/scripts/provider-state.test.mjs
@@ -1,5 +1,6 @@
 import assert from "node:assert/strict";
 import { readFileSync } from "node:fs";
+import { readFile } from "node:fs/promises";
 import { test } from "node:test";
 import { build } from "esbuild";
 
@@ -30,6 +31,7 @@ const {
 	hostingProviderSelectable,
 	readyHostingIds,
 	selectableHostingProviders,
+	hostingCensusStateFrom,
 	hostingCensusFailureHelperText,
 	providerLoadErrorMessage,
 } = await import(
@@ -300,6 +302,80 @@ test("hosting picker: the failure line is the grid's sentence, verbatim", () => 
 	assert.match(
 		hostingCensusFailureHelperText(new Error("boom")),
 		/^Providers could not be loaded\./,
+	);
+});
+
+test("hosting picker: a failed REFETCH keeps the cached census, it does not blank", () => {
+	// Issue 92's shape, in the state no single-flag test reaches: react-query
+	// sets `data` and `isError` TOGETHER when a refetch fails over a successful
+	// query. Reading `isError` first resolves that to `failed`, which empties a
+	// fully-loaded picker the moment a background poll 5xx's -- a control that
+	// was working blanking itself while the user looks at it.
+	//
+	// This is the assertion that fails when the two checks in
+	// `hostingCensusStateFrom` are swapped. Before it existed, that swap kept
+	// every test in this repo green.
+	const refetchFailed = hostingCensusStateFrom({
+		data: census,
+		isError: true,
+	});
+	assert.equal(refetchFailed.status, "ready");
+	assert.deepEqual(
+		ids(selectableHostingProviders(manifest, refetchFailed)),
+		// Identical to a clean READY census: the failure changes nothing, because
+		// the cached answer is still the best evidence we have.
+		["anthropic", "openai", "ollama"],
+	);
+
+	// The other two states, so a regression cannot satisfy the above by
+	// collapsing everything to `ready`.
+	assert.equal(
+		hostingCensusStateFrom({ data: undefined, isError: true }).status,
+		"failed",
+	);
+	assert.equal(
+		hostingCensusStateFrom({ data: undefined, isError: false }).status,
+		"loading",
+	);
+	assert.equal(
+		hostingCensusStateFrom({ data: census, isError: false }).status,
+		"ready",
+	);
+});
+
+test("hosting picker: the component routes BOTH decisions through the shared selectors", async () => {
+	// Round-1 MAJOR-1: the three tests above assert the selectors, and test 12
+	// compares a one-line forwarder against the function it forwards to -- true
+	// by construction, for every input. None of that notices the PICKER dropping
+	// the selectors and hardcoding its own answer, which is precisely the drift
+	// this PR claims to prevent. Mutation-proved: hardcoding the helper string in
+	// `hosting-select.tsx` left 22/22 passing before this assertion existed.
+	//
+	// Same shape as the guard on the grid side in
+	// `provider-grid-error-copy.test.mjs`, which is already proven to fail under
+	// the equivalent mutation. Asserted on the source because the alternative --
+	// rendering the React component -- needs a DOM these node:test files do not
+	// have, and the property under test is which function the component calls.
+	const picker = await readFile(
+		"src/renderer/src/shared/components/hosting/hosting-select.tsx",
+		"utf8",
+	);
+	assert.ok(
+		picker.includes("hostingCensusFailureHelperText(census.error)"),
+		"hosting-select no longer routes its failure copy through hostingCensusFailureHelperText, so it can drift from the grid's sentence",
+	);
+	assert.ok(
+		picker.includes("selectableHostingProviders(all, censusState)"),
+		"hosting-select no longer routes its option list through selectableHostingProviders, so it can drift from the grid's readiness predicate",
+	);
+	assert.ok(
+		picker.includes("hostingCensusStateFrom("),
+		"hosting-select no longer derives its census state through hostingCensusStateFrom, so the data-before-isError ordering is unguarded again",
+	);
+	// The failure sentence must not be restated as a literal beside the call.
+	assert.ok(
+		!picker.includes("Providers could not be loaded"),
+		"hosting-select hardcodes the grid's failure sentence instead of calling the shared selector",
 	);
 });
 

--- a/scripts/provider-state.test.mjs
+++ b/scripts/provider-state.test.mjs
@@ -29,13 +29,17 @@ const {
 	hasConnectedProvider,
 	hostingProviderSelectable,
 	readyHostingIds,
-} =
-	await import(
-		`data:text/javascript;base64,${Buffer.from(bundle.outputFiles[0].text).toString("base64")}`
-	);
+	selectableHostingProviders,
+	hostingCensusFailureHelperText,
+	providerLoadErrorMessage,
+} = await import(
+	`data:text/javascript;base64,${Buffer.from(bundle.outputFiles[0].text).toString("base64")}`
+);
 
 const census = JSON.parse(
-	readFileSync(new URL("./fixtures/auth-providers-0.50.0.json", import.meta.url)),
+	readFileSync(
+		new URL("./fixtures/auth-providers-0.50.0.json", import.meta.url),
+	),
 ).result.providers;
 
 test("real 0.50.0 census renders 'Signed in' for every provider with a credential", () => {
@@ -112,7 +116,10 @@ test("first-time decision: only local providers configured -> first time", () =>
 			// The legacy list is IGNORED once the census has answered: on a real
 			// machine it held Google/AWS/Radient keys and still meant nothing
 			// about model providers.
-			legacy: { status: "ready", keys: ["GOOGLE_ACCESS_TOKEN", "AWS_ACCESS_KEY_ID"] },
+			legacy: {
+				status: "ready",
+				keys: ["GOOGLE_ACCESS_TOKEN", "AWS_ACCESS_KEY_ID"],
+			},
 		}),
 		"first_time",
 	);
@@ -209,6 +216,90 @@ test("hosting picker agrees with the census, not the env-file key list", () => {
 			has_credential: false,
 		}),
 		false,
+	);
+});
+
+// The manifest rows the picker filters. Only `id` is read, so the three ids
+// below stand for "selectable", "not selectable" and "local" in the fixture.
+const manifest = [
+	{ id: "anthropic" },
+	{ id: "openai" },
+	{ id: "google" },
+	{ id: "ollama" },
+];
+const ids = (rows) => rows.map((row) => row.id);
+
+test("hosting picker: a LOADING census suppresses filtering", () => {
+	// The one state in which an unfiltered list is correct: the answer is
+	// moments away and blanking a populated control reads as it breaking.
+	assert.deepEqual(
+		ids(selectableHostingProviders(manifest, { status: "loading" })),
+		["anthropic", "openai", "google", "ollama"],
+	);
+});
+
+test("hosting picker: a READY census filters to what the grid calls ready", () => {
+	assert.deepEqual(
+		ids(
+			selectableHostingProviders(manifest, {
+				status: "ready",
+				providers: census,
+			}),
+		),
+		// google is "Needs sign-in" in the fixture; ollama is a local server.
+		["anthropic", "openai", "ollama"],
+	);
+});
+
+test("hosting picker: a FAILED census offers nothing, not everything", () => {
+	// Issue 93. The failed and loading states used to be one branch, so a
+	// census that 5xx'd offered every provider on no evidence -- "we could not
+	// find out" rendered as "yes", the same defect the onboarding gate fixed
+	// by resolving a failed census to pending rather than first_time.
+	assert.deepEqual(
+		ids(selectableHostingProviders(manifest, { status: "failed" })),
+		[],
+	);
+	// Stated as the three-way distinction the fix is about, so a regression
+	// that re-merges failure into either neighbour fails here by name.
+	const loading = ids(
+		selectableHostingProviders(manifest, { status: "loading" }),
+	);
+	const ready = ids(
+		selectableHostingProviders(manifest, {
+			status: "ready",
+			providers: census,
+		}),
+	);
+	const failed = ids(
+		selectableHostingProviders(manifest, { status: "failed" }),
+	);
+	assert.notDeepEqual(failed, loading);
+	assert.notDeepEqual(failed, ready);
+	assert.equal(loading.length > ready.length, true);
+	assert.equal(failed.length, 0);
+});
+
+test("hosting picker: the failure line is the grid's sentence, verbatim", () => {
+	// The picker must not go silent on failure -- an empty control with no
+	// reason is a dead end -- and it must not invent a fourth wording for the
+	// backend being unreachable. Asserting by string equality against the
+	// selector the grid renders is what makes the two surfaces provably agree.
+	for (const error of [
+		new Error("boom"),
+		Object.assign(new Error("stalled"), { status: null }),
+		Object.assign(new Error("refused"), { status: 503 }),
+	]) {
+		assert.equal(
+			hostingCensusFailureHelperText(error),
+			providerLoadErrorMessage(error),
+		);
+	}
+	// And it is a real sentence, not an empty string that would render as no
+	// helper text at all.
+	assert.match(
+		hostingCensusFailureHelperText(new Error("boom")),
+		/^Providers could not be loaded\./,
 	);
 });
 

--- a/src/renderer/src/features/providers/provider-labels.ts
+++ b/src/renderer/src/features/providers/provider-labels.ts
@@ -139,6 +139,30 @@ export type HostingCensusState<P> =
 	| { status: "ready"; providers: P[] };
 
 /**
+ * Reduce a census query's flags to the three states the picker distinguishes.
+ *
+ * `data` outranks `isError` deliberately: a refetch that fails while an earlier
+ * census is still cached means we DID find out, once, and the cached answer is
+ * better evidence than no answer. Only a census that has NEVER delivered a
+ * payload is `failed`. Swapping those two checks blanks a fully-loaded picker
+ * the moment a background refetch 5xx's, which is the shape of issue 92.
+ *
+ * This lives here rather than inline in the component because that ordering is
+ * the entire defence against re-shipping 92, and an invariant protected only by
+ * a comment is how 92 shipped in the first place. As a pure function it is
+ * assertable over `{ data, isError }` set TOGETHER -- the state no behavioural
+ * test of either flag alone can reach.
+ */
+export function hostingCensusStateFrom<P>(census: {
+	data?: P[] | undefined;
+	isError: boolean;
+}): HostingCensusState<P> {
+	if (census.data) return { status: "ready", providers: census.data };
+	if (census.isError) return { status: "failed" };
+	return { status: "loading" };
+}
+
+/**
  * Which hosting providers the picker may offer, given the census state.
  *
  * The three states have three different answers, and conflating the last two

--- a/src/renderer/src/features/providers/provider-labels.ts
+++ b/src/renderer/src/features/providers/provider-labels.ts
@@ -123,6 +123,70 @@ export function readyHostingIds(
 }
 
 /**
+ * What the picker knows about the census, in the three states it can be in.
+ *
+ * Shaped like `CensusInput` in `first-time-user.ts` on purpose: both surfaces
+ * decide from the same three facts, and the defect this exists to fix was the
+ * picker collapsing two of them into one. There is no `unavailable` member
+ * because a backend that never advertised the census does not reach this
+ * function at all -- the picker falls to the env-file key list there, which is
+ * the same `unavailable` branch `decideFirstTimeUser` takes.
+ */
+export type HostingCensusState<P> =
+	| { status: "loading" }
+	/** The backend advertised the census and then failed to serve it. */
+	| { status: "failed" }
+	| { status: "ready"; providers: P[] };
+
+/**
+ * Which hosting providers the picker may offer, given the census state.
+ *
+ * The three states have three different answers, and conflating the last two
+ * is issue 93:
+ *
+ * - **loading** -- filtering is suppressed and every provider is offered. The
+ *   census is about to answer, and blanking a populated control for the length
+ *   of one request reads as the list breaking. This is the ONLY state in which
+ *   an unfiltered list is correct.
+ * - **ready** -- the census owns the filter, using the same predicate the
+ *   onboarding grid uses, so the two surfaces cannot disagree about a provider.
+ * - **failed** -- nothing from the census. A census that did not answer is not
+ *   evidence that a provider is usable, and offering all of them turns "we
+ *   could not find out" into "yes". That is the same defect class the
+ *   onboarding gate fixed by resolving a failed census to `pending` rather
+ *   than `first_time`.
+ *
+ * The failed case deliberately does NOT disable the control or drop the value
+ * the user already has -- see `hostingCensusFailureHelperText` and the
+ * `isDisabled` gate in `hosting-select.tsx`. Refusing to assert a provider is
+ * ready is honest; locking the user out of a control because we could not find
+ * out is the same overreach in the other direction.
+ */
+export function selectableHostingProviders<
+	P extends { id: string } & Parameters<typeof hostingProviderSelectable>[0],
+	T extends { id: string },
+>(all: T[], census: HostingCensusState<P>): T[] {
+	if (census.status === "loading") return all;
+	if (census.status === "failed") return [];
+	const ready = readyHostingIds(census.providers);
+	return all.filter((provider) => ready.has(provider.id));
+}
+
+/**
+ * Why the picker is offering nothing, when the reason is a failed census.
+ *
+ * Routed through the SAME selector the onboarding grid renders in its error
+ * alert, rather than a picker-private sentence, so the two surfaces report one
+ * fault in one set of words and point at one remedy. That agreement is
+ * assertable by string equality in `scripts/provider-state.test.mjs`, which is
+ * the property issue 93 is about: an empty picker beside a grid explaining why
+ * is a dead end only if the picker stays silent.
+ */
+export function hostingCensusFailureHelperText(error: unknown): string {
+	return providerLoadErrorMessage(error);
+}
+
+/**
  * What to tell the user when the provider list fails to load.
  *
  * The diagnosis and the remedy both come from the shared classification rather

--- a/src/renderer/src/shared/components/hosting/hosting-select.tsx
+++ b/src/renderer/src/shared/components/hosting/hosting-select.tsx
@@ -7,6 +7,7 @@
 
 import {
 	hostingCensusFailureHelperText,
+	hostingCensusStateFrom,
 	selectableHostingProviders,
 } from "@features/providers/provider-labels";
 import {
@@ -107,17 +108,16 @@ export const HostingSelect: FC<HostingSelectProps> = ({
 	/**
 	 * The census in the three states the picker distinguishes.
 	 *
-	 * `data` outranks `isError` deliberately: a refetch that fails while an
-	 * earlier census is still cached means we DID find out, once, and the
-	 * cached answer is better evidence than no answer. Only a census that has
-	 * never delivered a payload is `failed`.
+	 * The `data`-before-`isError` ordering that keeps a cached census alive
+	 * through a failed refetch lives in `hostingCensusStateFrom`, beside the
+	 * selector that consumes it, so that ordering is unit-assertable over both
+	 * flags set at once rather than being protected by a comment in a component.
 	 */
-	const censusState = useMemo(() => {
-		if (census.data)
-			return { status: "ready" as const, providers: census.data };
-		if (census.isError) return { status: "failed" as const };
-		return { status: "loading" as const };
-	}, [census.data, census.isError]);
+	const censusState = useMemo(
+		() =>
+			hostingCensusStateFrom({ data: census.data, isError: census.isError }),
+		[census.data, census.isError],
+	);
 	const censusFailed = censusEnabled && censusState.status === "failed";
 
 	const availableHostingProviders = useMemo(() => {

--- a/src/renderer/src/shared/components/hosting/hosting-select.tsx
+++ b/src/renderer/src/shared/components/hosting/hosting-select.tsx
@@ -5,7 +5,10 @@
  * Filters available options based on user credentials.
  */
 
-import { readyHostingIds } from "@features/providers/provider-labels";
+import {
+	hostingCensusFailureHelperText,
+	selectableHostingProviders,
+} from "@features/providers/provider-labels";
 import {
 	desktopFeatureEnabled,
 	useDesktopCapabilities,
@@ -101,22 +104,38 @@ export const HostingSelect: FC<HostingSelectProps> = ({
 
 	const [isSubmitting, setIsSubmitting] = useState(false);
 
+	/**
+	 * The census in the three states the picker distinguishes.
+	 *
+	 * `data` outranks `isError` deliberately: a refetch that fails while an
+	 * earlier census is still cached means we DID find out, once, and the
+	 * cached answer is better evidence than no answer. Only a census that has
+	 * never delivered a payload is `failed`.
+	 */
+	const censusState = useMemo(() => {
+		if (census.data)
+			return { status: "ready" as const, providers: census.data };
+		if (census.isError) return { status: "failed" as const };
+		return { status: "loading" as const };
+	}, [census.data, census.isError]);
+	const censusFailed = censusEnabled && censusState.status === "failed";
+
 	const availableHostingProviders = useMemo(() => {
 		const all = getHostingProviders();
 		if (!filterByCredentials) return all;
 		if (censusEnabled) {
-			// Advertised census owns this filter even while it is still loading
-			// or has 5xx'd: falling through to the env-file list is Q3.
-			if (!census.data) return all;
-			const ready = readyHostingIds(census.data);
-			return all.filter((provider) => ready.has(provider.id));
+			// Advertised census owns this filter. Suppressing it while the census
+			// LOADS is deliberate; doing the same when it FAILED offered every
+			// provider on no evidence at all, which is issue 93. The three-state
+			// rule lives beside the grid's predicate so neither can drift.
+			return selectableHostingProviders(all, censusState);
 		}
 		// Unmanaged / old backends have no census; the env-file list is the
 		// only remaining source. Never mix it with a live census: that is
 		// how Anthropic showed "Requires additional credentials" while the
 		// grid said Signed in.
 		return getAvailableHostingProviders(userCredentials);
-	}, [filterByCredentials, censusEnabled, census.data, userCredentials]);
+	}, [filterByCredentials, censusEnabled, censusState, userCredentials]);
 
 	// Convert hosting providers to autocomplete options
 	const hostingOptions: HostingOption[] = useMemo(() => {
@@ -147,11 +166,16 @@ export const HostingSelect: FC<HostingSelectProps> = ({
 		) {
 			const customProvider = getHostingProviderById(value);
 			if (customProvider) {
-				// If it's a known provider but not available with current credentials
+				// If it's a known provider but not available with current credentials.
+				// The suffix is an assertion about the user's credentials, so it is
+				// withheld when the census failed: there the provider is missing from
+				// the list because nothing answered, not because anything was checked.
 				options.push({
 					id: customProvider.id,
 					name: customProvider.name,
-					description: `${customProvider.description} (Requires additional credentials)`,
+					description: censusFailed
+						? customProvider.description
+						: `${customProvider.description} (Requires additional credentials)`,
 					provider: customProvider,
 				});
 			} else if (allowCustom) {
@@ -173,7 +197,13 @@ export const HostingSelect: FC<HostingSelectProps> = ({
 		}
 
 		return options;
-	}, [availableHostingProviders, value, allowCustom, allowDefault]);
+	}, [
+		availableHostingProviders,
+		value,
+		allowCustom,
+		allowDefault,
+		censusFailed,
+	]);
 
 	/*
 	 * "No hosting providers available" under a select that is displaying
@@ -184,6 +214,20 @@ export const HostingSelect: FC<HostingSelectProps> = ({
 	 * telling them their own setting does not exist.
 	 */
 	const helperText = useMemo(() => {
+		/*
+		 * A failed census empties the list for a reason that has nothing to do
+		 * with the user's credentials, so it gets the reason rather than the
+		 * add-credentials prompt -- which would send someone to Settings to fix
+		 * a server that is not answering. It is also shown when a value IS set,
+		 * unlike the empty-credentials line: it does not contradict the row
+		 * above (the setting still exists), it explains why the list beneath is
+		 * empty, and without it an unreachable server reads as a broken control.
+		 *
+		 * The sentence is the grid's, verbatim, from the shared classifier.
+		 */
+		if (filterByCredentials && censusFailed) {
+			return hostingCensusFailureHelperText(census.error);
+		}
 		if (
 			filterByCredentials &&
 			availableHostingProviders.length === 0 &&
@@ -197,6 +241,8 @@ export const HostingSelect: FC<HostingSelectProps> = ({
 		filterByCredentials,
 		emptyHelperText,
 		value,
+		censusFailed,
+		census.error,
 	]);
 
 	// Find the current selected option
@@ -255,10 +301,17 @@ export const HostingSelect: FC<HostingSelectProps> = ({
 		}
 	};
 
-	// Disable if no credentials and default not allowed
+	// Disable if no credentials and default not allowed.
+	//
+	// A failed census is exempt. The list is empty there because nothing
+	// answered, not because the user has no credentials, and disabling the
+	// control would strand a user whose server is down with no way to type a
+	// provider they know they have -- turning "we could not find out" into a
+	// lockout, which is the same overreach as offering everything, inverted.
 	const isDisabled =
 		!allowDefault &&
 		filterByCredentials &&
+		!censusFailed &&
 		availableHostingProviders.length === 0 &&
 		!hostingOptions.some((opt) => opt.id === value && value !== "");
 


### PR DESCRIPTION
## Summary

Fixes #93. The hosting picker returned **all** providers while the provider census was loading *or* had failed. On failure it fell open to every provider, disagreeing with the onboarding grid, which correctly gates on the census.

This is the same defect class as the two fixed in #87: a surface treating "we could not find out" as "yes".

## What changed

Three census states, three answers:

| state | picker |
| --- | --- |
| loading | all providers — unchanged, the only correct unfiltered state |
| ready | census filter, same predicate as the grid |
| **failed** | **empty, plus the reason** |

The reason comes from `providerLoadErrorMessage` — the same selector `ProviderGrid` renders — rather than a fourth wording for "the backend is unreachable". A test asserts the two are string-equal so they cannot drift.

The decision logic is a pure function in `provider-labels.ts`, beside the grid's predicate, mirroring `CensusInput` in `first-time-user.ts`.

## Two deliberate non-choices

- **The control is not disabled on failure.** Locking a user out because *we* could not find out is the same overreach inverted — they can still type a provider they know they have.
- **The `(Requires additional credentials)` suffix is withheld** on failure, since it asserts something about credentials that nothing checked.

## Testing evidence

**Mutation check: yes.** Reverting `return []` to `return all` on the failed branch fails test 11:

```
+ [ 'anthropic', 'openai', 'google', 'ollama' ]   actual
- []                                              expected
```

12/13 passed under the mutation, so the new test isolates this defect rather than failing for an unrelated reason. Restored: 13/13.

**Frames** — captured from the committed harness (`scripts/hosting-census-evidence.*`), which composes the real `ProviderGrid` and `HostingSelect` behind an injected `window.api.desktop`. Re-captured on head `056e5a0ee`; all five pass the repo's own `assertFramePaints` against `localOperatorDark`.

| # | State | Frame |
| --- | --- | --- |
| 0 | **BEFORE** (base `5ab8b4e26`), census 503, picker open — offers the full provider list on no evidence. This is issue #93. | [00-BEFORE-failed-picker-offers-everything.png](https://raw.githubusercontent.com/damianvtran/local-operator-ui/evidence/pr-95/ev/00-BEFORE-failed-picker-offers-everything.png) |
| 1 | **AFTER**, census 503 — picker and grid state the *identical* sentence. | [01-census-failed-agreement.png](https://raw.githubusercontent.com/damianvtran/local-operator-ui/evidence/pr-95/ev/01-census-failed-agreement.png) |
| 2 | Census ready — the filter applies; Google/Mistral absent (need sign-in), local servers kept. | [02-census-ready.png](https://raw.githubusercontent.com/damianvtran/local-operator-ui/evidence/pr-95/ev/02-census-ready.png) |
| 3 | Census loading — unfiltered, deliberately. | [03-census-loading.png](https://raw.githubusercontent.com/damianvtran/local-operator-ui/evidence/pr-95/ev/03-census-loading.png) |
| 4 | **AFTER**, census 503, picker open — "No matches", with the reason beneath. | [04-failed-picker-open-offers-nothing.png](https://raw.githubusercontent.com/damianvtran/local-operator-ui/evidence/pr-95/ev/04-failed-picker-open-offers-nothing.png) |

Frames 0 and 4 are the before/after pair for #93: the same injected 503, the same open dropdown, seventeen providers against none.

Hosted on the throwaway branch `evidence/pr-95` (delete after merge) rather than committed to the tree, per the evidence-off-the-tree rule.

**CSS confirmed loaded, two ways** rather than by eye: the served stylesheet is 97 KB with `.bg-canvas`, `.bg-surface`, `.text-ink-muted`, `.border-hairline` and `.bg-sunken` all compiled, and all five frames pass the repo's own `assertFramePaints`. This matters because an evidence harness in #92 set `root: scripts/`, so Tailwind never scanned `src/renderer` and every frame came out achromatic — unable to show the state it was captioned as showing. This harness is rooted at the repo.

**Gates:** `biome check src` 0 errors / 7 warnings (matches `main`), typecheck clean, **73/73** across all eight desktop test files — and, as of round 1, those tests now run in CI on every push (`Desktop Tests` job), which they previously did not.

## Four near-misses worth recording

Each would have produced evidence that proved nothing, and each was caught before it reached this PR:

1. **Every early test run was a no-op.** `. nvm.sh` returns rc=3, so `&&` chains died before `node --test` ever ran — empty output plus rc=3 read as success.
2. **The first harness frame was a bare ground** — a hand-written fixture used `methods` where the backend sends `auth_methods`. Switched to the committed fixture.
3. **One mutable bridge flag across three panels** meant later panels' mount refetches read whatever the flag held last, so the "ready" panel rendered a *failure* under a healthy caption.
4. **Zustand `persist` rehydration silently overwrote the seeded models store**, leaving the picker empty in every state — all three frames would have looked identical and none would have been the state claimed.

## Not covered

- Not exercised in packaged Electron; the harness drives the shipped IPC path via an injected `window.api.desktop`, not a real backend returning 503.
- Dark theme only (`localOperatorDark`); the other eleven palettes were not captured.
- MINOR-3 and NIT-2 from the same review round are left alone, as the issue proposes.

