### PR TITLE
chore(release): bump version to 0.15.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "local-operator-ui",
-  "version": "0.15.1",
+  "version": "0.15.2",
   "productName": "Local Operator",
   "description": "User interface for AI agent assistants that run Python code safely on your device through an intuitive chat interface. Supports local and cloud LLM models with built-in security features.",
   "main": "./out/main/index.js",


### PR DESCRIPTION
## Summary

Version bump for the 0.15.2 patch. One line in one file.

Covers two merged PRs:
- **#95** (`aa5b5e1af`) — the hosting picker offered every provider when the provider census failed, disagreeing with the onboarding grid (issue #93)
- **#96** (`02fe53e8c`) — the Linux npm/global install could not launch because `chrome-sandbox` is not SUID after npm strips setuid bits (issue #91)

Patch rather than minor: both are bug fixes against behaviour 0.15.x already promised. No new capability, no new surface.
