### PR TITLE
feat(chat): canonical profiles, teams and sessions in the chat sidebar

### DIFF
--- a/package.json
+++ b/package.json
@@ -65,7 +65,7 @@
     "check-types:main": "tsc --noEmit -p tsconfig.node.json",
     "check-types:renderer": "tsc --noEmit -p tsconfig.app.json",
     "check-types": "pnpm run check-types:main && pnpm run check-types:renderer",
-    "test:desktop": "node --test scripts/linux-sandbox.test.mjs scripts/desktop-contract.test.mjs scripts/transcript-reducer.test.mjs scripts/provider-state.test.mjs scripts/stale-agent.test.mjs scripts/desktop-renderer-transport.test.mjs scripts/provider-grid-error-copy.test.mjs scripts/settings-time-to-error.test.mjs scripts/backend-error-surfaces.test.mjs",
+    "test:desktop": "node --test scripts/linux-sandbox.test.mjs scripts/desktop-contract.test.mjs scripts/transcript-reducer.test.mjs scripts/provider-state.test.mjs scripts/stale-agent.test.mjs scripts/desktop-renderer-transport.test.mjs scripts/provider-grid-error-copy.test.mjs scripts/settings-time-to-error.test.mjs scripts/backend-error-surfaces.test.mjs scripts/canonical-chat.test.mjs",
     "check-themes": "node scripts/generate-theme-css.mjs --check && node scripts/contrast-contract.mjs",
     "check-evidence": "node scripts/check-evidence.mjs",
     "check-edit-diffs": "node scripts/check-edit-diffs.mjs",

--- a/scripts/canonical-chat.test.mjs
+++ b/scripts/canonical-chat.test.mjs
@@ -49,6 +49,7 @@ const {
 	useCanonicalSessionsStore: store,
 	replaceSessionRows,
 	admitChatDraft,
+	draftIdentityFor,
 	desktopRequestSchema,
 } = module;
 function reset() {
@@ -142,14 +143,9 @@ test("create success plus admission failure retries exact same session and paylo
 		1,
 	);
 	const messages = calls.filter((request) => request.op === "sessions.message");
-	// Admission identity and payload must be replayed byte-for-byte; `mode` is a
-	// delivery instruction and deliberately follows the CURRENT session state, so
-	// a retry against a now-streaming session steers rather than queueing (F2).
-	assert.deepEqual(
-		{ ...messages[1], mode: undefined },
-		{ ...firstMessage, mode: undefined },
-	);
-	assert.equal(messages[1].mode, "steer");
+	// The whole admission — `mode` included — is the server's receipt fingerprint,
+	// so a retry of the same requestId must be byte-identical or it 409s (F3).
+	assert.deepEqual(messages[1], firstMessage);
 	assert.equal(store.getState().activeSessionId, "222222222222");
 	assert.equal(store.getState().drafts[key], undefined);
 });
@@ -228,26 +224,79 @@ test("only an issued admission pins the payload, and a discard always frees it",
 	assert.ok(await admitChatDraft(fresh, { ...input, text: "different" }));
 });
 
-test("a retry after a streaming turn begins steers instead of queueing", async () => {
+test("a lost admission response replays idempotently instead of conflicting", async () => {
 	reset();
-	let failAdmission = true;
+	// Models the REAL receipt store: DesktopReceipts fingerprints a sha256 of the
+	// whole request body (`mode` included) and raises ReceiptConflict -> HTTP 409
+	// when the same requestId arrives hashing differently. A stub that accepts
+	// unconditionally cannot observe this, which is exactly how the previous
+	// version of this test asserted behaviour the real server rejects.
+	const receipts = new Map();
+	let dropResponse = true;
 	globalThis.__canonicalRequest = async (request) => {
 		calls.push(request);
 		if (request.op === "sessions.create")
 			return { session_id: "222222222222", binding: null };
-		if (failAdmission) throw new Error("provider unavailable");
-		return { status: "admitted" };
+		const { requestId, ...body } = request;
+		const fingerprint = JSON.stringify(body, Object.keys(body).sort());
+		const seen = receipts.get(requestId);
+		if (seen && seen.fingerprint !== fingerprint)
+			throw new Error("Request ID was already used with different input");
+		if (seen) return { ...seen.result, replayed: true };
+		const result = { status: "admitted" };
+		receipts.set(requestId, { fingerprint, result });
+		// The turn IS admitted server-side; only the response is lost, which is
+		// what leaves the UI believing the send failed while the session streams.
+		if (dropResponse) throw new Error("connection reset");
+		return result;
 	};
 	const key = store.getState().stageDraft({ kind: "agent", name: "reviewer" });
 	await assert.rejects(
 		admitChatDraft(key, { ...input, mode: "prompt" }),
-		/provider unavailable/,
+		/connection reset/,
 	);
-	failAdmission = false;
+	dropResponse = false;
+	// The session is now streaming, so the composer recomputes busy -> "steer".
+	// The retry must still replay the ORIGINAL fingerprint, or it 409s forever
+	// and reports a failure for a message that already landed (F3).
 	await admitChatDraft(key, { ...input, mode: "steer" });
 	const admissions = calls.filter((call) => call.op === "sessions.message");
-	assert.equal(admissions.at(-1).mode, "steer");
 	assert.equal(admissions[0].requestId, admissions.at(-1).requestId);
+	assert.equal(admissions.at(-1).mode, "prompt");
+	assert.deepEqual(admissions.at(-1), admissions[0]);
+	assert.equal(store.getState().drafts[key], undefined);
+});
+
+test("an existing session's retained draft stays reachable after a failed send", () => {
+	reset();
+	// F1's reachability half was manual-only: reverting this rule left every test
+	// green because no test mounts chat-page.tsx. The rule lives in the store so
+	// the guard sits on the code the view actually calls.
+	assert.equal(
+		draftIdentityFor("draft:agent:reviewer", null),
+		"draft:agent:reviewer",
+	);
+	// The staged key wins while it exists, so a first send does not orphan its
+	// own pending draft the moment the session id arrives.
+	assert.equal(
+		draftIdentityFor("draft:agent:reviewer", "222222222222"),
+		"draft:agent:reviewer",
+	);
+	// An existing session has no staged key; without this the retained text and
+	// its Discard control are unreachable and the composer stays locked.
+	assert.equal(draftIdentityFor(null, "222222222222"), "send:222222222222");
+	assert.equal(draftIdentityFor(null, null), null);
+	store.getState().updateDraft("send:222222222222", {
+		key: "send:222222222222",
+		createRequestId: "c",
+		admissionRequestId: "a",
+		submittedText: "held text",
+		admissionAttempted: true,
+	});
+	const identity = draftIdentityFor(null, "222222222222");
+	assert.equal(store.getState().drafts[identity].submittedText, "held text");
+	store.getState().discardDraft(identity);
+	assert.equal(store.getState().drafts[identity], undefined);
 });
 
 test("typed repair failures retain the canonical draft and error category", async () => {

--- a/scripts/canonical-chat.test.mjs
+++ b/scripts/canonical-chat.test.mjs
@@ -142,7 +142,14 @@ test("create success plus admission failure retries exact same session and paylo
 		1,
 	);
 	const messages = calls.filter((request) => request.op === "sessions.message");
-	assert.deepEqual(messages[1], firstMessage);
+	// Admission identity and payload must be replayed byte-for-byte; `mode` is a
+	// delivery instruction and deliberately follows the CURRENT session state, so
+	// a retry against a now-streaming session steers rather than queueing (F2).
+	assert.deepEqual(
+		{ ...messages[1], mode: undefined },
+		{ ...firstMessage, mode: undefined },
+	);
+	assert.equal(messages[1].mode, "steer");
 	assert.equal(store.getState().activeSessionId, "222222222222");
 	assert.equal(store.getState().drafts[key], undefined);
 });
@@ -174,11 +181,73 @@ test("ambiguous create retains request ID and duplicate concurrent sends allocat
 			(call) => call.op === "sessions.create" && call.requestId === request,
 		),
 	);
+	// Creation never succeeded, so NOTHING was admitted: changing the text is
+	// safe and must not be refused. Locking here is what bricked a conversation
+	// after a single 503 (F1).
+	await assert.rejects(
+		admitChatDraft(key, { ...input, text: "different" }),
+		/indeterminate/,
+	);
+	assert.equal(calls.length, 3);
+});
+
+test("only an issued admission pins the payload, and a discard always frees it", async () => {
+	reset();
+	let failAdmission = true;
+	globalThis.__canonicalRequest = async (request) => {
+		calls.push(request);
+		if (request.op === "sessions.create")
+			return { session_id: "222222222222", binding: null };
+		if (failAdmission) throw new Error("provider unavailable");
+		return { status: "admitted" };
+	};
+	const key = store.getState().stageDraft({ kind: "agent", name: "reviewer" });
+	await assert.rejects(admitChatDraft(key, input), /provider unavailable/);
+	// The admission WAS issued, so its outcome is unknown and the payload is
+	// pinned until the user resolves it.
+	assert.equal(store.getState().drafts[key].admissionAttempted, true);
 	await assert.rejects(
 		admitChatDraft(key, { ...input, text: "different" }),
 		/not been confirmed/,
 	);
-	assert.equal(calls.length, 2);
+	// Adding an image is a payload change too and must not be silently dropped.
+	await assert.rejects(
+		admitChatDraft(key, {
+			...input,
+			images: [{ data_b64: "x", mime_type: "image/png" }],
+		}),
+		/not been confirmed/,
+	);
+	// The escape hatch: discarding frees the composer for good.
+	store.getState().discardDraft(key);
+	assert.equal(store.getState().drafts[key], undefined);
+	failAdmission = false;
+	const fresh = store
+		.getState()
+		.stageDraft({ kind: "agent", name: "reviewer" });
+	assert.ok(await admitChatDraft(fresh, { ...input, text: "different" }));
+});
+
+test("a retry after a streaming turn begins steers instead of queueing", async () => {
+	reset();
+	let failAdmission = true;
+	globalThis.__canonicalRequest = async (request) => {
+		calls.push(request);
+		if (request.op === "sessions.create")
+			return { session_id: "222222222222", binding: null };
+		if (failAdmission) throw new Error("provider unavailable");
+		return { status: "admitted" };
+	};
+	const key = store.getState().stageDraft({ kind: "agent", name: "reviewer" });
+	await assert.rejects(
+		admitChatDraft(key, { ...input, mode: "prompt" }),
+		/provider unavailable/,
+	);
+	failAdmission = false;
+	await admitChatDraft(key, { ...input, mode: "steer" });
+	const admissions = calls.filter((call) => call.op === "sessions.message");
+	assert.equal(admissions.at(-1).mode, "steer");
+	assert.equal(admissions[0].requestId, admissions.at(-1).requestId);
 });
 
 test("typed repair failures retain the canonical draft and error category", async () => {

--- a/scripts/canonical-chat.test.mjs
+++ b/scripts/canonical-chat.test.mjs
@@ -187,6 +187,42 @@ test("ambiguous create retains request ID and duplicate concurrent sends allocat
 	assert.equal(calls.length, 3);
 });
 
+test("a send that never reached admission carries the user's NEW images", async () => {
+	reset();
+	// Every other test sends `images: []`, so pinning images unconditionally --
+	// the original F2 defect -- was invisible to the suite: stale [] and fresh []
+	// are indistinguishable. Non-empty, DIFFERENT images are what make the two
+	// behaviours separable, so this is the only test that can observe it.
+	const stale = [{ data_b64: "AAA", mime_type: "image/png" }];
+	const replacement = [{ data_b64: "BBB", mime_type: "image/png" }];
+	let failCreate = true;
+	globalThis.__canonicalRequest = async (request) => {
+		calls.push(request);
+		if (request.op === "sessions.create") {
+			// The create fails, so NOTHING is admitted and no receipt exists: the
+			// user is free to change the message, images included.
+			if (failCreate) throw new Error("session could not start");
+			return { session_id: "222222222222", binding: null };
+		}
+		return { status: "admitted" };
+	};
+	const key = store.getState().stageDraft({ kind: "agent", name: "reviewer" });
+	await assert.rejects(
+		admitChatDraft(key, { ...input, images: stale }),
+		/session could not start/,
+	);
+	assert.ok(!store.getState().drafts[key].admissionAttempted);
+	failCreate = false;
+	await admitChatDraft(key, {
+		...input,
+		text: "different",
+		images: replacement,
+	});
+	const sent = calls.filter((call) => call.op === "sessions.message").at(-1);
+	assert.deepEqual(sent.images, replacement);
+	assert.equal(sent.text, "different");
+});
+
 test("only an issued admission pins the payload, and a discard always frees it", async () => {
 	reset();
 	let failAdmission = true;

--- a/scripts/canonical-chat.test.mjs
+++ b/scripts/canonical-chat.test.mjs
@@ -1,0 +1,295 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+import { build } from "esbuild";
+
+// Exercise the shipped store and closed IPC schema in memory. The transport
+// fixture records effects; this is deterministic state evidence, not a browser.
+const values = new Map();
+globalThis.localStorage = {
+	getItem: (key) => values.get(key) ?? null,
+	setItem: (key, value) => values.set(key, value),
+	removeItem: (key) => values.delete(key),
+};
+const calls = [];
+globalThis.__canonicalRequest = async (request) => {
+	calls.push(request);
+	return {};
+};
+const bundle = await build({
+	stdin: {
+		contents:
+			'export * from "./src/renderer/src/shared/store/canonical-sessions-store"; export {desktopRequestSchema} from "./src/shared/desktop-contract"; export {desktopFeatureEnabled} from "./src/renderer/src/shared/api/local-operator/desktop-hooks";',
+		resolveDir: process.cwd(),
+	},
+	bundle: true,
+	format: "esm",
+	platform: "node",
+	write: false,
+	plugins: [
+		{
+			name: "canonical-transport-fixture",
+			setup(builder) {
+				builder.onResolve(
+					{ filter: /@shared\/api\/local-operator\/desktop-api/ },
+					() => ({ path: "transport", namespace: "fixture" }),
+				);
+				builder.onLoad({ filter: /.*/, namespace: "fixture" }, () => ({
+					contents:
+						"export const desktopResult = request => globalThis.__canonicalRequest(request);",
+					loader: "js",
+				}));
+			},
+		},
+	],
+});
+const module = await import(
+	`data:text/javascript;base64,${Buffer.from(bundle.outputFiles[0].text).toString("base64")}`
+);
+const {
+	useCanonicalSessionsStore: store,
+	replaceSessionRows,
+	admitChatDraft,
+	desktopRequestSchema,
+} = module;
+function reset() {
+	calls.length = 0;
+	store.setState({
+		sessions: [],
+		activeSessionId: "111111111111",
+		activeDraftKey: null,
+		drafts: {},
+		sessionByAgent: {},
+		pendingSessionId: null,
+		error: null,
+	});
+}
+function attention(revision, unseen = true) {
+	return {
+		conversation_id: "session/111111111111",
+		completion_token: "token",
+		anchor_id: "anchor",
+		kind: "complete",
+		unseen,
+		revision,
+	};
+}
+const input = {
+	text: "Review this",
+	attachments: [],
+	images: [],
+	mode: "prompt",
+	cwd: "/tmp",
+};
+
+test("profile selection stages a stable draft without allocating or rebinding outgoing work", () => {
+	reset();
+	const first = store
+		.getState()
+		.stageDraft({ kind: "agent", name: "reviewer" });
+	const request = store.getState().drafts[first].createRequestId;
+	const again = store
+		.getState()
+		.stageDraft({ kind: "agent", name: "reviewer" });
+	assert.equal(first, again);
+	assert.equal(store.getState().drafts[again].createRequestId, request);
+	assert.equal(store.getState().activeSessionId, "111111111111");
+	assert.equal(calls.length, 0);
+	assert.notEqual(
+		store.getState().stageDraft({ kind: "agent", name: "reviewer" }, true),
+		first,
+	);
+});
+
+test("authoritative refresh removes absent IDs while newer viewed revision survives", () => {
+	const rows = replaceSessionRows(
+		[
+			{ session_id: "111111111111", attention: attention([5, 5], false) },
+			{ session_id: "222222222222" },
+		],
+		[{ session_id: "111111111111", attention: attention([4, 4]) }],
+	);
+	assert.deepEqual(
+		rows.map((row) => row.session_id),
+		["111111111111"],
+	);
+	assert.equal(rows[0].attention.unseen, false);
+	assert.deepEqual(rows[0].attention.revision, [5, 5]);
+});
+
+test("create success plus admission failure retries exact same session and payload", async () => {
+	reset();
+	let attempts = 0;
+	globalThis.__canonicalRequest = async (request) => {
+		calls.push(request);
+		if (request.op === "sessions.create")
+			return {
+				session_id: "222222222222",
+				binding: { agent: "reviewer", team: null },
+			};
+		if (++attempts === 1) throw new Error("provider unavailable");
+		return { status: "admitted" };
+	};
+	const key = store.getState().stageDraft({ kind: "agent", name: "reviewer" });
+	await assert.rejects(admitChatDraft(key, input), /provider unavailable/);
+	assert.equal(store.getState().drafts[key].sessionId, "222222222222");
+	assert.equal(store.getState().drafts[key].pending, false);
+	const firstMessage = calls.find(
+		(request) => request.op === "sessions.message",
+	);
+	await admitChatDraft(key, { ...input, mode: "steer" });
+	assert.equal(
+		calls.filter((request) => request.op === "sessions.create").length,
+		1,
+	);
+	const messages = calls.filter((request) => request.op === "sessions.message");
+	assert.deepEqual(messages[1], firstMessage);
+	assert.equal(store.getState().activeSessionId, "222222222222");
+	assert.equal(store.getState().drafts[key], undefined);
+});
+
+test("ambiguous create retains request ID and duplicate concurrent sends allocate once", async () => {
+	reset();
+	let release;
+	const pending = new Promise((resolve) => {
+		release = resolve;
+	});
+	globalThis.__canonicalRequest = async (request) => {
+		calls.push(request);
+		if (request.op === "sessions.create") {
+			await pending;
+			throw new Error("indeterminate outcome");
+		}
+		return {};
+	};
+	const key = store.getState().stageDraft({ kind: "team", name: "lopdev" });
+	const request = store.getState().drafts[key].createRequestId;
+	const first = admitChatDraft(key, input);
+	assert.equal(await admitChatDraft(key, input), null);
+	release();
+	await assert.rejects(first, /indeterminate/);
+	await assert.rejects(admitChatDraft(key, input), /indeterminate/);
+	assert.equal(calls.length, 2);
+	assert.ok(
+		calls.every(
+			(call) => call.op === "sessions.create" && call.requestId === request,
+		),
+	);
+	await assert.rejects(
+		admitChatDraft(key, { ...input, text: "different" }),
+		/not been confirmed/,
+	);
+	assert.equal(calls.length, 2);
+});
+
+test("typed repair failures retain the canonical draft and error category", async () => {
+	reset();
+	globalThis.__canonicalRequest = async (request) => {
+		calls.push(request);
+		if (request.op === "sessions.create")
+			return {
+				session_id: "222222222222",
+				binding: { agent: "reviewer", team: null },
+			};
+		throw Object.assign(new Error("Choose an available profile."), {
+			code: "unresolved_attachment",
+		});
+	};
+	const key = store.getState().stageDraft({ kind: "agent", name: "reviewer" });
+	await assert.rejects(admitChatDraft(key, input));
+	assert.equal(store.getState().drafts[key].errorCode, "unresolved_attachment");
+	assert.equal(store.getState().drafts[key].submittedText, input.text);
+	assert.equal(store.getState().drafts[key].sessionId, "222222222222");
+});
+
+test("latest candidate open wins and a failed open retains outgoing session", async () => {
+	reset();
+	const resolutions = new Map();
+	globalThis.__canonicalRequest = (request) => {
+		calls.push(request);
+		return new Promise((resolve, reject) =>
+			resolutions.set(request.sessionId, { resolve, reject }),
+		);
+	};
+	const first = store.getState().openSession("222222222222");
+	const last = store.getState().openSession("333333333333");
+	assert.equal(store.getState().activeSessionId, "111111111111");
+	resolutions.get("333333333333").resolve({});
+	assert.equal(await last, true);
+	resolutions.get("222222222222").resolve({});
+	assert.equal(await first, false);
+	assert.equal(store.getState().activeSessionId, "333333333333");
+	const failed = store.getState().openSession("444444444444");
+	resolutions.get("444444444444").reject(new Error("unavailable"));
+	assert.equal(await failed, false);
+	assert.equal(store.getState().activeSessionId, "333333333333");
+	assert.ok(calls.every((request) => request.op === "sessions.get"));
+});
+
+test("canonical catalogue requires negotiated version two and paired authorization", () => {
+	const caps = { desktop_available: true, features: { session_catalogue: 1 } };
+	assert.equal(
+		module.desktopFeatureEnabled(caps, "session_catalogue", 2),
+		false,
+	);
+	assert.equal(
+		module.desktopFeatureEnabled(
+			{ ...caps, features: { session_catalogue: 2 } },
+			"session_catalogue",
+			2,
+		),
+		true,
+	);
+	assert.equal(
+		module.desktopFeatureEnabled(
+			{ ...caps, desktop_available: false, features: { session_catalogue: 2 } },
+			"session_catalogue",
+			2,
+		),
+		false,
+	);
+});
+
+test("new closed IPC operations validate roster and forbid hidden payload writes", () => {
+	const requestId = "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa";
+	for (const name of ["..", ".", "../teams", "path\\\\escape", "control\u007f"])
+		assert.equal(
+			desktopRequestSchema.safeParse({ op: "profiles.get", name }).success,
+			false,
+		);
+	assert.ok(
+		desktopRequestSchema.safeParse({
+			op: "sessions.create",
+			requestId,
+			cwd: "/tmp",
+			target: { kind: "team", name: "lopdev" },
+		}).success,
+	);
+	assert.ok(
+		desktopRequestSchema.safeParse({
+			op: "profiles.create",
+			requestId,
+			name: "auditor",
+			fields: { description: "Audit", instructions: "Verify" },
+		}).success,
+	);
+	assert.equal(
+		desktopRequestSchema.safeParse({
+			op: "profiles.update",
+			requestId,
+			name: "auditor",
+			fields: { system_prompt: "bypass" },
+		}).success,
+		false,
+	);
+	assert.equal(
+		desktopRequestSchema.safeParse({
+			op: "teams.create",
+			requestId,
+			fields: {
+				name: "test",
+				members: [{ role: "reviewer", count: 17, kind: "agent" }],
+			},
+		}).success,
+		false,
+	);
+});

--- a/scripts/desktop-renderer-transport.test.mjs
+++ b/scripts/desktop-renderer-transport.test.mjs
@@ -86,3 +86,26 @@ test("a desktop control that answers is returned unchanged", async () => {
 		body: { result: { hosting: "openai" } },
 	});
 });
+
+test("structured profile repair conflict retains its category and actionable text", async () => {
+	const message = "Choose an available profile or detach it before sending.";
+	const { desktopResult, DesktopControlError } = await loadTransport(
+		async () => ({
+			status: 409,
+			body: { detail: { code: "unresolved_attachment", message } },
+		}),
+	);
+	await assert.rejects(
+		desktopResult({
+			op: "sessions.message",
+			sessionId: "111111111111",
+			requestId: "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa",
+			text: "retained draft",
+		}),
+		(error) =>
+			error instanceof DesktopControlError &&
+			error.status === 409 &&
+			error.code === "unresolved_attachment" &&
+			error.message === message,
+	);
+});

--- a/src/renderer/src/features/agents/components/agents-page.tsx
+++ b/src/renderer/src/features/agents/components/agents-page.tsx
@@ -1,308 +1,660 @@
-/**
- * Agents Page Component
- *
- * Main page for displaying and managing agents.
- * Uses React Router for navigation and state management.
- * A fixed-width agent list sits beside the settings for the selected agent.
- */
-
-import type { AgentDetails } from "@shared/api/local-operator/types";
-import { PageHeader } from "@shared/components/common/page-header";
+import { desktopResult } from "@shared/api/local-operator/desktop-api";
 import {
-	Button,
-	DropdownMenu,
-	DropdownMenuContent,
-	DropdownMenuItem,
-	DropdownMenuTrigger,
-	Tooltip,
-} from "@shared/components/ui";
+	desktopFeatureEnabled,
+	useDesktopCapabilities,
+} from "@shared/api/local-operator/desktop-hooks";
 import {
-	useExportAgent,
-	useUploadAgentToRadientMutation,
-} from "@shared/hooks/use-agent-mutations";
-import { useAgent } from "@shared/hooks/use-agents";
-import { useRadientAuth } from "@shared/hooks/use-radient-auth";
-import { useAgentRouteParam } from "@shared/hooks/use-route-params";
-import { useAgentSelectionStore } from "@shared/store/agent-selection-store";
-import {
-	Bot,
-	CloudUpload,
-	Ellipsis,
-	FileUp,
-	MessageSquare,
-} from "lucide-react";
-import { useEffect, useState } from "react";
-import type { FC } from "react";
-import { useNavigate } from "react-router-dom";
-import { AgentSettings } from "./agent-settings";
-import { AgentsSidebar } from "./agents-sidebar";
-import { UploadAgentDialog } from "./upload-agent-dialog";
+	type ReusableProfile,
+	type ReusableTeam,
+	type TeamMember,
+	useProfiles,
+	useTeams,
+} from "@shared/api/local-operator/profile-hooks";
+import { Button } from "@shared/components/ui/button";
+import { cn } from "@shared/lib/utils";
+import { useCanonicalSessionsStore } from "@shared/store/canonical-sessions-store";
+import { useQuery, useQueryClient } from "@tanstack/react-query";
+import { Bot, Plus, Users } from "lucide-react";
+import { type FormEvent, Suspense, lazy, useRef, useState } from "react";
+import { useNavigate, useParams, useSearchParams } from "react-router-dom";
 
-/**
- * Props for the AgentsPage component
- * No props needed as we use React Router hooks internally
- */
-type AgentsPageProps = Record<string, never>;
+// Old UUID links remain ordinary chat-agent settings, not reusable profiles.
+// Loading them explicitly preserves compatibility without contaminating the
+// canonical catalogue or silently converting somebody's saved conversation.
+const LegacyAgentsPage = lazy(() =>
+	import("./legacy-agents-page").then((module) => ({
+		default: module.LegacyAgentsPage,
+	})),
+);
+const field =
+	"w-full rounded-md border border-control bg-surface px-3 py-2 text-body-sm text-ink";
 
-/**
- * Agents Page Component
- *
- * Main page for displaying and managing agents.
- * Uses React Router for navigation and state management.
- * Layout follows the pattern of other pages with a sidebar and content area.
- */
-export const AgentsPage: FC<AgentsPageProps> = () => {
-	const { agentId, navigateToAgent } = useAgentRouteParam();
-	const navigate = useNavigate();
-	const { isAuthenticated } = useRadientAuth(); // Get auth status
-	const [isUploadDialogOpen, setIsUploadDialogOpen] = useState(false); // State for dialog
-	const [uploadValidationIssues, setUploadValidationIssues] = useState<
-		string[]
-	>([]);
-
-	// Export agent mutation
-	const exportAgentMutation = useExportAgent();
-	// Upload agent mutation
-	const uploadAgentMutation = useUploadAgentToRadientMutation();
-
-	// Get agent selection store functions
-	const { setLastAgentsPageAgentId, getLastAgentId } = useAgentSelectionStore();
-
-	// Use the agent ID from URL or the last selected agent ID
-	const effectiveAgentId = agentId || getLastAgentId("agents");
-
-	// Fetch the agent details if agentId is provided from URL
-	const { data: selectedAgent, refetch: refetchAgent } = useAgent(
-		effectiveAgentId || undefined,
+function ProfileEditor({
+	profile,
+	creating,
+	onSaved,
+}: {
+	profile?: ReusableProfile;
+	creating: boolean;
+	onSaved: (name: string) => void;
+}) {
+	const [extending, setExtending] = useState(false);
+	const [editing, setEditing] = useState(creating);
+	const [name, setName] = useState(profile?.name ?? "");
+	const [kind, setKind] = useState<"role" | "specialist">(
+		profile?.kind ?? "role",
 	);
-
-	// Update the last selected agent ID when the agent ID changes
-	useEffect(() => {
-		if (agentId) {
-			setLastAgentsPageAgentId(agentId);
+	const [description, setDescription] = useState(profile?.description ?? "");
+	const [instructions, setInstructions] = useState(profile?.instructions ?? "");
+	const [tools, setTools] = useState(profile?.tools?.join(", ") ?? "");
+	const [effort, setEffort] = useState(profile?.effort ?? "inherit");
+	const [delegate, setDelegate] = useState(profile?.delegate ?? false);
+	const [pending, setPending] = useState(false);
+	const [error, setError] = useState<string | null>(null);
+	const request = useRef<{ id: string; body: string } | null>(null);
+	const navigate = useNavigate();
+	const fresh = creating || extending;
+	const save = async (event: FormEvent) => {
+		event.preventDefault();
+		if (pending) return;
+		const fields = {
+			kind,
+			description,
+			instructions,
+			tools: tools
+				.split(",")
+				.map((value) => value.trim())
+				.filter(Boolean),
+			effort,
+			delegate,
+		};
+		const body = JSON.stringify({ name, fields, fresh });
+		if (request.current && request.current.body !== body) {
+			setError(
+				"The previous save has not been confirmed. Retry it unchanged or reload the profile to reconcile before editing again.",
+			);
+			return;
 		}
-	}, [agentId, setLastAgentsPageAgentId]);
-
-	// Handler for exporting the selected agent
-	const handleExportAgent = async () => {
-		if (!selectedAgent) return;
-
+		request.current ??= { id: crypto.randomUUID(), body };
+		setPending(true);
+		setError(null);
 		try {
-			const blob = await exportAgentMutation.mutateAsync(selectedAgent.id);
-
-			// Create a download link
-			const url = URL.createObjectURL(blob);
-			const a = document.createElement("a");
-			a.href = url;
-			a.download = `${selectedAgent.name.replace(/\s+/g, "-").toLowerCase()}-lo-agent.zip`;
-			document.body.appendChild(a);
-			a.click();
-
-			URL.revokeObjectURL(url);
-			document.body.removeChild(a);
+			const result = await desktopResult<ReusableProfile>({
+				op: fresh ? "profiles.create" : "profiles.update",
+				requestId: request.current.id,
+				name,
+				fields,
+			});
+			request.current = null;
+			setEditing(false);
+			onSaved(result.name);
 		} catch (error) {
-			console.error("Failed to export agent:", error);
+			setError(
+				error instanceof Error ? error.message : "Profile could not be saved.",
+			);
+		} finally {
+			setPending(false);
 		}
 	};
-
-	// Validation for agent upload
-	const getAgentUploadValidationIssues = (
-		agent: AgentDetails | null,
-	): string[] => {
-		if (!agent) return ["No agent selected."];
-		const issues: string[] = [];
-		if (!agent.name || agent.name.trim() === "")
-			issues.push("Name is required.");
-		if (!agent.description || agent.description.trim() === "")
-			issues.push("Description is required.");
-		// Accept both category and categories (array or string), but require at least one
-		const hasCategory = agent.categories && agent.categories.length > 0;
-		if (!hasCategory) issues.push("At least one category is required.");
-		return issues;
+	const install = async () => {
+		if (!profile || pending) return;
+		setPending(true);
+		setError(null);
+		try {
+			const result = await desktopResult<ReusableProfile>({
+				op: "profiles.install",
+				name: profile.name,
+				requestId: crypto.randomUUID(),
+			});
+			onSaved(result.name);
+		} catch (error) {
+			setError(
+				error instanceof Error
+					? error.message
+					: "Profile could not be installed.",
+			);
+		} finally {
+			setPending(false);
+		}
 	};
-
-	// Handlers for the Upload Dialog
-	const handleOpenUploadDialog = () => {
-		const issues = getAgentUploadValidationIssues(selectedAgent ?? null);
-		setUploadValidationIssues(issues);
-		setIsUploadDialogOpen(true);
-	};
-
-	const handleCloseUploadDialog = () => {
-		setIsUploadDialogOpen(false);
-		setUploadValidationIssues([]);
-	};
-
-	const handleConfirmUpload = () => {
-		if (!selectedAgent || !isAuthenticated) return;
-
-		// Call the actual upload mutation
-		uploadAgentMutation.mutateAsync(selectedAgent.id);
-		handleCloseUploadDialog(); // Close dialog after initiating upload
-	};
-
-	const handleSelectAgent = (agent: AgentDetails) => {
-		setLastAgentsPageAgentId(agent.id);
-		navigateToAgent(agent.id, "agents");
-	};
-
 	return (
-		<div className="flex h-full w-full overflow-hidden">
-			{/* The sidebar itself is width:100% — the 280px lives here, and the
-			    pane must not shrink when the agent list has a long name in it. */}
-			<div className="h-full w-70 shrink-0">
-				<AgentsSidebar
-					selectedAgentId={selectedAgent?.id}
-					onSelectAgent={handleSelectAgent}
-				/>
-			</div>
-
-			{/* `grow` rather than `flex-1`: the content pane keeps an auto basis so
-			    it fills the space the sidebar leaves, and `overflow-hidden` is what
-			    keeps its scrolling inside the pane instead of the window. */}
-			<div className="h-full grow overflow-hidden">
-				{/* `gap-8`: `PageHeader` no longer ships its own bottom margin. The
-				    header sits in the same measured column as the settings below it,
-				    so the page title and the fields it heads share one left edge. */}
-				<div className="flex h-full flex-col gap-8 p-4 sm:p-6 lg:p-8">
-					<div className="mx-auto w-full max-w-4xl">
-						<PageHeader
-							title="Agent management"
-							icon={Bot}
-							subtitle="View, configure and manage your agents"
-						>
-							{selectedAgent && (
-								<div className="flex items-center gap-2">
-									{/*
-									 * The two secondary actions collapse into a menu once the
-									 * header has less than 400px to work with. `PageHeader`
-									 * already wraps them onto a line of their own, and the
-									 * three buttons need about 360px side by side, so 400 is
-									 * the width below which wrapping stops being enough and
-									 * they would be clipped by the page's `overflow-hidden`.
-									 * The threshold is on the header's own width because the
-									 * app rail and the agent list between it and the window
-									 * edge both collapse independently of the viewport.
-									 *
-									 * These same two actions are already in the menu on every
-									 * row of the agent list, so folding them here repeats an
-									 * affordance the user has met rather than inventing one.
-									 */}
-									<DropdownMenu>
-										<DropdownMenuTrigger asChild>
-											<Button
-												/*
-												 * Carries the tour tag as well as the wide button
-												 * does: exactly one of the two is rendered at any
-												 * width, and the tour resolves whichever the user
-												 * can actually see. Anchoring only the wide one
-												 * left the spotlight attached to a `display:none`
-												 * element for the whole 800-950px band the
-												 * window's own minWidth floors the app to.
-												 */
-												data-tour-tag="upload-to-hub-header-button"
-												variant="secondary"
-												size="icon"
-												aria-label="More agent actions"
-												className="@min-[400px]:hidden"
-											>
-												<Ellipsis aria-hidden="true" />
-											</Button>
-										</DropdownMenuTrigger>
-										<DropdownMenuContent align="end" className="min-w-45">
-											<DropdownMenuItem
-												disabled={exportAgentMutation.isPending}
-												onSelect={handleExportAgent}
-											>
-												<FileUp aria-hidden="true" />
-												<span>Export</span>
-											</DropdownMenuItem>
-											<DropdownMenuItem
-												disabled={uploadAgentMutation.isPending}
-												onSelect={handleOpenUploadDialog}
-											>
-												<CloudUpload aria-hidden="true" />
-												<span>
-													{uploadAgentMutation.isPending
-														? "Uploading..."
-														: "Upload to hub"}
-												</span>
-											</DropdownMenuItem>
-										</DropdownMenuContent>
-									</DropdownMenu>
-
-									<Button
-										variant="secondary"
-										onClick={handleExportAgent}
-										disabled={exportAgentMutation.isPending}
-										className="hidden @min-[400px]:inline-flex"
-									>
-										<FileUp aria-hidden="true" />
-										Export
-									</Button>
-
-									<Button
-										data-tour-tag="upload-to-hub-header-button"
-										/*
-										 * A second, action-specific tag. The tour tag now sits
-										 * on two controls so the spotlight can find whichever
-										 * is visible, but they do different things: this one
-										 * opens the upload dialog, the overflow trigger opens
-										 * a menu. `click()` does not need visibility, so the
-										 * tour presses THIS one for the action and anchors to
-										 * the visible one for the highlight.
-										 */
-										data-tour-action="open-upload-dialog"
-										variant="secondary"
-										onClick={handleOpenUploadDialog}
-										disabled={uploadAgentMutation.isPending}
-										className="hidden @min-[400px]:inline-flex"
-									>
-										<CloudUpload aria-hidden="true" />
-										{uploadAgentMutation.isPending
-											? "Uploading..."
-											: "Upload to hub"}
-									</Button>
-
-									{/* The only tooltip here: it names the agent, which the
-								    button label cannot. */}
-									<Tooltip
-										content={`Chat with ${selectedAgent.name || "this agent"}`}
-									>
-										<Button
-											variant="primary"
-											onClick={() => navigate(`/chat/${selectedAgent.id}`)}
-										>
-											<MessageSquare aria-hidden="true" />
-											Chat
-										</Button>
-									</Tooltip>
-								</div>
-							)}
-						</PageHeader>
-					</div>
-
-					<div className="min-h-0 grow overflow-hidden">
-						<AgentSettings
-							selectedAgent={selectedAgent ?? null}
-							refetchAgent={refetchAgent}
-							initialSelectedAgentId={agentId}
-						/>
-					</div>
+		<div className="max-w-3xl space-y-6">
+			<header>
+				<h1 className="text-title">
+					{fresh
+						? extending
+							? "Extend agent"
+							: "Create agent"
+						: profile?.name}
+				</h1>
+				<p className="mt-2 text-body-sm text-ink-muted">
+					Reusable instructions shared by agent commands, subagents and teams.
+					Chats remain separate.
+				</p>
+			</header>
+			{profile && !fresh && (
+				<div className="flex flex-wrap items-center gap-2">
+					<span className="text-meta text-ink-muted">
+						{profile.source === "builtin"
+							? "Built-in"
+							: profile.source === "installed"
+								? "Installed"
+								: "Custom"}
+						{profile.divergent_fields?.length ? " · Modified" : ""} ·{" "}
+						{profile.kind}
+					</span>
+					{profile.source === "builtin" ? (
+						<Button variant="outline" onClick={install} disabled={pending}>
+							Install
+						</Button>
+					) : (
+						<Button variant="outline" onClick={() => setEditing(true)}>
+							Edit
+						</Button>
+					)}
+					<Button
+						variant="outline"
+						onClick={() => {
+							setExtending(true);
+							setEditing(true);
+							setName("");
+							request.current = null;
+						}}
+					>
+						Extend
+					</Button>
+					<Button
+						onClick={() => {
+							useCanonicalSessionsStore
+								.getState()
+								.stageDraft({ kind: "agent", name: profile.name });
+							navigate("/chat");
+						}}
+					>
+						New chat
+					</Button>
 				</div>
-			</div>
-
-			{/* Render the Upload Confirmation Dialog */}
-			{selectedAgent && (
-				<UploadAgentDialog
-					open={isUploadDialogOpen}
-					onClose={handleCloseUploadDialog}
-					agentName={selectedAgent?.name ?? ""}
-					isAuthenticated={isAuthenticated}
-					onConfirmUpload={handleConfirmUpload}
-					validationIssues={uploadValidationIssues}
-				/>
 			)}
+			{error && (
+				<p role="alert" className="text-body-sm text-danger">
+					{error}
+				</p>
+			)}
+			<form onSubmit={save} className="space-y-4">
+				<fieldset disabled={!editing || pending} className="space-y-4">
+					<label className="block space-y-1 text-body-sm">
+						<span>Name</span>
+						<input
+							className={field}
+							value={name}
+							disabled={!fresh}
+							required
+							onChange={(event) => setName(event.target.value)}
+						/>
+					</label>
+					<label className="block space-y-1 text-body-sm">
+						<span>Kind</span>
+						<select
+							className={field}
+							value={kind}
+							disabled={!fresh}
+							onChange={(event) =>
+								setKind(event.target.value as "role" | "specialist")
+							}
+						>
+							<option value="role">Role</option>
+							<option value="specialist">Specialist</option>
+						</select>
+					</label>
+					<label className="block space-y-1 text-body-sm">
+						<span>When to use this agent</span>
+						<input
+							className={field}
+							value={description}
+							maxLength={8000}
+							onChange={(event) => setDescription(event.target.value)}
+						/>
+					</label>
+					<label className="block space-y-1 text-body-sm">
+						<span>Instructions</span>
+						<textarea
+							className={cn(field, "min-h-52")}
+							value={instructions}
+							required
+							maxLength={8000}
+							onChange={(event) => setInstructions(event.target.value)}
+						/>
+					</label>
+					{kind === "role" && (
+						<>
+							<label className="block space-y-1 text-body-sm">
+								<span>Allowed tools</span>
+								<input
+									className={field}
+									value={tools}
+									onChange={(event) => setTools(event.target.value)}
+									placeholder="All tools when empty; otherwise comma-separated names"
+								/>
+							</label>
+							<label className="block space-y-1 text-body-sm">
+								<span>Effort tier</span>
+								<input
+									className={field}
+									value={effort}
+									onChange={(event) => setEffort(event.target.value)}
+									aria-describedby="effort-help"
+								/>
+								<span id="effort-help" className="text-meta text-ink-muted">
+									Use inherit, or a tier configured in backend settings.
+									Unsupported tiers are rejected before saving.
+								</span>
+							</label>
+							<label className="flex items-center gap-2 text-body-sm">
+								<input
+									type="checkbox"
+									checked={delegate}
+									onChange={(event) => setDelegate(event.target.checked)}
+								/>
+								May delegate to subagents
+							</label>
+						</>
+					)}
+				</fieldset>
+				{editing && (
+					<Button type="submit" disabled={pending}>
+						{pending ? "Saving…" : fresh ? "Create agent" : "Save changes"}
+					</Button>
+				)}
+			</form>
+			{!editing &&
+			profile?.packaged_instructions &&
+			profile.divergent_fields?.length ? (
+				<details className="text-body-sm">
+					<summary>Compare packaged instructions</summary>
+					<pre className="mt-2 whitespace-pre-wrap text-body-sm text-ink-muted">
+						{profile.packaged_instructions}
+					</pre>
+				</details>
+			) : null}
 		</div>
 	);
-};
+}
+
+function TeamEditor({
+	team,
+	onSaved,
+}: { team?: ReusableTeam; onSaved: (name: string) => void }) {
+	const [name, setName] = useState(team?.name ?? "");
+	const [description, setDescription] = useState(team?.description ?? "");
+	const [manager, setManager] = useState(team?.manager ?? "manager");
+	const [members, setMembers] = useState<(TeamMember & { key: string })[]>(
+		(team?.members ?? []).map((member) => ({
+			...member,
+			key: crypto.randomUUID(),
+		})),
+	);
+	const [instructions, setInstructions] = useState(team?.instructions ?? "");
+	const [project, setProject] = useState(team?.project ?? "");
+	const [pending, setPending] = useState(false);
+	const [error, setError] = useState<string | null>(null);
+	const request = useRef<{ id: string; body: string } | null>(null);
+	const navigate = useNavigate();
+	const save = async (event: FormEvent) => {
+		event.preventDefault();
+		if (pending) return;
+		const fields = {
+			name,
+			description,
+			manager,
+			members: members.map(({ key: _key, ...member }) => member),
+			instructions,
+			project,
+		};
+		const body = JSON.stringify(fields);
+		if (request.current && request.current.body !== body) {
+			setError(
+				"The previous save has not been confirmed. Reload the team before changing that request.",
+			);
+			return;
+		}
+		request.current ??= { id: crypto.randomUUID(), body };
+		setPending(true);
+		setError(null);
+		try {
+			const result = team
+				? await desktopResult<ReusableTeam>({
+						op: "teams.update",
+						name: team.name,
+						requestId: request.current.id,
+						fields,
+					})
+				: await desktopResult<ReusableTeam>({
+						op: "teams.create",
+						requestId: request.current.id,
+						fields,
+					});
+			request.current = null;
+			onSaved(result.name);
+		} catch (error) {
+			setError(
+				error instanceof Error ? error.message : "Team could not be saved.",
+			);
+		} finally {
+			setPending(false);
+		}
+	};
+	const updateMember = (index: number, patch: Partial<TeamMember>) =>
+		setMembers((rows) =>
+			rows.map((row, position) =>
+				position === index ? { ...row, ...patch } : row,
+			),
+		);
+	return (
+		<div className="max-w-3xl space-y-6">
+			<header>
+				<h1 className="text-title">{team ? team.name : "Create team"}</h1>
+				<p className="mt-2 text-body-sm text-ink-muted">
+					The manager leads the chat. Members retain their own instructions and
+					start only when delegated work.
+				</p>
+			</header>
+			{team && (
+				<Button
+					onClick={() => {
+						useCanonicalSessionsStore
+							.getState()
+							.stageDraft({ kind: "team", name: team.name });
+						navigate("/chat");
+					}}
+				>
+					New team chat
+				</Button>
+			)}
+			{error && (
+				<p role="alert" className="text-body-sm text-danger">
+					{error}
+				</p>
+			)}
+			<form onSubmit={save} className="space-y-4">
+				<fieldset disabled={pending} className="space-y-4">
+					<label className="block space-y-1 text-body-sm">
+						<span>Name</span>
+						<input
+							className={field}
+							required
+							maxLength={64}
+							value={name}
+							onChange={(event) => setName(event.target.value)}
+						/>
+					</label>
+					<label className="block space-y-1 text-body-sm">
+						<span>Description</span>
+						<input
+							className={field}
+							value={description}
+							onChange={(event) => setDescription(event.target.value)}
+						/>
+					</label>
+					<label className="block space-y-1 text-body-sm">
+						<span>Manager agent</span>
+						<input
+							className={field}
+							required
+							value={manager}
+							onChange={(event) => setManager(event.target.value)}
+						/>
+					</label>
+					<section className="space-y-2">
+						<h2 className="text-heading">Members</h2>
+						{members.map((member, index) => (
+							<div
+								key={member.key}
+								className="flex flex-wrap items-center gap-2"
+							>
+								<input
+									className={cn(field, "w-48 flex-1")}
+									aria-label={`Member ${index + 1} name`}
+									required
+									value={member.role}
+									onChange={(event) =>
+										updateMember(index, { role: event.target.value })
+									}
+								/>
+								<select
+									className={cn(field, "w-32")}
+									aria-label={`Member ${index + 1} kind`}
+									value={member.kind}
+									onChange={(event) =>
+										updateMember(index, {
+											kind: event.target.value as "agent" | "team",
+										})
+									}
+								>
+									<option value="agent">Agent</option>
+									<option value="team">Nested team</option>
+								</select>
+								<input
+									className={cn(field, "w-20")}
+									aria-label={`Member ${index + 1} count`}
+									type="number"
+									min={1}
+									max={16}
+									value={member.count}
+									onChange={(event) =>
+										updateMember(index, { count: Number(event.target.value) })
+									}
+								/>
+								<Button
+									type="button"
+									variant="ghost"
+									onClick={() =>
+										setMembers((rows) =>
+											rows.filter((_, position) => position !== index),
+										)
+									}
+								>
+									Remove
+								</Button>
+							</div>
+						))}
+						<Button
+							type="button"
+							variant="outline"
+							onClick={() =>
+								setMembers((rows) => [
+									...rows,
+									{
+										role: "",
+										count: 1,
+										kind: "agent",
+										key: crypto.randomUUID(),
+									},
+								])
+							}
+						>
+							Add member
+						</Button>
+					</section>
+					<label className="block space-y-1 text-body-sm">
+						<span>Collaboration instructions</span>
+						<textarea
+							className={cn(field, "min-h-36")}
+							maxLength={8000}
+							value={instructions}
+							onChange={(event) => setInstructions(event.target.value)}
+						/>
+					</label>
+					<label className="block space-y-1 text-body-sm">
+						<span>Project brief</span>
+						<textarea
+							className={cn(field, "min-h-36")}
+							maxLength={8000}
+							value={project}
+							onChange={(event) => setProject(event.target.value)}
+						/>
+					</label>
+				</fieldset>
+				<Button type="submit" disabled={pending}>
+					{pending ? "Saving…" : team ? "Save team" : "Create team"}
+				</Button>
+			</form>
+		</div>
+	);
+}
+
+export function AgentsPage() {
+	const { agentId } = useParams<{ agentId?: string }>();
+	const [params, setParams] = useSearchParams();
+	const teamMode =
+		params.get("kind") === "team" || params.get("create") === "team";
+	const creating = params.has("create");
+	const name = params.get("name");
+	const capabilities = useDesktopCapabilities();
+	const enabled = desktopFeatureEnabled(
+		capabilities.data,
+		teamMode ? "team_catalogue" : "profile_catalogue",
+	);
+	const profiles = useProfiles(enabled && !teamMode);
+	const teams = useTeams(enabled && teamMode);
+	const queryClient = useQueryClient();
+	const detail = useQuery<ReusableProfile | ReusableTeam>({
+		queryKey: ["desktop", teamMode ? "team" : "profile", name],
+		enabled: enabled && Boolean(name) && !creating,
+		queryFn: () =>
+			desktopResult<ReusableProfile | ReusableTeam>({
+				op: teamMode ? "teams.get" : "profiles.get",
+				name: name ?? "",
+			}),
+		retry: false,
+	});
+	const saved = async (savedName: string) => {
+		await queryClient.invalidateQueries({ queryKey: ["desktop"] });
+		setParams({ kind: teamMode ? "team" : "agent", name: savedName });
+	};
+	if (agentId)
+		return (
+			<Suspense
+				fallback={<p className="p-6 text-body">Loading saved agent…</p>}
+			>
+				<LegacyAgentsPage />
+			</Suspense>
+		);
+	return (
+		<div className="flex h-full min-h-0 bg-canvas text-ink">
+			<aside className="flex w-64 shrink-0 flex-col gap-4 border-r border-hairline bg-surface p-4">
+				<h1 className="text-heading">Agents and teams</h1>
+				<div className="flex gap-2">
+					<Button
+						variant={teamMode ? "ghost" : "outline"}
+						onClick={() => setParams({ kind: "agent" })}
+					>
+						<Bot className="size-4" />
+						Agents
+					</Button>
+					<Button
+						variant={teamMode ? "outline" : "ghost"}
+						onClick={() => setParams({ kind: "team" })}
+					>
+						<Users className="size-4" />
+						Teams
+					</Button>
+				</div>
+				<Button
+					variant="outline"
+					disabled={!enabled}
+					onClick={() => setParams({ create: teamMode ? "team" : "agent" })}
+				>
+					<Plus className="size-4" />
+					{teamMode ? "Create team" : "Create agent"}
+				</Button>
+				<div className="min-h-0 flex-1 overflow-y-auto">
+					{(teamMode ? teams.data : profiles.data)?.map((row) => (
+						<button
+							key={row.name}
+							type="button"
+							className={cn(
+								"flex h-8 w-full items-center rounded-md px-2 text-left text-body-sm hover:bg-elevated",
+								row.name === name && "bg-accent-wash",
+							)}
+							onClick={() =>
+								setParams({ kind: teamMode ? "team" : "agent", name: row.name })
+							}
+						>
+							<span className="truncate">{row.name}</span>
+						</button>
+					))}
+				</div>
+			</aside>
+			<main className="min-w-0 flex-1 overflow-auto p-6">
+				{!enabled ? (
+					<div aria-live="polite" className="space-y-3 text-body-sm">
+						<p>
+							{capabilities.isLoading
+								? "Connecting to the backend…"
+								: capabilities.error
+									? capabilities.error.message
+									: "Update the backend to manage reusable agents and teams. Saved chats are unchanged."}
+						</p>
+						<Button
+							variant="outline"
+							onClick={() => void capabilities.refetch()}
+						>
+							Retry connection
+						</Button>
+					</div>
+				) : profiles.error || teams.error || detail.error ? (
+					<div role="alert">
+						<p className="text-danger">
+							{profiles.error?.message ||
+								teams.error?.message ||
+								detail.error?.message}
+						</p>
+						<Button
+							variant="outline"
+							onClick={() => {
+								void profiles.refetch();
+								void teams.refetch();
+								void detail.refetch();
+							}}
+						>
+							Retry
+						</Button>
+					</div>
+				) : creating ? (
+					teamMode ? (
+						<TeamEditor key="create-team" onSaved={saved} />
+					) : (
+						<ProfileEditor key="create-agent" creating onSaved={saved} />
+					)
+				) : name && detail.isLoading ? (
+					<p aria-live="polite">Loading details…</p>
+				) : name && detail.data ? (
+					teamMode ? (
+						<TeamEditor
+							key={name}
+							team={detail.data as ReusableTeam}
+							onSaved={saved}
+						/>
+					) : (
+						<ProfileEditor
+							key={name}
+							profile={detail.data as ReusableProfile}
+							creating={false}
+							onSaved={saved}
+						/>
+					)
+				) : (
+					<div>
+						<h2 className="text-title">
+							{teamMode ? "Reusable teams" : "Reusable agents"}
+						</h2>
+						<p className="mt-2 text-body text-ink-muted">
+							Select a definition to view or edit it. A new chat does not change
+							its definition.
+						</p>
+					</div>
+				)}
+			</main>
+		</div>
+	);
+}

--- a/src/renderer/src/features/agents/components/agents-page.tsx
+++ b/src/renderer/src/features/agents/components/agents-page.tsx
@@ -106,6 +106,21 @@ function ProfileEditor({
 				name: profile.name,
 				requestId: crypto.randomUUID(),
 			});
+			// Install is idempotent and is NOT a restore of whatever is on screen.
+			// The form was seeded from the BUILTIN, and installing does not change
+			// the name, so without re-seeding from the authoritative result an Edit
+			// would start from stale text and Save would overwrite the installed
+			// role's real instructions.
+			setEditing(false);
+			setExtending(false);
+			request.current = null;
+			setName(result.name);
+			setKind(result.kind);
+			setDescription(result.description ?? "");
+			setInstructions(result.instructions ?? "");
+			setTools(result.tools?.join(", ") ?? "");
+			setEffort(result.effort ?? "inherit");
+			setDelegate(result.delegate ?? false);
 			onSaved(result.name);
 		} catch (error) {
 			setError(
@@ -180,6 +195,12 @@ function ProfileEditor({
 					{error}
 				</p>
 			)}
+			{!editing && profile?.source === "builtin" && (
+				<p id="builtin-readonly" className="text-body-sm text-ink-muted">
+					Built-in agents are read-only. Install this one to edit it, or Extend
+					it to start a separate agent from its instructions.
+				</p>
+			)}
 			<form onSubmit={save} className="space-y-4">
 				<fieldset disabled={!editing || pending} className="space-y-4">
 					<label className="block space-y-1 text-body-sm">
@@ -189,6 +210,9 @@ function ProfileEditor({
 							value={name}
 							disabled={!fresh}
 							required
+							aria-describedby={
+								profile?.source === "builtin" ? "builtin-readonly" : undefined
+							}
 							onChange={(event) => setName(event.target.value)}
 						/>
 					</label>
@@ -637,7 +661,10 @@ export function AgentsPage() {
 						/>
 					) : (
 						<ProfileEditor
-							key={name}
+							/* Identity is name AND source: installing does not rename a
+							   profile, so keying on name alone kept the builtin-seeded form
+							   mounted across builtin -> installed. */
+							key={`${name}:${(detail.data as ReusableProfile).source}`}
 							profile={detail.data as ReusableProfile}
 							creating={false}
 							onSaved={saved}

--- a/src/renderer/src/features/agents/components/legacy-agents-page.tsx
+++ b/src/renderer/src/features/agents/components/legacy-agents-page.tsx
@@ -1,0 +1,308 @@
+/**
+ * Agents Page Component
+ *
+ * Main page for displaying and managing agents.
+ * Uses React Router for navigation and state management.
+ * A fixed-width agent list sits beside the settings for the selected agent.
+ */
+
+import type { AgentDetails } from "@shared/api/local-operator/types";
+import { PageHeader } from "@shared/components/common/page-header";
+import {
+	Button,
+	DropdownMenu,
+	DropdownMenuContent,
+	DropdownMenuItem,
+	DropdownMenuTrigger,
+	Tooltip,
+} from "@shared/components/ui";
+import {
+	useExportAgent,
+	useUploadAgentToRadientMutation,
+} from "@shared/hooks/use-agent-mutations";
+import { useAgent } from "@shared/hooks/use-agents";
+import { useRadientAuth } from "@shared/hooks/use-radient-auth";
+import { useAgentRouteParam } from "@shared/hooks/use-route-params";
+import { useAgentSelectionStore } from "@shared/store/agent-selection-store";
+import {
+	Bot,
+	CloudUpload,
+	Ellipsis,
+	FileUp,
+	MessageSquare,
+} from "lucide-react";
+import { useEffect, useState } from "react";
+import type { FC } from "react";
+import { useNavigate } from "react-router-dom";
+import { AgentSettings } from "./agent-settings";
+import { AgentsSidebar } from "./agents-sidebar";
+import { UploadAgentDialog } from "./upload-agent-dialog";
+
+/**
+ * Props for the AgentsPage component
+ * No props needed as we use React Router hooks internally
+ */
+type AgentsPageProps = Record<string, never>;
+
+/**
+ * Agents Page Component
+ *
+ * Main page for displaying and managing agents.
+ * Uses React Router for navigation and state management.
+ * Layout follows the pattern of other pages with a sidebar and content area.
+ */
+export const LegacyAgentsPage: FC<AgentsPageProps> = () => {
+	const { agentId, navigateToAgent } = useAgentRouteParam();
+	const navigate = useNavigate();
+	const { isAuthenticated } = useRadientAuth(); // Get auth status
+	const [isUploadDialogOpen, setIsUploadDialogOpen] = useState(false); // State for dialog
+	const [uploadValidationIssues, setUploadValidationIssues] = useState<
+		string[]
+	>([]);
+
+	// Export agent mutation
+	const exportAgentMutation = useExportAgent();
+	// Upload agent mutation
+	const uploadAgentMutation = useUploadAgentToRadientMutation();
+
+	// Get agent selection store functions
+	const { setLastAgentsPageAgentId, getLastAgentId } = useAgentSelectionStore();
+
+	// Use the agent ID from URL or the last selected agent ID
+	const effectiveAgentId = agentId || getLastAgentId("agents");
+
+	// Fetch the agent details if agentId is provided from URL
+	const { data: selectedAgent, refetch: refetchAgent } = useAgent(
+		effectiveAgentId || undefined,
+	);
+
+	// Update the last selected agent ID when the agent ID changes
+	useEffect(() => {
+		if (agentId) {
+			setLastAgentsPageAgentId(agentId);
+		}
+	}, [agentId, setLastAgentsPageAgentId]);
+
+	// Handler for exporting the selected agent
+	const handleExportAgent = async () => {
+		if (!selectedAgent) return;
+
+		try {
+			const blob = await exportAgentMutation.mutateAsync(selectedAgent.id);
+
+			// Create a download link
+			const url = URL.createObjectURL(blob);
+			const a = document.createElement("a");
+			a.href = url;
+			a.download = `${selectedAgent.name.replace(/\s+/g, "-").toLowerCase()}-lo-agent.zip`;
+			document.body.appendChild(a);
+			a.click();
+
+			URL.revokeObjectURL(url);
+			document.body.removeChild(a);
+		} catch (error) {
+			console.error("Failed to export agent:", error);
+		}
+	};
+
+	// Validation for agent upload
+	const getAgentUploadValidationIssues = (
+		agent: AgentDetails | null,
+	): string[] => {
+		if (!agent) return ["No agent selected."];
+		const issues: string[] = [];
+		if (!agent.name || agent.name.trim() === "")
+			issues.push("Name is required.");
+		if (!agent.description || agent.description.trim() === "")
+			issues.push("Description is required.");
+		// Accept both category and categories (array or string), but require at least one
+		const hasCategory = agent.categories && agent.categories.length > 0;
+		if (!hasCategory) issues.push("At least one category is required.");
+		return issues;
+	};
+
+	// Handlers for the Upload Dialog
+	const handleOpenUploadDialog = () => {
+		const issues = getAgentUploadValidationIssues(selectedAgent ?? null);
+		setUploadValidationIssues(issues);
+		setIsUploadDialogOpen(true);
+	};
+
+	const handleCloseUploadDialog = () => {
+		setIsUploadDialogOpen(false);
+		setUploadValidationIssues([]);
+	};
+
+	const handleConfirmUpload = () => {
+		if (!selectedAgent || !isAuthenticated) return;
+
+		// Call the actual upload mutation
+		uploadAgentMutation.mutateAsync(selectedAgent.id);
+		handleCloseUploadDialog(); // Close dialog after initiating upload
+	};
+
+	const handleSelectAgent = (agent: AgentDetails) => {
+		setLastAgentsPageAgentId(agent.id);
+		navigateToAgent(agent.id, "agents");
+	};
+
+	return (
+		<div className="flex h-full w-full overflow-hidden">
+			{/* The sidebar itself is width:100% — the 280px lives here, and the
+			    pane must not shrink when the agent list has a long name in it. */}
+			<div className="h-full w-70 shrink-0">
+				<AgentsSidebar
+					selectedAgentId={selectedAgent?.id}
+					onSelectAgent={handleSelectAgent}
+				/>
+			</div>
+
+			{/* `grow` rather than `flex-1`: the content pane keeps an auto basis so
+			    it fills the space the sidebar leaves, and `overflow-hidden` is what
+			    keeps its scrolling inside the pane instead of the window. */}
+			<div className="h-full grow overflow-hidden">
+				{/* `gap-8`: `PageHeader` no longer ships its own bottom margin. The
+				    header sits in the same measured column as the settings below it,
+				    so the page title and the fields it heads share one left edge. */}
+				<div className="flex h-full flex-col gap-8 p-4 sm:p-6 lg:p-8">
+					<div className="mx-auto w-full max-w-4xl">
+						<PageHeader
+							title="Agent management"
+							icon={Bot}
+							subtitle="View, configure and manage your agents"
+						>
+							{selectedAgent && (
+								<div className="flex items-center gap-2">
+									{/*
+									 * The two secondary actions collapse into a menu once the
+									 * header has less than 400px to work with. `PageHeader`
+									 * already wraps them onto a line of their own, and the
+									 * three buttons need about 360px side by side, so 400 is
+									 * the width below which wrapping stops being enough and
+									 * they would be clipped by the page's `overflow-hidden`.
+									 * The threshold is on the header's own width because the
+									 * app rail and the agent list between it and the window
+									 * edge both collapse independently of the viewport.
+									 *
+									 * These same two actions are already in the menu on every
+									 * row of the agent list, so folding them here repeats an
+									 * affordance the user has met rather than inventing one.
+									 */}
+									<DropdownMenu>
+										<DropdownMenuTrigger asChild>
+											<Button
+												/*
+												 * Carries the tour tag as well as the wide button
+												 * does: exactly one of the two is rendered at any
+												 * width, and the tour resolves whichever the user
+												 * can actually see. Anchoring only the wide one
+												 * left the spotlight attached to a `display:none`
+												 * element for the whole 800-950px band the
+												 * window's own minWidth floors the app to.
+												 */
+												data-tour-tag="upload-to-hub-header-button"
+												variant="secondary"
+												size="icon"
+												aria-label="More agent actions"
+												className="@min-[400px]:hidden"
+											>
+												<Ellipsis aria-hidden="true" />
+											</Button>
+										</DropdownMenuTrigger>
+										<DropdownMenuContent align="end" className="min-w-45">
+											<DropdownMenuItem
+												disabled={exportAgentMutation.isPending}
+												onSelect={handleExportAgent}
+											>
+												<FileUp aria-hidden="true" />
+												<span>Export</span>
+											</DropdownMenuItem>
+											<DropdownMenuItem
+												disabled={uploadAgentMutation.isPending}
+												onSelect={handleOpenUploadDialog}
+											>
+												<CloudUpload aria-hidden="true" />
+												<span>
+													{uploadAgentMutation.isPending
+														? "Uploading..."
+														: "Upload to hub"}
+												</span>
+											</DropdownMenuItem>
+										</DropdownMenuContent>
+									</DropdownMenu>
+
+									<Button
+										variant="secondary"
+										onClick={handleExportAgent}
+										disabled={exportAgentMutation.isPending}
+										className="hidden @min-[400px]:inline-flex"
+									>
+										<FileUp aria-hidden="true" />
+										Export
+									</Button>
+
+									<Button
+										data-tour-tag="upload-to-hub-header-button"
+										/*
+										 * A second, action-specific tag. The tour tag now sits
+										 * on two controls so the spotlight can find whichever
+										 * is visible, but they do different things: this one
+										 * opens the upload dialog, the overflow trigger opens
+										 * a menu. `click()` does not need visibility, so the
+										 * tour presses THIS one for the action and anchors to
+										 * the visible one for the highlight.
+										 */
+										data-tour-action="open-upload-dialog"
+										variant="secondary"
+										onClick={handleOpenUploadDialog}
+										disabled={uploadAgentMutation.isPending}
+										className="hidden @min-[400px]:inline-flex"
+									>
+										<CloudUpload aria-hidden="true" />
+										{uploadAgentMutation.isPending
+											? "Uploading..."
+											: "Upload to hub"}
+									</Button>
+
+									{/* The only tooltip here: it names the agent, which the
+								    button label cannot. */}
+									<Tooltip
+										content={`Chat with ${selectedAgent.name || "this agent"}`}
+									>
+										<Button
+											variant="primary"
+											onClick={() => navigate(`/chat/${selectedAgent.id}`)}
+										>
+											<MessageSquare aria-hidden="true" />
+											Chat
+										</Button>
+									</Tooltip>
+								</div>
+							)}
+						</PageHeader>
+					</div>
+
+					<div className="min-h-0 grow overflow-hidden">
+						<AgentSettings
+							selectedAgent={selectedAgent ?? null}
+							refetchAgent={refetchAgent}
+							initialSelectedAgentId={agentId}
+						/>
+					</div>
+				</div>
+			</div>
+
+			{/* Render the Upload Confirmation Dialog */}
+			{selectedAgent && (
+				<UploadAgentDialog
+					open={isUploadDialogOpen}
+					onClose={handleCloseUploadDialog}
+					agentName={selectedAgent?.name ?? ""}
+					isAuthenticated={isAuthenticated}
+					onConfirmUpload={handleConfirmUpload}
+					validationIssues={uploadValidationIssues}
+				/>
+			)}
+		</div>
+	);
+};

--- a/src/renderer/src/features/chat/components/chat-content.tsx
+++ b/src/renderer/src/features/chat/components/chat-content.tsx
@@ -84,7 +84,10 @@ type ChatContentProps = {
 	messagesEndRef: React.RefObject<HTMLDivElement>;
 	scrollToBottom: () => void;
 	rawInfoContent: string;
-	onSendMessage: (content: string, attachments: string[]) => void;
+	onSendMessage: (
+		content: string,
+		attachments: string[],
+	) => undefined | boolean | Promise<undefined | boolean>;
 	currentJobId: string | null;
 	onCancelJob: (jobId: string) => void;
 	agentData?: AgentDetails | null;
@@ -98,6 +101,7 @@ type ChatContentProps = {
 	canonical?: {
 		view: CanonicalSessionHandle;
 		busy: boolean;
+		admitting?: boolean;
 		onStop: () => void;
 	};
 };
@@ -263,11 +267,13 @@ export const ChatContent: FC<ChatContentProps> = React.memo(
 							onOpenOptions={onOpenOptions}
 						/>
 						{/* Chat Options Sidebar */}
-						<ChatOptionsSidebar
-							open={isOptionsSidebarOpen}
-							onClose={onCloseOptions}
-							agentId={agentId}
-						/>
+						{!canonical && (
+							<ChatOptionsSidebar
+								open={isOptionsSidebarOpen}
+								onClose={onCloseOptions}
+								agentId={agentId}
+							/>
+						)}
 						{/* Tabs for chat and raw - only shown in development mode */}
 						{showTabs && (
 							<ChatTabs activeTab={activeTab} onChange={onTabChange} />
@@ -319,7 +325,7 @@ export const ChatContent: FC<ChatContentProps> = React.memo(
 								ref={messageInputRef}
 								onSendMessage={onSendMessage}
 								initialSuggestions={DEFAULT_MESSAGE_SUGGESTIONS}
-								isLoading={canonical ? false : isLoading}
+								isLoading={canonical ? Boolean(canonical.admitting) : isLoading}
 								conversationId={agentId}
 								messages={
 									canonical

--- a/src/renderer/src/features/chat/components/chat-page.tsx
+++ b/src/renderer/src/features/chat/components/chat-page.tsx
@@ -85,8 +85,13 @@ function SessionPanel({
 	const input = useRef<MessageInputHandle>(null);
 	const container = useRef<HTMLDivElement>(null);
 	const end = useRef<HTMLDivElement>(null);
+	// An existing session's send draft is keyed `send:<id>`, NOT by draftKey
+	// (which is null once a session exists). Reading only the staged draft left
+	// a failed send's retained text unreachable, so the user could neither see
+	// nor clear the text the guard was holding them to.
+	const draftIdentity = draftKey ?? (sessionId ? `send:${sessionId}` : null);
 	const draft = useCanonicalSessionsStore((state) =>
-		draftKey ? state.drafts[draftKey] : undefined,
+		draftIdentity ? state.drafts[draftIdentity] : undefined,
 	);
 	const cwd = useCanonicalSessionsStore((state) => state.cwd);
 	const setCwd = useCanonicalSessionsStore((state) => state.setCwd);
@@ -279,9 +284,35 @@ function SessionPanel({
 				</label>
 			)}
 			{(sendError || draft?.error) && (
-				<p role="alert" className="px-4 py-2 text-body-sm text-danger">
-					{sendError || draft?.error} Your draft is retained.
-				</p>
+				<div role="alert" className="px-4 py-2 text-body-sm text-danger">
+					<p>
+						{sendError || draft?.error}{" "}
+						{draft?.submittedText
+							? "Your message is kept below \u2014 send it again, or discard it to write something else."
+							: "Your draft is retained."}
+					</p>
+					{draft?.submittedText && (
+						<div className="mt-2 space-y-2">
+							<p className="whitespace-pre-wrap rounded-md border border-control bg-surface px-2 py-1 text-body-sm text-ink">
+								{draft.submittedText}
+							</p>
+							<button
+								type="button"
+								className="underline"
+								onClick={() => {
+									if (draftIdentity)
+										useCanonicalSessionsStore
+											.getState()
+											.discardDraft(draftIdentity);
+									setSendError(null);
+									setSendErrorCode(undefined);
+								}}
+							>
+								Discard unsent message
+							</button>
+						</div>
+					)}
+				</div>
 			)}
 			{(sendErrorCode ?? draft?.errorCode) === "unresolved_attachment" && (
 				<div className="flex gap-2 px-4 pb-2 text-body-sm">
@@ -347,6 +378,9 @@ function SessionPanel({
 					onTabChange={setTab}
 					agentName={title}
 					description={
+						// `loaded` names the agent/team actually answering; without it an
+						// opened chat showed only a cwd and the user could not tell which
+						// profile was in force.
 						loaded ||
 						(draftKey
 							? "The session starts when you send your first message."

--- a/src/renderer/src/features/chat/components/chat-page.tsx
+++ b/src/renderer/src/features/chat/components/chat-page.tsx
@@ -1,51 +1,26 @@
-import { createLocalOperatorClient } from "@shared/api/local-operator";
-import {
-	desktopResult,
-	isServerUnreachable,
-} from "@shared/api/local-operator/desktop-api";
+import { desktopResult } from "@shared/api/local-operator/desktop-api";
 import {
 	desktopFeatureEnabled,
 	useDesktopCapabilities,
 } from "@shared/api/local-operator/desktop-hooks";
-import { JobsApi } from "@shared/api/local-operator/jobs-api";
-import type { JobStatus } from "@shared/api/local-operator/types";
+import type { ChatTarget } from "@shared/api/local-operator/profile-hooks";
 import { ChatLayout } from "@shared/components/common/chat-layout";
-import { apiConfig } from "@shared/config";
-import { useAgent } from "@shared/hooks/use-agents";
 import { useCanonicalSessionStream } from "@shared/hooks/use-canonical-session";
-import { useConfig } from "@shared/hooks/use-config";
-import { useConversationMessages } from "@shared/hooks/use-conversation-messages";
 import { useDesktopWatchLease } from "@shared/hooks/use-desktop-watch-lease";
-import { useJobPolling } from "@shared/hooks/use-job-polling";
-import { useAgentRouteParam } from "@shared/hooks/use-route-params";
 import { useScrollToBottom } from "@shared/hooks/use-scroll-to-bottom";
-import { terminateStreamingMessages } from "@shared/hooks/use-streaming-message";
-import { useAgentSelectionStore } from "@shared/store/agent-selection-store";
-import { useCanonicalSessionsStore } from "@shared/store/canonical-sessions-store";
-import { useChatStore } from "@shared/store/chat-store";
-import { useConversationInputStore } from "@shared/store/conversation-input-store";
-import { useUiPreferencesStore } from "@shared/store/ui-preferences-store";
-import { isDevelopmentMode } from "@shared/utils/env-utils";
-import { showErrorToast } from "@shared/utils/toast-manager";
-import React, {
-	useState,
-	useMemo,
-	useEffect,
-	useCallback,
-	useRef,
-} from "react";
-import type { FC } from "react";
-import { useNavigate } from "react-router-dom";
-import { v4 as uuidv4 } from "uuid";
+import {
+	admitChatDraft,
+	useCanonicalSessionsStore,
+} from "@shared/store/canonical-sessions-store";
+import { useEffect, useRef, useState } from "react";
+import { useNavigate, useParams } from "react-router-dom";
 import { PickerOutlet } from "../pickers/picker-registry";
-import type { Message } from "../types/message";
 import { ChatContent } from "./chat-content";
 import { ChatSidebar } from "./chat-sidebar";
-import { ErrorView } from "./error-view";
 import type { MessageInputHandle } from "./message-input";
-import { PlaceholderView } from "./placeholder-view";
 import { useSlashDispatch } from "./slash-dispatch";
 
+const SESSION_ID = /^[a-f0-9]{12}$/;
 const IMAGE_MIME_BY_EXT: Record<
 	string,
 	"image/png" | "image/jpeg" | "image/gif" | "image/webp"
@@ -92,848 +67,457 @@ async function encodeImageAttachments(attachments: string[]) {
 	return images.slice(0, 8);
 }
 
-/**
- * Props for the ChatPage component
- * No props needed as we use React Router hooks internally
- */
-type ChatProps = Record<string, never>;
-
-/**
- * Chat Page Component
- *
- * Displays the chat interface with a sidebar for agent selection and a main area for messages
- * Uses React Router for navigation and state management
- */
-export const ChatPage: FC<ChatProps> = () => {
-	const didAutoScrollRef = React.useRef(false);
-	const messageInputRef = useRef<MessageInputHandle>(null);
-	// Get agent ID from URL parameters using custom hook
-	const { agentId, navigateToAgent } = useAgentRouteParam();
-	const navigate = useNavigate();
-	const isCanvasOpen = useUiPreferencesStore((state) => state.isCanvasOpen);
-	const setCanvasOpen = useUiPreferencesStore((state) => state.setCanvasOpen);
-
-	useEffect(() => {
-		const handleKeyDown = (event: KeyboardEvent) => {
-			if (
-				event.key === "c" &&
-				(event.metaKey || event.ctrlKey) &&
-				event.shiftKey
-			) {
-				event.preventDefault();
-				setCanvasOpen(!isCanvasOpen);
-			}
-		};
-
-		document.addEventListener("keydown", handleKeyDown);
-
-		return () => {
-			document.removeEventListener("keydown", handleKeyDown);
-		};
-	}, [isCanvasOpen, setCanvasOpen]);
-
-	// Get agent selection store functions
-	const setLastChatAgentId = useAgentSelectionStore(
-		(state) => state.setLastChatAgentId,
+/** Each displayed identity owns its stream and composer. A candidate open is
+ * prepared by the store first; changing rows never stops the outgoing runtime. */
+function SessionPanel({
+	identity,
+	draftKey,
+	sessionId,
+	pendingNavigation,
+}: {
+	identity: string;
+	draftKey: string | null;
+	sessionId?: string;
+	pendingNavigation: boolean;
+}) {
+	const canonical = useCanonicalSessionStream(sessionId, Boolean(sessionId));
+	useDesktopWatchLease(sessionId, canonical.subscriptionId);
+	const input = useRef<MessageInputHandle>(null);
+	const container = useRef<HTMLDivElement>(null);
+	const end = useRef<HTMLDivElement>(null);
+	const draft = useCanonicalSessionsStore((state) =>
+		draftKey ? state.drafts[draftKey] : undefined,
 	);
-	const getLastAgentId = useAgentSelectionStore(
-		(state) => state.getLastAgentId,
-	);
-	const clearAgentFromAllPages = useAgentSelectionStore(
-		(state) => state.clearAgentFromAllPages,
-	);
-
-	// Use the agent ID from URL or the last selected agent ID
-	const effectiveAgentId = agentId || getLastAgentId("chat");
-	const conversationId = effectiveAgentId || undefined;
-	const selectedConversation = effectiveAgentId || undefined;
-
-	// Canonical session identity. The agent id is a profile reference; the
-	// conversation the backend runs is a canonical 12-hex session id. Each
-	// agent maps to one canonical session that is created once and reopened
-	// on every later visit, so identity survives restarts and the watcher.
-	const capabilities = useDesktopCapabilities();
-	const canonicalEnabled =
-		desktopFeatureEnabled(capabilities.data, "commands") &&
-		desktopFeatureEnabled(capabilities.data, "lifecycle");
-	const sessionByAgent = useCanonicalSessionsStore(
-		(state) => state.sessionByAgent,
-	);
-	const createSession = useCanonicalSessionsStore(
-		(state) => state.createSession,
-	);
-	const setActiveSession = useCanonicalSessionsStore(
-		(state) => state.setActiveSession,
-	);
-	const bindSession = useCanonicalSessionsStore((state) => state.bindSession);
-	const canonicalSessionId = conversationId
-		? sessionByAgent[conversationId]
-		: undefined;
-
-	// In production mode, always use "chat" tab
-	const [activeTab, setActiveTab] = useState<"chat" | "raw">("chat");
-
-	// Force "chat" tab in production mode
-	useEffect(() => {
-		if (!isDevelopmentMode() && activeTab !== "chat") {
-			setActiveTab("chat");
-		}
-	}, [activeTab]);
-	const [isOptionsSidebarOpen, setIsOptionsSidebarOpen] = useState(false);
-
-	// Initialize the API client (memoized to prevent recreation on every render)
-	const apiClient = useMemo(
-		() => createLocalOperatorClient(apiConfig.baseUrl),
-		[],
-	);
-
-	// Get the chat store functions
-	const getMessages = useChatStore((state) => state.getMessages);
-
-	// Fetch agent details for the current conversation
-	const { data: agentData } = useAgent(conversationId);
-
-	// Bind the agent to a canonical session once its working directory is
-	// known. Creation is idempotent per agent through the store's mapping;
-	// re-mounting reopens the same identity rather than minting another.
-	const creatingSessionRef = useRef<string | null>(null);
-	useEffect(() => {
-		if (!canonicalEnabled || !conversationId || !agentData) return;
-		if (canonicalSessionId) {
-			setActiveSession(canonicalSessionId);
-			return;
-		}
-		if (creatingSessionRef.current === conversationId) return;
-		creatingSessionRef.current = conversationId;
-		const cwd = agentData.current_working_directory || "~";
-		void createSession(cwd, conversationId).finally(() => {
-			if (creatingSessionRef.current === conversationId) {
-				creatingSessionRef.current = null;
-			}
-		});
-	}, [
-		canonicalEnabled,
-		conversationId,
-		agentData,
-		canonicalSessionId,
-		createSession,
-		setActiveSession,
-	]);
-
-	// Canonical stream over the authenticated relay, plus the watch lease it
-	// keys off. A terminal canonical event is what resolves the legacy
-	// "Waiting to start" latch: the job poller can miss a fast failure, but
-	// the canonical stream always reports the turn boundary.
-	const canonical = useCanonicalSessionStream(
-		canonicalSessionId,
-		canonicalEnabled && Boolean(canonicalSessionId),
-	);
-	useDesktopWatchLease(canonicalSessionId, canonical.subscriptionId);
-
-	// Only fetch messages if we have a valid conversation ID
-	const {
-		messages,
-		isLoading: isLoadingMessages,
-		isError,
-		error,
-		isAgentNotFound,
-		isFetchingMore,
-		hasMoreMessages,
-		messagesContainerRef, // Get the ref from the hook
-		refetch,
-	} = useConversationMessages(conversationId);
-
-	// A persisted selection that the backend no longer knows is a stale
-	// pointer, not an error: the agent was deleted, or the config dir changed
-	// under the app. Drop it so the page falls back to the agent list instead
-	// of a dead-end banner. Only the remembered id is dropped -- an explicit
-	// URL to a missing agent still reports that it is missing, because there
-	// the user asked for it by name.
-	useEffect(() => {
-		if (isAgentNotFound && !agentId && effectiveAgentId) {
-			clearAgentFromAllPages(effectiveAgentId);
-		}
-	}, [isAgentNotFound, agentId, effectiveAgentId, clearAgentFromAllPages]);
-
-	// Get the addMessage function from the chat store
-	const addMessage = useChatStore((state) => state.addMessage);
-	const getCurrentInput = useConversationInputStore(
-		(state) => state.getCurrentInput,
-	);
-	const setCurrentInput = useConversationInputStore(
-		(state) => state.setCurrentInput,
-	);
-
-	// Use the job polling hook
-	const {
-		currentJobId,
-		setCurrentJobId,
-		jobStatus,
-		isLoading,
-		setIsLoading,
-		currentExecution,
-	} = useJobPolling({
-		conversationId,
-		addMessage,
-	});
-
-	// Canonical transcript mode: once the agent is bound to a canonical
-	// session and the stream is live, the conversation is painted from the
-	// backend's durable history + live events and prompts are admitted through
-	// `sessions.message`. The legacy job/message path below stays only for a
-	// backend that predates the desktop contract (capabilities fail closed).
-	const canonicalMode = canonicalEnabled && Boolean(canonicalSessionId);
-	const canonicalBusy =
-		canonicalMode &&
-		(canonical.frontend?.streaming === true ||
-			canonical.transcript.records.some(
-				(record) =>
-					(record.kind === "assistant" && record.streaming) ||
-					(record.kind === "tool" && record.phase !== "done"),
-			));
-	// Admission pending: the composer disables between POST and the owner's
-	// `message_start` echo so a double Enter cannot admit twice.
+	const cwd = useCanonicalSessionsStore((state) => state.cwd);
+	const setCwd = useCanonicalSessionsStore((state) => state.setCwd);
 	const [admitting, setAdmitting] = useState(false);
-
-	// Resolve the busy latch from the canonical stream. Each terminal event
-	// is consumed once (tracked by generation) so an old terminal does not
-	// clear a later turn's loading state.
-	const lastTerminalRef = useRef<string | null>(null);
-	useEffect(() => {
-		const marker = canonical.terminal
-			? `${canonical.receipt?.epoch ?? ""}:${canonical.receipt?.seq ?? 0}:${canonical.terminal}`
-			: null;
-		if (!marker || marker === lastTerminalRef.current) return;
-		lastTerminalRef.current = marker;
-		if (
-			canonical.terminal === "agent_end" ||
-			canonical.terminal === "turn_end"
-		) {
-			setIsLoading(false);
-		}
-	}, [canonical.terminal, canonical.receipt, setIsLoading]);
-
-	// Use custom hook to track scroll position and show/hide scroll button
-	// Pass the messagesContainerRef to the hook to ensure it tracks the correct container
+	const sendLock = useRef(false);
+	const lastCatalogueState = useRef("");
+	const [sendError, setSendError] = useState<string | null>(null);
+	const [sendErrorCode, setSendErrorCode] = useState<string | undefined>();
+	const [options, setOptions] = useState(false);
+	const [tab, setTab] = useState<"chat" | "raw">("chat");
 	const { isFarFromBottom, scrollToBottom } = useScrollToBottom(
 		50,
-		messagesContainerRef,
-		messages.length,
+		container,
+		canonical.transcript.records.length,
 	);
-
-	// Create a ref for the messages end element (for backwards compatibility)
-	const messagesEndRef = useRef<HTMLDivElement>(null);
-
-	// "New activity" instead of autoscroll: when messages grow while the
-	// reader is scrolled up, flag it and let them choose to jump. Cleared
-	// the moment they are back near the bottom.
-	const [hasNewActivity, setHasNewActivity] = useState(false);
-	const seenMessageCountRef = useRef(messages.length);
-	useEffect(() => {
-		if (messages.length > seenMessageCountRef.current && isFarFromBottom) {
-			setHasNewActivity(true);
-		}
-		seenMessageCountRef.current = messages.length;
-	}, [messages.length, isFarFromBottom]);
-	useEffect(() => {
-		if (!isFarFromBottom) setHasNewActivity(false);
-	}, [isFarFromBottom]);
-	// biome-ignore lint/correctness/useExhaustiveDependencies: reset on conversation change only
-	useEffect(() => {
-		// A new conversation starts with nothing unread.
-		setHasNewActivity(false);
-		seenMessageCountRef.current = 0;
-	}, [conversationId]);
-
-	// Update the last selected agent ID when the agent ID changes
-	// Force scroll to bottom only when switching to a new conversation
-	// Also, focus the input if the agentId has changed (intentional navigation)
-	useEffect(() => {
-		if (agentId) {
-			const previousAgentId = previousConversationIdRef.current;
-			setLastChatAgentId(agentId);
-
-			// Only scroll if we have a new conversation with loaded messages
-			if (!isLoadingMessages && messages.length > 0) {
-				const prevMessages = getMessages(agentId);
-				if (!prevMessages || prevMessages.length === 0) {
-					scrollToBottom();
-				}
-			}
-
-			// Focus input if agentId changed and it's not the initial load
-			if (previousAgentId && previousAgentId !== agentId) {
-				Promise.resolve().then(() => {
-					messageInputRef.current?.focusInput();
-				});
-			}
-		}
-	}, [
-		agentId,
-		setLastChatAgentId,
-		isLoadingMessages,
-		messages.length,
-		scrollToBottom,
-		getMessages,
-	]);
-
-	// Reset auto-scroll flag when conversation changes
-	// biome-ignore lint/correctness/useExhaustiveDependencies: only trigger on agentId change
-	useEffect(() => {
-		didAutoScrollRef.current = false;
-	}, [agentId]);
-
-	// Scroll to bottom when switching conversations or when messages load
-	// biome-ignore lint/correctness/useExhaustiveDependencies: messagesContainerRef.current is used but we don't want to re-run on every ref change
-	useEffect(() => {
-		// Reset auto-scroll flag when conversation changes
-		if (agentId !== previousConversationIdRef.current) {
-			didAutoScrollRef.current = false;
-			previousConversationIdRef.current = agentId;
-		}
-
-		// Scroll to bottom once after messages load and focus input
-		if (
-			!didAutoScrollRef.current &&
-			agentId &&
-			!isLoadingMessages &&
-			messages.length > 0
-		) {
-			// Immediately scroll to bottom (scrollTop = 0 in column-reverse)
-			if (messagesContainerRef.current) {
-				messagesContainerRef.current.scrollTop = 0;
-			}
-			// Focus the input after messages are loaded and scrolled
-			Promise.resolve().then(() => {
-				messageInputRef.current?.focusInput();
+	const busy = canonical.frontend?.streaming === true;
+	const navigate = useNavigate();
+	const rebind = (id: string) => {
+		void useCanonicalSessionsStore
+			.getState()
+			.openSession(id)
+			.then((ok) => {
+				if (ok) navigate(`/chat/${id}`);
 			});
-			didAutoScrollRef.current = true; // Mark that auto scroll and focus has happened
-		}
-	}, [agentId, isLoadingMessages, messages.length, scrollToBottom]); // Added scrollToBottom as it's used indirectly via didAutoScrollRef logic
-
-	// Reference to track previous conversation ID
-	const previousConversationIdRef = useRef<string | undefined>(undefined);
-
-	const handleOpenOptions = useCallback(() => {
-		setIsOptionsSidebarOpen(true);
-	}, []);
-
-	const handleCloseOptions = useCallback(() => {
-		setIsOptionsSidebarOpen(false);
-	}, []);
-
-	// Handle selecting a conversation
-	const handleSelectConversation = useCallback(
-		(id: string) => {
-			setLastChatAgentId(id);
-			navigateToAgent(id, "chat");
-		},
-		[setLastChatAgentId, navigateToAgent],
-	);
-
-	// Handle navigating to agent settings
-	const handleNavigateToAgentSettings = useCallback(
-		(agentId: string) => {
-			navigate(`/agents/${agentId}`);
-		},
-		[navigate],
-	);
-
-	// Handle job cancellation
-	const handleCancelJob = useCallback(
-		async (jobId: string) => {
-			if (!jobId) return;
-
-			let cancelError: unknown = null;
-			try {
-				await JobsApi.cancelJob(apiConfig.baseUrl, jobId);
-			} catch (error) {
-				console.error("Error cancelling job:", error);
-				cancelError = error;
-			}
-
-			// The local teardown runs whether or not the backend accepted the
-			// cancel. The user asked to stop, so the UI has to read as stopped:
-			// bailing out on a rejected request left the stream armed, which kept
-			// the composer disabled and the reconnect effect re-firing every
-			// 1600ms for the rest of the session with no way for the user back
-			// out — the cancel button appeared to do nothing, permanently.
-			//
-			// The backend no longer sends frames for a cancelled job, but nothing
-			// tells the client the stream was over: the store never marks it
-			// complete and the socket stays open. Marking the stream finished is
-			// what actually stops it — it stands the reconnect guard down, closes
-			// the socket, and lets the message settle into its final rendered
-			// state.
-			if (conversationId) {
-				terminateStreamingMessages(conversationId);
-			}
-
-			// Clear the current job ID and loading state
-			setCurrentJobId(null);
-			setIsLoading(false);
-
-			if (cancelError) {
-				// Said plainly rather than as a clean cancel: the local stream is
-				// down but the server never acknowledged, so the agent may still
-				// be working and the user needs to know that before they retry.
-				showErrorToast(
-					`Stopped locally, but the server did not confirm the cancellation: ${
-						cancelError instanceof Error ? cancelError.message : "unknown error"
-					}. The agent may still be running.`,
-				);
-			}
-
-			// Record the outcome in the transcript so it survives the toast.
-			if (conversationId) {
-				const outcomeMessage: Message = {
-					id: Date.now().toString(),
-					role: "system",
-					message: cancelError
-						? "Stopped by user. The server did not confirm the cancellation, so the agent may still be running."
-						: "Job cancelled by user.",
-					timestamp: new Date(),
-					status: cancelError ? "error" : undefined,
-				};
-
-				addMessage(conversationId, outcomeMessage);
-			}
-		},
-		[addMessage, conversationId, setCurrentJobId, setIsLoading],
-	);
-
-	// Memoized function to handle sending a new message
-	const { data: configData } = useConfig();
-
-	// Slash submissions are dispatched to the desktop command control, never
-	// admitted as model chat. The backend rejects slash text on /messages with
-	// 422 — intercepting here is what makes `/settings` navigate instead of
-	// failing against a missing model key one API round-trip later.
-	const rebindSession = useCallback(
-		(nextSessionId: string) => {
-			if (!conversationId) return;
-			bindSession(conversationId, nextSessionId);
-		},
-		[conversationId, bindSession],
-	);
-	// A send that never reached the backend must hand the user's words back.
-	// The composer reads its draft from the conversation input store on every
-	// value change, so writing there restores the text in place -- no second
-	// source of draft state, and it survives the navigation the failure might
-	// prompt. Attachments are deliberately NOT re-attached: the composer holds
-	// them as `Attachment` records and only their paths reach this callback, so
-	// re-adding them here would invent metadata; the note says what happened and
-	// the files are still on disk.
-	const restoreDraft = useCallback(
-		(content: string, _attachments: string[]) => {
-			if (!conversationId) return;
-			// Only when the composer is empty: the user may already be typing the
-			// next thing, and overwriting that would repeat the very defect this
-			// fixes.
-			if (getCurrentInput(conversationId).trim()) return;
-			setCurrentInput(conversationId, content);
-		},
-		[conversationId, getCurrentInput, setCurrentInput],
-	);
-
-	// Notes land in the transcript the user is LOOKING at. In canonical mode the
-	// view is painted from `canonical.view`, so a system row written into the
-	// legacy chat store goes to a surface nobody renders -- which is how a failed
-	// send lost both the message and its error (QA Q1, and UX U5 from the picker
-	// path). Same rule as `useSlashDispatch`'s own `note`, kept identical on
-	// purpose: one way to say something to the user, not two.
-	const note = useCallback(
-		(text: string, error = false) => {
-			if (canonicalMode && canonicalSessionId) {
-				canonical.addNote(text, error ? "error" : "info");
-				return;
-			}
-			if (!conversationId) return;
-			addMessage(conversationId, {
-				id: uuidv4(),
-				role: "system",
-				message: text,
-				timestamp: new Date(),
-				status: error ? "error" : undefined,
-			});
-		},
-		[
-			addMessage,
-			canonical.addNote,
-			canonicalMode,
-			canonicalSessionId,
-			conversationId,
-		],
-	);
-
-	const { dispatch: handleSlashDispatch, picker } = useSlashDispatch({
-		sessionId: canonicalSessionId,
-		addMessage: (message) => {
-			if (conversationId) addMessage(conversationId, message);
-		},
-		canonical,
-		rebind: rebindSession,
-	});
-
-	const handleSendMessage = useCallback(
-		async (content: string, attachments: string[]) => {
-			if (!conversationId) return;
-
-			// A leading slash is a command, full stop. Dispatch consumes it and
-			// nothing below (model job creation) runs for it.
-			if (await handleSlashDispatch(content)) return;
-
-			if (canonicalMode && canonicalSessionId) {
-				// Canonical admission. 200 means the owner ADMITTED the prompt, not
-				// that the model answered: the transcript paints the user row from
-				// the owner's own `message_start` echo (keyed by this request id),
-				// so nothing optimistic is inserted here to be deduplicated later.
-				// A pending gate is answered through the answers route instead of
-				// being admitted as a new prompt the owner would queue.
-				const gate = canonical.frontend?.pending_gate ?? null;
-				const requestId = uuidv4();
-				setAdmitting(true);
-				try {
-					if (gate && canonical.ownerEpoch) {
-						const trimmed = content.trim().toLowerCase();
-						if (gate.kind === "approval") {
-							const yes = ["y", "yes", "approve", "ok", "allow"].includes(
-								trimmed,
-							);
-							const no = ["n", "no", "deny", "reject", "cancel"].includes(
-								trimmed,
-							);
-							if (!yes && !no) {
-								note("Reply yes or no to answer the approval request.", true);
-								// The prompt was never sent, so it is still the user's to
-								// edit rather than something to retype from memory.
-								restoreDraft(content, attachments);
-								return;
-							}
-							await desktopResult({
-								op: "sessions.answer",
-								sessionId: canonicalSessionId,
-								epoch: canonical.ownerEpoch,
-								requestId: gate.request_id,
-								approved: yes,
-							});
-						} else {
-							await desktopResult({
-								op: "sessions.answer",
-								sessionId: canonicalSessionId,
-								epoch: canonical.ownerEpoch,
-								requestId: gate.request_id,
-								value: content,
-								questionIndex: gate.question_index,
-							});
-						}
-						return;
-					}
-					const images = await encodeImageAttachments(attachments);
-					await desktopResult({
-						op: "sessions.message",
-						sessionId: canonicalSessionId,
-						requestId,
-						text: content,
-						images: images.length > 0 ? images : undefined,
-						// Steer rather than queue when the owner is mid-turn: that is
-						// what typing during a turn means in the terminal too.
-						mode: canonicalBusy ? "steer" : "prompt",
-					});
-					requestAnimationFrame(() => scrollToBottom());
-				} catch (error) {
-					note(
-						`The message was not sent: ${
-							error instanceof Error ? error.message : "the backend refused it"
-						}`,
-						true,
-					);
-					// The composer clears on submit, so a failed admission used to
-					// DESTROY the typed prompt outright. Hand it back instead: the
-					// user's words are theirs, and a failure is not consent to lose
-					// them.
-					restoreDraft(content, attachments);
-				} finally {
-					setAdmitting(false);
-				}
-				return;
-			}
-
-			// Create a new user message
-			const userMessage: Message = {
-				id: uuidv4(),
-				role: "user",
-				message: content,
-				timestamp: new Date(),
-				files: attachments.length > 0 ? attachments : undefined,
-			};
-
-			// Add user message to chat store
-			addMessage(conversationId, userMessage);
-
-			// Scroll to bottom immediately after adding the message
-			// This ensures the user sees their message right away
-			requestAnimationFrame(() => {
-				scrollToBottom();
-			});
-
-			// Set loading state
-			setIsLoading(true);
-
-			try {
-				// Prepare options from agent settings
-				const options = {
-					temperature: agentData?.temperature,
-					top_p: agentData?.top_p,
-					top_k: agentData?.top_k,
-					max_tokens: agentData?.max_tokens,
-					stop: agentData?.stop,
-					frequency_penalty: agentData?.frequency_penalty,
-					presence_penalty: agentData?.presence_penalty,
-					seed: agentData?.seed,
-				};
-
-				// Filter out undefined values
-				const filteredOptions = Object.fromEntries(
-					Object.entries(options).filter(
-						([_, value]) => value !== undefined && value !== null,
-					),
-				);
-
-				const resolvedHosting =
-					!agentData?.hosting ||
-					agentData.hosting === "default" ||
-					agentData.hosting.trim() === ""
-						? configData?.values.hosting || ""
-						: agentData.hosting;
-
-				const resolvedModel =
-					!agentData?.model ||
-					agentData.model === "default" ||
-					agentData.model.trim() === ""
-						? configData?.values.model_name || ""
-						: agentData.model;
-
-				const jobDetails = await apiClient.chat.processAgentChatAsync(
-					conversationId,
-					{
-						hosting: resolvedHosting,
-						model: resolvedModel,
-						prompt: content,
-						persist_conversation: true,
-						user_message_id: userMessage.id,
-						options:
-							Object.keys(filteredOptions).length > 0
-								? filteredOptions
-								: undefined,
-						attachments: attachments.length > 0 ? attachments : undefined,
-					},
-				);
-
-				if (jobDetails.result?.id) {
-					setCurrentJobId(jobDetails.result.id);
-				} else {
-					console.error("Job details missing ID:", jobDetails);
-					throw new Error("Failed to get job ID from response");
-				}
-			} catch (error) {
-				console.error("Error sending message:", error);
-
-				let errorDetails = "Unknown error occurred";
-				if (error instanceof Error) {
-					errorDetails = `${error.message}\n${error.stack || ""}`;
-				} else if (typeof error === "object" && error !== null) {
-					errorDetails = JSON.stringify(error, null, 2);
-				}
-
-				const errorMessage: Message = {
-					id: Date.now().toString(),
-					role: "assistant",
-					message: "Sorry, there was an error processing your request.",
-					stderr: errorDetails,
-					timestamp: new Date(),
-					status: "error",
-				};
-
-				addMessage(conversationId, errorMessage);
-				setIsLoading(false);
-			}
-		},
-		[
-			conversationId,
-			addMessage,
-			setIsLoading,
-			agentData,
-			apiClient,
-			setCurrentJobId,
-			configData,
-			scrollToBottom,
-			handleSlashDispatch,
-			canonicalMode,
-			canonicalSessionId,
-			canonicalBusy,
-			canonical.frontend?.pending_gate,
-			canonical.ownerEpoch,
-			note,
-			restoreDraft,
-		],
-	);
-
-	// `/stop`-equivalent for the composer's stop button in canonical mode: the
-	// canonical stop control ends the session's current work through the
-	// owner's own protocol (never the legacy job cancel).
-	const handleCanonicalStop = useCallback(async () => {
-		if (!canonicalSessionId || !conversationId) return;
-		try {
-			const result = await desktopResult<{
-				data: { results?: { session_id: string; status: string }[] };
-			}>({
-				op: "sessions.stop",
-				requestId: uuidv4(),
-				targets: [canonicalSessionId],
-				confirmed: true,
-			});
-			const status = result.data?.results?.[0]?.status ?? "stop_requested";
-			addMessage(conversationId, {
-				id: uuidv4(),
-				role: "system",
-				message:
-					status === "already_stopped"
-						? "Nothing was running."
-						: "Stop requested. The session ends its current work.",
-				timestamp: new Date(),
-			});
-		} catch (error) {
-			addMessage(conversationId, {
-				id: uuidv4(),
-				role: "system",
-				message: `Stop was not accepted: ${
-					error instanceof Error ? error.message : "the backend refused it"
-				}`,
-				timestamp: new Date(),
-				status: "error",
-			});
-		}
-	}, [canonicalSessionId, conversationId, addMessage]);
-
-	// Memoize the raw information content to prevent re-rendering
-	const rawInfoContent = useMemo(() => {
-		if (!conversationId) return "";
-
-		return `Conversation ID: ${conversationId}
-Messages count: ${messages.length}
-Has more messages: ${hasMoreMessages ? "Yes" : "No"}
-Loading more: ${isFetchingMore ? "Yes" : "No"}
-Current job ID: ${currentJobId || "None"}
-Job status: ${jobStatus || "None"}
-Is loading: ${isLoading ? "Yes" : "No"}
-Store messages: ${JSON.stringify(getMessages(conversationId || ""), null, 2)}`;
-	}, [
-		conversationId,
-		messages.length,
-		hasMoreMessages,
-		isFetchingMore,
-		currentJobId,
-		jobStatus,
-		isLoading,
-		getMessages,
-	]);
-
-	// Handle tab change - only allow changing tabs in development mode
-	const handleTabChange = useCallback((newTab: "chat" | "raw") => {
-		if (isDevelopmentMode()) {
-			setActiveTab(newTab);
-		}
-	}, []);
-
-	// Render the appropriate content based on the state
-	const renderContent = () => {
-		if (!conversationId) {
-			return (
-				<PlaceholderView
-					title="No agent selected"
-					description="Select an agent from the sidebar to start a conversation."
-					directionText="Choose an agent from the list"
-				/>
-			);
-		}
-
-		if (isError) {
-			if (isAgentNotFound) {
-				// Reached only via a direct URL (the persisted case has already
-				// cleared itself above). The server answered, so the "local
-				// server" copy would be a false claim here.
-				return (
-					<PlaceholderView
-						title="This agent no longer exists"
-						description="It may have been deleted, or the app is using a different data folder. Pick another agent from the sidebar."
-						directionText="Choose an agent from the list"
-					/>
-				);
-			}
-			return (
-				<ErrorView
-					message={error?.message || ""}
-					serverUnreachable={isServerUnreachable(error)}
-				/>
-			);
-		}
-
-		return (
-			<ChatContent
-				activeTab={activeTab}
-				onTabChange={handleTabChange}
-				agentName={agentData?.name || ""}
-				description={agentData?.description || "Conversation with this agent"}
-				onOpenOptions={handleOpenOptions}
-				isOptionsSidebarOpen={isOptionsSidebarOpen}
-				onCloseOptions={handleCloseOptions}
-				agentId={conversationId}
-				messages={messages}
-				isLoading={isLoading}
-				isLoadingMessages={isLoadingMessages}
-				isFetchingMore={isFetchingMore}
-				isFarFromBottom={isFarFromBottom}
-				hasNewActivity={hasNewActivity}
-				jobStatus={jobStatus as JobStatus | null}
-				currentExecution={currentExecution}
-				messagesContainerRef={messagesContainerRef}
-				messagesEndRef={messagesEndRef}
-				scrollToBottom={scrollToBottom}
-				rawInfoContent={rawInfoContent}
-				onSendMessage={handleSendMessage}
-				currentJobId={currentJobId}
-				onCancelJob={handleCancelJob}
-				agentData={agentData}
-				refetch={refetch}
-				messageInputRef={messageInputRef}
-				canonical={
-					canonicalMode
-						? {
-								view: canonical,
-								busy: canonicalBusy || admitting,
-								onStop: handleCanonicalStop,
-							}
-						: undefined
-				}
-			/>
-		);
 	};
-
+	const { dispatch, picker } = useSlashDispatch({
+		sessionId,
+		canonical,
+		rebind,
+		addMessage: (message) => canonical.addNote(message.message ?? ""),
+	});
+	useEffect(() => {
+		if (draftKey) input.current?.focusInput();
+	}, [draftKey]);
+	useEffect(() => {
+		if (!sessionId || !canonical.frontend) return;
+		// Only metadata comes from the stream. Membership/order remain list-owned,
+		// and attention merges by the durable revision rather than arrival time.
+		const store = useCanonicalSessionsStore.getState();
+		if (!store.sessions.some((row) => row.session_id === sessionId)) return;
+		store.upsertSession({
+			session_id: sessionId,
+			title: canonical.frontend.conversation_title,
+			attention: canonical.frontend.attention,
+		});
+	}, [sessionId, canonical.frontend]);
+	useEffect(() => {
+		const marker = JSON.stringify([
+			sessionId,
+			canonical.frontend?.streaming,
+			canonical.frontend?.attention?.unseen,
+			canonical.frontend?.active_agent,
+			canonical.frontend?.active_team,
+		]);
+		if (!sessionId || marker === lastCatalogueState.current) return;
+		lastCatalogueState.current = marker;
+		void useCanonicalSessionsStore.getState().fetchSessions();
+	}, [
+		sessionId,
+		canonical.frontend?.streaming,
+		canonical.frontend?.attention?.unseen,
+		canonical.frontend?.active_agent,
+		canonical.frontend?.active_team,
+	]);
+	const send = async (
+		content: string,
+		attachments: string[],
+	): Promise<boolean> => {
+		const store = useCanonicalSessionsStore.getState();
+		const key = draftKey ?? `send:${sessionId}`;
+		const previous = store.drafts[key];
+		if (pendingNavigation || sendLock.current || previous?.pending)
+			return false;
+		sendLock.current = true;
+		setAdmitting(true);
+		setSendError(null);
+		setSendErrorCode(undefined);
+		try {
+			if (await dispatch(content)) return true;
+			if (!draftKey && !sessionId) return false;
+			const gate = canonical.frontend?.pending_gate;
+			if (gate && canonical.ownerEpoch && sessionId) {
+				if (gate.kind === "approval") {
+					const value = content.trim().toLowerCase();
+					const yes = ["y", "yes", "approve", "ok", "allow"].includes(value);
+					if (!yes && !["n", "no", "deny", "reject", "cancel"].includes(value))
+						throw new Error("Reply yes or no to answer the approval request.");
+					await desktopResult({
+						op: "sessions.answer",
+						sessionId,
+						epoch: canonical.ownerEpoch,
+						requestId: gate.request_id,
+						approved: yes,
+					});
+				} else
+					await desktopResult({
+						op: "sessions.answer",
+						sessionId,
+						epoch: canonical.ownerEpoch,
+						requestId: gate.request_id,
+						value: content,
+						questionIndex: gate.question_index,
+					});
+				return true;
+			}
+			const images = await encodeImageAttachments(attachments);
+			const id = await admitChatDraft(
+				key,
+				{
+					text: content,
+					attachments,
+					images,
+					mode: busy ? "steer" : "prompt",
+					cwd,
+				},
+				sessionId,
+			);
+			if (!id) return false;
+			if (
+				draftKey &&
+				useCanonicalSessionsStore.getState().activeSessionId === id
+			)
+				navigate(`/chat/${id}`, { replace: true });
+			void store.fetchSessions();
+			return true;
+		} catch (error) {
+			const message =
+				error instanceof Error
+					? error.message
+					: "The send could not be confirmed. Retry this draft.";
+			setSendError(message);
+			setSendErrorCode(
+				error instanceof Error &&
+					"code" in error &&
+					typeof error.code === "string"
+					? error.code
+					: undefined,
+			);
+			return false;
+		} finally {
+			sendLock.current = false;
+			setAdmitting(false);
+		}
+	};
+	const stop = () => {
+		if (sessionId)
+			void desktopResult({
+				op: "sessions.command",
+				sessionId,
+				requestId: crypto.randomUUID(),
+				command: "stop",
+			}).catch((error) =>
+				setSendError(
+					error instanceof Error
+						? error.message
+						: "Stop could not be confirmed.",
+				),
+			);
+	};
+	const loadedTarget =
+		canonical.frontend?.active_team ||
+		canonical.frontend?.active_agent ||
+		draft?.target?.name;
+	const title = draftKey
+		? loadedTarget
+			? `New chat with ${loadedTarget}`
+			: "New chat"
+		: canonical.frontend?.conversation_title || "Untitled chat";
+	const loaded = [
+		canonical.frontend?.active_agent,
+		canonical.frontend?.active_team,
+	]
+		.filter(Boolean)
+		.join(" · ");
+	const view = !sessionId
+		? { ...canonical, status: "live" as const, error: null }
+		: canonical;
 	return (
-		<>
-			<ChatLayout
-				sidebar={
-					<ChatSidebar
-						selectedConversation={selectedConversation}
-						onSelectConversation={handleSelectConversation}
-						onNavigateToAgentSettings={handleNavigateToAgentSettings}
+		<div className="flex h-full min-h-0 flex-col">
+			{draftKey && (
+				<label className="flex items-center gap-2 border-b border-hairline px-4 py-2 text-meta text-ink-muted">
+					Working directory
+					<input
+						aria-label="New chat working directory"
+						className="min-w-0 flex-1 rounded-md border border-control bg-surface px-2 py-1 text-ink"
+						value={cwd}
+						disabled={Boolean(draft?.sessionId) || admitting}
+						onChange={(event) => setCwd(event.target.value)}
 					/>
-				}
-				content={renderContent()}
-			/>
-			{/* The one picker host for slash destinations; null when idle. */}
+				</label>
+			)}
+			{(sendError || draft?.error) && (
+				<p role="alert" className="px-4 py-2 text-body-sm text-danger">
+					{sendError || draft?.error} Your draft is retained.
+				</p>
+			)}
+			{(sendErrorCode ?? draft?.errorCode) === "unresolved_attachment" && (
+				<div className="flex gap-2 px-4 pb-2 text-body-sm">
+					<button
+						type="button"
+						className="underline"
+						onClick={() => void dispatch("/agent")}
+					>
+						Choose agent
+					</button>
+					<button
+						type="button"
+						className="underline"
+						onClick={() => void dispatch("/team")}
+					>
+						Choose team
+					</button>
+				</div>
+			)}
+			{(sendErrorCode ?? draft?.errorCode) ===
+				"profile_registry_unavailable" && (
+				<button
+					type="button"
+					className="self-start px-4 pb-2 text-body-sm underline"
+					onClick={() => navigate("/agents")}
+				>
+					Manage agents
+				</button>
+			)}
+			{options && (
+				<div className="flex flex-wrap gap-2 border-b border-hairline px-4 py-2 text-body-sm">
+					{[
+						"model",
+						"agent",
+						"team",
+						"rename",
+						"resume",
+						"fork",
+						"new",
+						"settings",
+					].map((command) => (
+						<button
+							key={command}
+							type="button"
+							className="rounded-md px-2 py-1 hover:bg-elevated"
+							onClick={() => {
+								setOptions(false);
+								void dispatch(`/${command}`);
+							}}
+						>
+							{command === "agent"
+								? "Choose agent"
+								: command === "team"
+									? "Choose team"
+									: command.charAt(0).toUpperCase() + command.slice(1)}
+						</button>
+					))}
+				</div>
+			)}
+			<div className="min-h-0 flex-1">
+				<ChatContent
+					activeTab={tab}
+					onTabChange={setTab}
+					agentName={title}
+					description={
+						loaded ||
+						(draftKey
+							? "The session starts when you send your first message."
+							: canonical.frontend?.cwd || "Canonical chat")
+					}
+					onOpenOptions={() => setOptions((value) => !value)}
+					isOptionsSidebarOpen={false}
+					onCloseOptions={() => setOptions(false)}
+					agentId={identity}
+					messages={[]}
+					isLoading={false}
+					isLoadingMessages={false}
+					isFetchingMore={canonical.loadingOlder}
+					isFarFromBottom={isFarFromBottom}
+					messagesContainerRef={container}
+					messagesEndRef={end}
+					scrollToBottom={scrollToBottom}
+					rawInfoContent={JSON.stringify(canonical.frontend, null, 2)}
+					onSendMessage={send}
+					currentJobId={null}
+					onCancelJob={stop}
+					messageInputRef={input}
+					canonical={{
+						view,
+						busy,
+						admitting: admitting || pendingNavigation,
+						onStop: stop,
+					}}
+				/>
+			</div>
 			<PickerOutlet context={picker} />
-		</>
+		</div>
 	);
-};
+}
+
+export function ChatPage() {
+	const { agentId: routeIdentity } = useParams<{ agentId?: string }>();
+	const navigate = useNavigate();
+	const capabilities = useDesktopCapabilities();
+	const enabled = desktopFeatureEnabled(
+		capabilities.data,
+		"session_catalogue",
+		2,
+	);
+	const active = useCanonicalSessionsStore((state) => state.activeSessionId);
+	const draftKey = useCanonicalSessionsStore((state) => state.activeDraftKey);
+	const draft = useCanonicalSessionsStore((state) =>
+		draftKey ? state.drafts[draftKey] : undefined,
+	);
+	const pending = useCanonicalSessionsStore((state) => state.pendingSessionId);
+	const error = useCanonicalSessionsStore((state) => state.error);
+	const [routeError, setRouteError] = useState<string | null>(null);
+	useEffect(() => {
+		if (!enabled || !routeIdentity) return;
+		const store = useCanonicalSessionsStore.getState();
+		const id = SESSION_ID.test(routeIdentity)
+			? routeIdentity
+			: store.sessionByAgent[routeIdentity];
+		if (!id) {
+			setRouteError(
+				"This legacy link has no canonical chat. Its saved history is unchanged.",
+			);
+			return;
+		}
+		setRouteError(null);
+		if (store.activeSessionId !== id || store.activeDraftKey)
+			void store.openSession(id);
+	}, [enabled, routeIdentity]);
+	useEffect(() => {
+		const keydown = (event: KeyboardEvent) => {
+			if (
+				event.key === "Escape" &&
+				useCanonicalSessionsStore.getState().pendingSessionId
+			) {
+				event.preventDefault();
+				useCanonicalSessionsStore.getState().cancelOpen();
+			}
+		};
+		window.addEventListener("keydown", keydown);
+		return () => window.removeEventListener("keydown", keydown);
+	}, []);
+	const stage = (target?: ChatTarget, fresh?: boolean) => {
+		useCanonicalSessionsStore.getState().stageDraft(target, fresh);
+		setRouteError(null);
+		navigate("/chat");
+	};
+	const select = (id: string) => {
+		void useCanonicalSessionsStore
+			.getState()
+			.openSession(id)
+			.then((ok) => {
+				if (ok) {
+					setRouteError(null);
+					navigate(`/chat/${id}`);
+				}
+			});
+	};
+	const id = draftKey ? draft?.sessionId : (active ?? undefined);
+	const identity = draftKey ?? id;
+	return (
+		<ChatLayout
+			sidebar={
+				<ChatSidebar
+					selectedConversation={active ?? undefined}
+					onSelectConversation={select}
+					onStageDraft={stage}
+				/>
+			}
+			content={
+				<div className="flex h-full min-h-0 flex-col">
+					{pending && (
+						<p aria-live="polite" className="px-4 py-2 text-body-sm text-info">
+							Opening chat…{" "}
+							<button
+								type="button"
+								onClick={() =>
+									useCanonicalSessionsStore.getState().cancelOpen()
+								}
+							>
+								Cancel
+							</button>
+						</p>
+					)}
+					{(routeError || error) && (
+						<p role="alert" className="px-4 py-2 text-body-sm text-danger">
+							{routeError || error}
+						</p>
+					)}
+					{!enabled ? (
+						<div className="p-6 text-body text-ink-muted">
+							{capabilities.isLoading
+								? "Connecting to the backend…"
+								: capabilities.error
+									? capabilities.error.message
+									: "Update the backend to use canonical chats. Your existing histories are unchanged."}
+							<button
+								type="button"
+								className="ml-2 underline"
+								onClick={() => void capabilities.refetch()}
+							>
+								Retry
+							</button>
+						</div>
+					) : identity ? (
+						<div className="min-h-0 flex-1">
+							<SessionPanel
+								key={identity}
+								identity={identity}
+								draftKey={draftKey}
+								sessionId={id}
+								pendingNavigation={Boolean(pending)}
+							/>
+						</div>
+					) : (
+						<div className="p-6">
+							<h1 className="text-title">Start a chat</h1>
+							<p className="mt-2 text-body text-ink-muted">
+								Choose an agent or team, or start a new chat. Nothing starts
+								until you send.
+							</p>
+							<button
+								type="button"
+								className="mt-4 rounded-md border border-control px-3 py-2"
+								onClick={() => stage(undefined, true)}
+							>
+								New chat
+							</button>
+						</div>
+					)}
+				</div>
+			}
+		/>
+	);
+}

--- a/src/renderer/src/features/chat/components/chat-page.tsx
+++ b/src/renderer/src/features/chat/components/chat-page.tsx
@@ -160,7 +160,8 @@ function SessionPanel({
 		const store = useCanonicalSessionsStore.getState();
 		// Same identity the view reads, so a send can never address a different
 		// draft than the one whose retained text and Discard control are shown.
-		const key = draftIdentityFor(draftKey, sessionId) ?? `send:${sessionId}`;
+		const key = draftIdentityFor(draftKey, sessionId);
+		if (!key) return false;
 		const previous = store.drafts[key];
 		if (pendingNavigation || sendLock.current || previous?.pending)
 			return false;

--- a/src/renderer/src/features/chat/components/chat-page.tsx
+++ b/src/renderer/src/features/chat/components/chat-page.tsx
@@ -10,6 +10,7 @@ import { useDesktopWatchLease } from "@shared/hooks/use-desktop-watch-lease";
 import { useScrollToBottom } from "@shared/hooks/use-scroll-to-bottom";
 import {
 	admitChatDraft,
+	draftIdentityFor,
 	useCanonicalSessionsStore,
 } from "@shared/store/canonical-sessions-store";
 import { useEffect, useRef, useState } from "react";
@@ -85,11 +86,7 @@ function SessionPanel({
 	const input = useRef<MessageInputHandle>(null);
 	const container = useRef<HTMLDivElement>(null);
 	const end = useRef<HTMLDivElement>(null);
-	// An existing session's send draft is keyed `send:<id>`, NOT by draftKey
-	// (which is null once a session exists). Reading only the staged draft left
-	// a failed send's retained text unreachable, so the user could neither see
-	// nor clear the text the guard was holding them to.
-	const draftIdentity = draftKey ?? (sessionId ? `send:${sessionId}` : null);
+	const draftIdentity = draftIdentityFor(draftKey, sessionId);
 	const draft = useCanonicalSessionsStore((state) =>
 		draftIdentity ? state.drafts[draftIdentity] : undefined,
 	);
@@ -161,7 +158,9 @@ function SessionPanel({
 		attachments: string[],
 	): Promise<boolean> => {
 		const store = useCanonicalSessionsStore.getState();
-		const key = draftKey ?? `send:${sessionId}`;
+		// Same identity the view reads, so a send can never address a different
+		// draft than the one whose retained text and Discard control are shown.
+		const key = draftIdentityFor(draftKey, sessionId) ?? `send:${sessionId}`;
 		const previous = store.drafts[key];
 		if (pendingNavigation || sendLock.current || previous?.pending)
 			return false;
@@ -260,12 +259,23 @@ function SessionPanel({
 			? `New chat with ${loadedTarget}`
 			: "New chat"
 		: canonical.frontend?.conversation_title || "Untitled chat";
-	const loaded = [
-		canonical.frontend?.active_agent,
-		canonical.frontend?.active_team,
-	]
-		.filter(Boolean)
-		.join(" · ");
+	// active_agent/active_team come from the LIVE stream, so a cold session (no
+	// running owner) reports nulls and the header fell back to the cwd, naming
+	// nothing. The catalogue row's binding is the durable answer and is already
+	// what the sidebar groups by, so it is the fallback rather than a second
+	// source of truth: live values still win while an owner is attached.
+	const boundRow = useCanonicalSessionsStore((state) =>
+		sessionId
+			? state.sessions.find((row) => row.session_id === sessionId)
+			: undefined,
+	);
+	const loaded =
+		[canonical.frontend?.active_agent, canonical.frontend?.active_team]
+			.filter(Boolean)
+			.join(" · ") ||
+		[boundRow?.binding?.agent, boundRow?.binding?.team]
+			.filter(Boolean)
+			.join(" · ");
 	const view = !sessionId
 		? { ...canonical, status: "live" as const, error: null }
 		: canonical;

--- a/src/renderer/src/features/chat/components/chat-sidebar.tsx
+++ b/src/renderer/src/features/chat/components/chat-sidebar.tsx
@@ -1,608 +1,487 @@
-import { UploadAgentDialog } from "@features/agents/components/upload-agent-dialog";
-import type { AgentDetails } from "@shared/api/local-operator/types";
 import {
-	AgentOptionsMenu,
-	CompactPagination,
-	ImportAgentDialog,
-	SidebarHeader,
-} from "@shared/components/common";
-import { Spinner } from "@shared/components/common/spinner";
+	desktopFeatureEnabled,
+	useDesktopCapabilities,
+} from "@shared/api/local-operator/desktop-hooks";
 import {
-	Alert,
-	AlertDescription,
-	Avatar,
-	AvatarFallback,
-	Button,
-	Tooltip,
-	TooltipProvider,
-} from "@shared/components/ui";
-import {
-	useAgent,
-	useAgents,
-	useClearAgentConversation,
-	useExportAgent,
-	usePaginationParams,
-} from "@shared/hooks";
-import { useDebouncedValue } from "@shared/hooks/use-debounced-value";
-import { useRadientAuth } from "@shared/hooks/use-radient-auth";
+	type ChatTarget,
+	useProfiles,
+	useTeams,
+} from "@shared/api/local-operator/profile-hooks";
 import { cn } from "@shared/lib/utils";
-import { useCanonicalSessionsStore } from "@shared/store/canonical-sessions-store";
-import { useUiPreferencesStore } from "@shared/store/ui-preferences-store";
-import { formatMessageDateTime } from "@shared/utils/date-utils";
-import { Bot, MessageCircleOff } from "lucide-react";
-import type { ChangeEvent, FC } from "react";
-import { memo, useCallback, useEffect, useMemo, useState } from "react";
+import {
+	type CanonicalSessionRow,
+	useCanonicalSessionsStore,
+} from "@shared/store/canonical-sessions-store";
+import {
+	Bot,
+	Check,
+	ChevronDown,
+	ChevronRight,
+	Circle,
+	CircleAlert,
+	Clock,
+	List,
+	LoaderCircle,
+	MessageSquare,
+	MoreHorizontal,
+	Pause,
+	Plus,
+	Users,
+} from "lucide-react";
+import { type KeyboardEvent, useEffect, useMemo, useState } from "react";
 import { useNavigate } from "react-router-dom";
 
-/**
- * The rows truncate, so a tooltip is the only way to read a long name or
- * message preview. The delay keeps them quiet while the pointer merely
- * crosses the list.
- */
-const ROW_TOOLTIP_DELAY_MS = 1200;
-
-/**
- * Props for the ChatSidebar component
- */
-type ChatSidebarProps = {
-	/** Currently selected conversation ID */
+type Props = {
 	selectedConversation?: string;
-	/** Callback for when a conversation is selected */
 	onSelectConversation: (id: string) => void;
-	/** Callback for navigating to agent settings */
-	onNavigateToAgentSettings?: (agentId: string) => void;
+	onStageDraft: (target?: ChatTarget, fresh?: boolean) => void;
 };
+const rowStyle =
+	"flex h-8 min-w-0 items-center gap-1 rounded-md px-1 text-body-sm leading-5 hover:bg-elevated focus-visible:outline focus-visible:outline-2 focus-visible:outline-accent focus-visible:outline-offset-2";
 
-type ChatSidebarItemProps = {
-	agent: AgentDetails;
-	isSelected: boolean;
-	onSelectConversation: (agentId: string) => void;
-	onNavigateToAgentSettings?: (agentId: string) => void;
-	onExportAgent: (agentId: string) => void;
-	onClearAgentConversation: (agentId: string) => void;
-	onAgentDeleted: (deletedAgentId: string) => void;
-	onUploadAgentToHub: (agent: AgentDetails) => void;
-	formatMessageDateTime: (date: string) => string;
-	truncateMessage: (message?: string, maxLength?: number) => string;
-	index: number;
-	/**
-	 * The last reply from this agent's CANONICAL session, when it has one.
-	 *
-	 * Preferred over `agent.last_message`, which only the legacy execution path
-	 * ever writes: a canonical session keeps its conversation in its own
-	 * transcript, so every such row read "No messages yet" while displaying the
-	 * timestamp of the message it was denying (design D19).
-	 */
-	sessionPreview?: string;
-};
-
-const ChatSidebarItem: FC<ChatSidebarItemProps> = ({
-	agent,
-	isSelected,
-	onSelectConversation,
-	onNavigateToAgentSettings,
-	onExportAgent,
-	onClearAgentConversation,
-	onAgentDeleted,
-	onUploadAgentToHub,
-	formatMessageDateTime,
-	truncateMessage,
-	index,
-	sessionPreview,
-}) => {
-	// One authority per row, canonical first: the transcript is where a
-	// canonical session's conversation actually lives.
-	const lastMessage = sessionPreview || agent.last_message;
+function Status({ row }: { row: CanonicalSessionRow }) {
+	const code = row.status?.code;
+	const Icon =
+		code === "busy"
+			? LoaderCircle
+			: code === "approval" ||
+					code === "answer" ||
+					code === "wedged" ||
+					code === "error"
+				? CircleAlert
+				: code === "interrupted" || code === "dormant"
+					? Pause
+					: code === "complete"
+						? Check
+						: code === "scheduled"
+							? Clock
+							: code === "attached"
+								? MessageSquare
+								: Circle;
+	const ink =
+		code === "busy"
+			? "text-info motion-safe:animate-spin"
+			: code === "error" || code === "wedged"
+				? "text-danger"
+				: code === "approval" || code === "answer" || code === "interrupted"
+					? "text-warning"
+					: code === "complete"
+						? "text-success"
+						: "text-ink-dim";
 	return (
-		<li className="group relative">
-			<button
-				type="button"
-				onClick={() => onSelectConversation(agent.id)}
-				// Matched by `use-onboarding-tour.ts`, which also clicks it — the tag
-				// must stay on the button, and the value is fixed.
-				data-tour-tag={`agent-list-item-button-${index}`}
-				// The selected row is styled *and* announced: colour alone leaves a
-				// screen reader with no way to tell which conversation is open.
-				aria-current={isSelected ? "true" : undefined}
-				className={cn(
-					"flex w-full items-center gap-3 rounded-md px-2 py-1 pr-9 text-left",
-					"transition-colors duration-fast ease-out-quart",
-					isSelected ? "bg-accent-wash" : "hover:bg-elevated",
-				)}
-			>
-				<Avatar className="size-9 shrink-0">
-					<AvatarFallback>
-						<Bot size={18} aria-hidden={true} />
-					</AvatarFallback>
-				</Avatar>
-				<span className="relative isolate min-w-0 flex-1 overflow-hidden">
-					<span className="relative flex w-full items-center gap-2 overflow-hidden">
-						<Tooltip content={agent.name} side="top" align="start">
-							<span className="mb-0.5 min-w-0 flex-1 truncate font-semibold text-body-sm text-ink">
-								{agent.name}
-							</span>
-						</Tooltip>
-						{agent.last_message_datetime && (
-							/* No `title`: this span is `pointer-events-none`, so it is never
-							   the hit target and a native tooltip has nothing to trigger on.
-							   The attribute sat here looking like the exact timestamp was
-							   recoverable when it never was. The row already opens a real
-							   tooltip on the agent name beside it. */
-							<span className="pointer-events-none ml-2 flex shrink-0 items-center text-meta text-ink-dim">
-								{formatMessageDateTime(agent.last_message_datetime)}
-							</span>
-						)}
-					</span>
-
-					{lastMessage ? (
-						<Tooltip
-							content={truncateMessage(lastMessage, 500)}
-							side="bottom"
-							align="start"
-						>
-							<span className="block min-h-[18px] w-full truncate text-meta text-ink-muted">
-								{truncateMessage(lastMessage, 40)}
-							</span>
-						</Tooltip>
-					) : (
-						<span className="flex min-h-[18px] items-center gap-1 truncate text-meta italic text-ink-dim">
-							<MessageCircleOff size={12} aria-hidden={true} />
-							<span>No messages yet</span>
-						</span>
-					)}
-				</span>
-			</button>
-			<div
-				className={cn(
-					"pointer-events-none absolute top-0 right-1 flex h-full items-center",
-					"opacity-0 transition-opacity duration-fast ease-out-quart",
-					"group-hover:pointer-events-auto group-hover:opacity-100",
-					"group-focus-within:pointer-events-auto group-focus-within:opacity-100",
-				)}
-			>
-				<Tooltip content="Agent options">
-					<span>
-						<AgentOptionsMenu
-							agentId={agent.id}
-							agentName={agent.name}
-							isAgentsPage={false}
-							onViewAgentSettings={
-								onNavigateToAgentSettings
-									? () => onNavigateToAgentSettings(agent.id)
-									: undefined
-							}
-							onExportAgent={() => onExportAgent(agent.id)}
-							onClearConversation={() => onClearAgentConversation(agent.id)}
-							onAgentDeleted={onAgentDeleted}
-							onUploadAgentToHub={() => onUploadAgentToHub(agent)}
-							buttonSx={{
-								width: 24,
-								height: 24,
-								borderRadius: "6px",
-								display: "flex",
-								justifyContent: "center",
-								alignItems: "center",
-							}}
-						/>
-					</span>
-				</Tooltip>
-			</div>
-		</li>
+		<span
+			className="flex size-4 shrink-0"
+			title={row.status?.label ?? "Recent"}
+		>
+			<Icon className={cn("size-4", ink)} aria-hidden="true" />
+			<span className="sr-only">{row.status?.label ?? "Recent"}</span>
+		</span>
 	);
-};
+}
 
-const areChatSidebarItemsEqual = (
-	prev: Readonly<ChatSidebarItemProps>,
-	next: Readonly<ChatSidebarItemProps>,
-): boolean => {
-	return (
-		prev.isSelected === next.isSelected &&
-		prev.index === next.index &&
-		prev.agent.id === next.agent.id &&
-		prev.agent.name === next.agent.name &&
-		prev.agent.last_message === next.agent.last_message &&
-		prev.agent.last_message_datetime === next.agent.last_message_datetime &&
-		// Compared explicitly, like every other displayed field: this list uses a
-		// hand-written comparator, so a preview arriving from the canonical
-		// session list would otherwise never repaint the row it belongs to.
-		prev.sessionPreview === next.sessionPreview &&
-		prev.onSelectConversation === next.onSelectConversation &&
-		prev.onNavigateToAgentSettings === next.onNavigateToAgentSettings &&
-		prev.onExportAgent === next.onExportAgent &&
-		prev.onClearAgentConversation === next.onClearAgentConversation &&
-		prev.onAgentDeleted === next.onAgentDeleted &&
-		prev.onUploadAgentToHub === next.onUploadAgentToHub &&
-		prev.formatMessageDateTime === next.formatMessageDateTime &&
-		prev.truncateMessage === next.truncateMessage
-	);
-};
-
-const MemoizedChatSidebarItem = memo(ChatSidebarItem, areChatSidebarItemsEqual);
-
-/**
- * Chat Sidebar Component
- *
- * Displays a list of agents with search, create, and delete functionality
- * Uses React Router for navigation
- */
-const ChatSidebarComponent: FC<ChatSidebarProps> = ({
+export function ChatSidebar({
 	selectedConversation,
 	onSelectConversation,
-	onNavigateToAgentSettings,
-}) => {
-	const [searchQuery, setSearchQuery] = useState("");
-	const openCreateAgentDialog = useUiPreferencesStore(
-		(state) => state.openCreateAgentDialog,
-	);
-	const debouncedSearchQuery = useDebouncedValue(searchQuery.trim(), 250);
-	const [isImportDialogOpen, setIsImportDialogOpen] = useState(false);
-	const perPage = 50;
-
-	// Upload to Hub dialog state
-	const [isUploadDialogOpen, setIsUploadDialogOpen] = useState(false);
-	const [uploadAgent, setUploadAgent] = useState<AgentDetails | null>(null);
-	const [uploadValidationIssues, setUploadValidationIssues] = useState<
-		string[]
-	>([]);
-	const { isAuthenticated } = useRadientAuth();
-
-	// Navigation
+	onStageDraft,
+}: Props) {
 	const navigate = useNavigate();
-
-	// Export agent mutation
-	const exportAgentMutation = useExportAgent();
-
-	// Clear conversation mutation
-	const clearConversationMutation = useClearAgentConversation();
-
-	// Use the pagination hook to get and set the page from URL
-	const { page, setPage } = usePaginationParams();
-
-	const {
-		data: agentListResult,
-		isLoading,
-		isError,
-		refetch,
-	} = useAgents(
-		page,
-		perPage,
-		0,
-		debouncedSearchQuery || undefined,
-		"last_message_datetime",
-		"desc",
+	const capabilities = useDesktopCapabilities();
+	const ready = desktopFeatureEnabled(
+		capabilities.data,
+		"session_catalogue",
+		2,
 	);
-
-	// Extract agents and total count from the result
-	const agents = agentListResult?.agents || [];
-	const totalAgents = agentListResult?.total || 0;
-
-	// Fetch details for the selected agent if it's not in the current list
-	const { data: selectedAgentDetails } = useAgent(
-		// Only fetch if selectedConversation exists and is not found in the current agents list
-		selectedConversation && !agents.find((a) => a.id === selectedConversation)
-			? selectedConversation
-			: undefined,
+	const profiles = useProfiles(
+		ready && desktopFeatureEnabled(capabilities.data, "profile_catalogue"),
 	);
-
-	// Agent id -> the last reply of the CANONICAL session bound to it.
-	//
-	// The list is agent-backed while the conversation is canonical, so the two
-	// are joined through the binding the store already maintains. Without this
-	// the row falls back to `agent.last_message`, which only the legacy path
-	// writes -- the "No messages yet" on conversations that plainly have them
-	// (design D19).
-	const canonicalSessions = useCanonicalSessionsStore(
-		(state) => state.sessions,
+	const teams = useTeams(
+		ready && desktopFeatureEnabled(capabilities.data, "team_catalogue"),
 	);
-	const sessionByAgentId = useCanonicalSessionsStore(
-		(state) => state.sessionByAgent,
-	);
-	const fetchSessions = useCanonicalSessionsStore(
-		(state) => state.fetchSessions,
-	);
-	/*
-	 * Fill the store the join above reads from.
-	 *
-	 * `createSession`/`bindSession` write only `{session_id, agent_id}` rows --
-	 * identity, no transcript-derived fields -- and only `sessionByAgent` and
-	 * `activeSessionId` are persisted. So without this the preview join had
-	 * nothing to join AGAINST in the shipped app: every row fell back to the
-	 * legacy `agent.last_message` and rendered "No messages yet", which is the
-	 * D19 symptom the backend `preview` was added to cure.
-	 *
-	 * This calls the store's own `sessions.list` rather than introducing a
-	 * second cache: the picker's React Query copy is a different surface with a
-	 * different shape, and two caches of the same list is how they drift.
-	 * Re-run when the agent page changes, because that is when the set of rows
-	 * needing a preview changes.
-	 */
+	const sessions = useCanonicalSessionsStore((s) => s.sessions);
+	const fetchSessions = useCanonicalSessionsStore((s) => s.fetchSessions);
+	const loading = useCanonicalSessionsStore((s) => s.loading);
+	const error = useCanonicalSessionsStore((s) => s.error);
+	const truncated = useCanonicalSessionsStore((s) => s.truncated);
+	const activeDraftKey = useCanonicalSessionsStore((s) => s.activeDraftKey);
+	const drafts = useCanonicalSessionsStore((s) => s.drafts);
+	const pendingId = useCanonicalSessionsStore((s) => s.pendingSessionId);
+	const [query, setQuery] = useState("");
+	const [all, setAll] = useState(false);
+	const [expanded, setExpanded] = useState<Record<string, boolean>>(() => {
+		try {
+			return JSON.parse(
+				localStorage.getItem("chat-sidebar-disclosures") ?? "{}",
+			);
+		} catch {
+			return {};
+		}
+	});
+	const isOpen = (key: string, initial = false) => expanded[key] ?? initial;
+	const toggle = (key: string, initial = false) =>
+		setExpanded((current) => ({
+			...current,
+			[key]: !(current[key] ?? initial),
+		}));
 	useEffect(() => {
+		localStorage.setItem("chat-sidebar-disclosures", JSON.stringify(expanded));
+	}, [expanded]);
+	useEffect(() => {
+		if (!ready) return;
 		void fetchSessions();
-	}, [fetchSessions]);
-	const previewByAgent = useMemo(() => {
-		const previews: Record<string, string> = {};
-		const bySession = new Map(
-			canonicalSessions.map((row) => [row.session_id, row]),
+		const timer = window.setInterval(() => {
+			if (document.visibilityState === "visible") void fetchSessions();
+		}, 5000);
+		return () => window.clearInterval(timer);
+	}, [ready, fetchSessions]);
+	const matching = useMemo(
+		() =>
+			sessions.filter((row) =>
+				`${row.title ?? ""} ${row.binding?.agent ?? ""} ${row.binding?.team ?? ""}`
+					.toLocaleLowerCase()
+					.includes(query.toLocaleLowerCase()),
+			),
+		[sessions, query],
+	);
+	const children = (kind: ChatTarget["kind"], name: string) =>
+		matching.filter((row) =>
+			kind === "team"
+				? row.binding?.team === name
+				: !row.binding?.team && row.binding?.agent === name,
 		);
-		for (const [agentId, sessionId] of Object.entries(sessionByAgentId)) {
-			const preview = bySession.get(sessionId)?.preview;
-			if (typeof preview === "string" && preview) previews[agentId] = preview;
-		}
-		return previews;
-	}, [canonicalSessions, sessionByAgentId]);
-
-	// Memoize combinedAgents to stabilize its reference for hook dependencies
-	const combinedAgents = useMemo(() => {
-		const combined = [...agents];
-		if (
-			selectedAgentDetails &&
-			!combined.find((a) => a.id === selectedAgentDetails.id)
-		) {
-			// Add the selected agent if it's not already in the list
-			combined.push(selectedAgentDetails);
-		}
-		return combined;
-	}, [agents, selectedAgentDetails]);
-
-	const handlePageChange = useCallback(
-		(_event: ChangeEvent<unknown>, value: number) => {
-			setPage(value);
-		},
-		[setPage],
-	);
-
-	const handleSelectConversation = useCallback(
-		(agentId: string) => {
-			onSelectConversation(agentId);
-		},
-		[onSelectConversation],
-	);
-
-	const handleOpenImportDialog = useCallback(() => {
-		setIsImportDialogOpen(true);
-	}, []);
-
-	const handleCloseImportDialog = useCallback(() => {
-		setIsImportDialogOpen(false);
-	}, []);
-
-	const handleExportAgent = useCallback(
-		async (agentId: string) => {
-			try {
-				const blob = await exportAgentMutation.mutateAsync(agentId);
-
-				// Get the agent name for the filename (check combined list)
-				const agent = combinedAgents.find((a) => a.id === agentId);
-				const agentName = agent
-					? agent.name.replace(/\s+/g, "-").toLowerCase()
-					: agentId;
-
-				// Create a download link
-				const url = URL.createObjectURL(blob);
-				const a = document.createElement("a");
-				a.href = url;
-				a.download = `${agentName}-export.zip`;
-				document.body.appendChild(a);
-				a.click();
-
-				// Clean up
-				URL.revokeObjectURL(url);
-				document.body.removeChild(a);
-			} catch (error) {
-				console.error("Failed to export agent:", error);
-			}
-		},
-		[combinedAgents, exportAgentMutation], // Use combinedAgents
-	);
-
-	const getAgentUploadValidationIssues = useCallback(
-		(agent: AgentDetails | null): string[] => {
-			if (!agent) return ["No agent selected."];
-			const issues: string[] = [];
-			if (!agent.name || agent.name.trim() === "")
-				issues.push("Name is required.");
-			if (!agent.description || agent.description.trim() === "")
-				issues.push("Description is required.");
-			const hasCategory = agent.categories && agent.categories.length > 0;
-			if (!hasCategory) issues.push("At least one category is required.");
-			return issues;
-		},
-		[],
-	); // Empty dependency array as it doesn't rely on component scope variables that change
-
-	const handleOpenUploadDialog = useCallback(
-		(agent: AgentDetails) => {
-			setUploadAgent(agent);
-			setUploadValidationIssues(getAgentUploadValidationIssues(agent));
-			setIsUploadDialogOpen(true);
-		},
-		[getAgentUploadValidationIssues],
-	);
-
-	const handleCloseUploadDialog = useCallback(() => {
-		setIsUploadDialogOpen(false);
-		setUploadAgent(null);
-		setUploadValidationIssues([]);
-	}, []);
-
-	const handleConfirmUpload = useCallback(() => {
-		// Implement actual upload logic here if needed
-		handleCloseUploadDialog();
-	}, [handleCloseUploadDialog]);
-
-	const handleAgentCreated = useCallback(
-		(agentId: string) => {
-			// Fetch the agent details to get the full agent object
-			const fetchAndSelectAgent = async () => {
-				try {
-					// Refetch the agents list to update the UI
-					const result = await refetch();
-
-					// Get the updated agents list from the refetch result
-					const updatedAgentList = result.data?.agents || [];
-
-					// Find the newly created agent in the updated list
-					const createdAgent = updatedAgentList.find(
-						(agent: AgentDetails) => agent.id === agentId,
-					);
-
-					// Select the newly created agent if found
-					if (createdAgent) {
-						onSelectConversation(agentId);
-					} else {
-						// If the agent wasn't found in the updated list, still select it
-						// The agent details will be fetched when needed
-						onSelectConversation(agentId);
-					}
-				} catch (error) {
-					console.error("Error fetching agent details:", error);
-					// Still select the agent even if there was an error
-					onSelectConversation(agentId);
-				}
-			};
-
-			fetchAndSelectAgent();
-		},
-		[onSelectConversation, refetch],
-	);
-
-	const handleClearAgentConversation = useCallback(
-		(agentId: string) => {
-			clearConversationMutation.mutate({ agentId });
-		},
-		[clearConversationMutation],
-	);
-
-	const handleAgentDeleted = useCallback(
-		(deletedAgentId: string) => {
-			if (selectedConversation === deletedAgentId) {
-				onSelectConversation(""); // Clear selection if the deleted agent was selected
-			}
-			refetch(); // Refetch the agent list
-			navigate("/chat"); // Navigate to the main chat page
-		},
-		[selectedConversation, onSelectConversation, refetch, navigate],
-	);
-
-	const handleUploadAgentToHub = useCallback(
-		(agent: AgentDetails) => {
-			handleOpenUploadDialog(agent);
-		},
-		[handleOpenUploadDialog], // handleOpenUploadDialog is stable as it's not in deps array of its own useCallback
-	);
-
-	const truncateMessage = useCallback((message?: string, maxLength = 60) => {
-		if (!message) return "";
-		return message.length > maxLength
-			? `${message.substring(0, maxLength)}...`
-			: message;
-	}, []);
-
-	return (
-		<div
-			className="flex h-full w-full flex-col overflow-hidden border-hairline border-r bg-surface"
-			data-tour-tag="agent-list-panel"
-		>
-			<SidebarHeader
-				title="Agents"
-				searchQuery={searchQuery}
-				onSearchChange={(query) => setSearchQuery(query)}
-				onNewAgentClick={openCreateAgentDialog}
-				onImportAgentClick={handleOpenImportDialog}
-				importAgentTooltip="Import an agent from a ZIP file"
-			/>
-
-			{isLoading ? (
-				<div className="flex flex-1 items-center justify-center">
-					{/* Nothing beside it says what is loading, so the spinner names itself. */}
-					<Spinner size="lg" label="Loading agents" />
-				</div>
-			) : isError ? (
-				<Alert
-					variant="danger"
-					// Appears in response to a failed fetch rather than sitting on the
-					// panel from the start, so it announces itself.
-					role="alert"
-					// `w-auto` overrides the primitive's `w-full`, which would
-					// overflow the column by the margin's 32px.
-					className="m-4 w-auto"
-				>
-					<AlertDescription>
-						Failed to load agents. Please try again.
-					</AlertDescription>
-					<Button
-						variant="ghost"
-						size="sm"
-						className="self-start"
-						onClick={() => refetch()}
-					>
-						Retry
-					</Button>
-				</Alert>
-			) : combinedAgents.length === 0 && !isLoading ? ( // Check combinedAgents and isLoading
-				<p className="p-6 text-center text-body-sm text-ink-muted">
-					{searchQuery ? "No agents match your search" : "No agents found"}
-				</p>
-			) : (
-				<TooltipProvider
-					delayDuration={ROW_TOOLTIP_DELAY_MS}
-					skipDelayDuration={0}
-				>
-					{/*
-					 * `min-h-0` so the list scrolls inside the flex column instead of
-					 * pushing the pagination out of the panel.
-					 */}
-					<ul className="flex min-h-0 flex-1 flex-col gap-1 overflow-y-auto py-2">
-						{combinedAgents.map((agent, index) => (
-							<MemoizedChatSidebarItem
-								key={agent.id}
-								agent={agent}
-								isSelected={
-									selectedConversation === agent.id ||
-									selectedAgentDetails?.id === agent.id
-								}
-								onSelectConversation={handleSelectConversation}
-								onNavigateToAgentSettings={onNavigateToAgentSettings}
-								onExportAgent={handleExportAgent}
-								onClearAgentConversation={handleClearAgentConversation}
-								onAgentDeleted={handleAgentDeleted}
-								onUploadAgentToHub={handleUploadAgentToHub}
-								formatMessageDateTime={formatMessageDateTime}
-								truncateMessage={truncateMessage}
-								index={index}
-								sessionPreview={previewByAgent[agent.id]}
-							/>
-						))}
-					</ul>
-				</TooltipProvider>
+	const draft = activeDraftKey ? drafts[activeDraftKey] : undefined;
+	const sessionRow = (row: CanonicalSessionRow, nested = false) => (
+		<button
+			key={row.session_id}
+			type="button"
+			data-chat-row
+			data-child={nested || undefined}
+			className={cn(
+				rowStyle,
+				"w-full text-left",
+				nested && "pl-7",
+				selectedConversation === row.session_id &&
+					!activeDraftKey &&
+					"bg-accent-wash text-ink",
+				row.attention?.unseen && "font-semibold",
 			)}
-
-			<ImportAgentDialog
-				open={isImportDialogOpen}
-				onClose={handleCloseImportDialog}
-				onAgentImported={handleAgentCreated}
-			/>
-
-			{totalAgents > 0 && (
-				<CompactPagination
-					page={page}
-					count={Math.max(1, Math.ceil(totalAgents / perPage))}
-					onChange={(newPage) =>
-						handlePageChange({} as ChangeEvent<unknown>, newPage)
-					}
+			aria-current={
+				selectedConversation === row.session_id && !activeDraftKey
+					? "page"
+					: undefined
+			}
+			title={`${row.title || "Untitled chat"}: ${row.status?.label ?? "Recent"}${row.attention?.unseen ? ", unread" : ""}`}
+			onClick={() => onSelectConversation(row.session_id)}
+		>
+			<Status row={row} />
+			<span className="min-w-0 flex-1 truncate">
+				{row.title || "Untitled chat"}
+			</span>
+			{pendingId === row.session_id && (
+				<LoaderCircle
+					className="size-4 shrink-0 motion-safe:animate-spin"
+					aria-label="Opening chat"
 				/>
 			)}
-
-			<UploadAgentDialog
-				open={isUploadDialogOpen}
-				onClose={handleCloseUploadDialog}
-				agentName={uploadAgent?.name || ""}
-				isAuthenticated={isAuthenticated}
-				onConfirmUpload={handleConfirmUpload}
-				validationIssues={uploadValidationIssues}
-			/>
-		</div>
+		</button>
 	);
-};
-
-export const ChatSidebar = memo(ChatSidebarComponent);
+	const entity = (kind: ChatTarget["kind"], name: string) => {
+		const rows = children(kind, name);
+		const key = `${kind}:${name}`;
+		const open = Boolean(query) || isOpen(key);
+		if (
+			query &&
+			!name.toLocaleLowerCase().includes(query.toLocaleLowerCase()) &&
+			!rows.length
+		)
+			return null;
+		const Icon = kind === "team" ? Users : Bot;
+		return (
+			<div key={key} data-entity>
+				<div
+					className={cn(
+						"flex h-8 items-center gap-1 rounded-md",
+						draft?.target?.kind === kind &&
+							draft.target.name === name &&
+							"bg-accent-wash",
+					)}
+				>
+					<button
+						type="button"
+						data-disclosure
+						aria-label={`${open ? "Collapse" : "Expand"} ${name} chats`}
+						aria-expanded={open}
+						className="flex size-6 shrink-0 items-center justify-center rounded-md hover:bg-elevated"
+						onClick={() => toggle(key)}
+					>
+						{open ? (
+							<ChevronDown className="size-3.5" />
+						) : (
+							<ChevronRight className="size-3.5" />
+						)}
+					</button>
+					<button
+						type="button"
+						data-chat-row
+						data-entity-name
+						className={cn(rowStyle, "flex-1 text-left")}
+						onClick={() => onStageDraft({ kind, name })}
+						title={`New chat with ${name}`}
+					>
+						<Icon className="size-4 shrink-0" />
+						<span className="min-w-0 flex-1 truncate">{name}</span>
+						<span className="text-meta tabular-nums text-ink-dim">
+							{rows.length || ""}
+						</span>
+					</button>
+					<button
+						type="button"
+						className="flex size-6 shrink-0 items-center justify-center rounded-md hover:bg-elevated"
+						aria-label={`Manage ${name}`}
+						onClick={() =>
+							navigate(`/agents?kind=${kind}&name=${encodeURIComponent(name)}`)
+						}
+					>
+						<MoreHorizontal className="size-4" />
+					</button>
+				</div>
+				{open && (
+					<div>
+						{rows.map((row) => sessionRow(row, true))}
+						{!rows.length && (
+							<p className="py-1 pl-7 text-meta text-ink-dim">No chats yet</p>
+						)}
+					</div>
+				)}
+			</div>
+		);
+	};
+	const heading = (
+		key: string,
+		label: string,
+		initial: boolean,
+		count?: number,
+	) => (
+		<button
+			type="button"
+			data-chat-row
+			className="flex h-7 w-full items-center gap-1 rounded-md px-1 text-body-sm font-medium text-ink-muted hover:bg-elevated"
+			aria-expanded={query ? true : isOpen(key, initial)}
+			onClick={() => toggle(key, initial)}
+		>
+			{query || isOpen(key, initial) ? (
+				<ChevronDown className="size-3.5" />
+			) : (
+				<ChevronRight className="size-3.5" />
+			)}
+			<span className="flex-1 text-left">{label}</span>
+			{count !== undefined && (
+				<span className="text-meta tabular-nums">{count}</span>
+			)}
+		</button>
+	);
+	const keyDown = (event: KeyboardEvent<HTMLElement>) => {
+		const target = event.target as HTMLElement;
+		if (target.tagName === "INPUT") {
+			if (event.key === "Escape") {
+				setQuery("");
+				target.blur();
+			}
+			return;
+		}
+		const rows = [
+			...event.currentTarget.querySelectorAll<HTMLElement>("[data-chat-row]"),
+		];
+		const index = rows.indexOf(target);
+		const next =
+			event.key === "ArrowDown"
+				? Math.min(rows.length - 1, index + 1)
+				: event.key === "ArrowUp"
+					? Math.max(0, index - 1)
+					: event.key === "Home"
+						? 0
+						: event.key === "End"
+							? rows.length - 1
+							: -1;
+		if (next >= 0) {
+			event.preventDefault();
+			rows[next]?.focus();
+			return;
+		}
+		const group = target.closest("[data-entity]");
+		const disclosure =
+			group?.querySelector<HTMLButtonElement>("[data-disclosure]");
+		if (event.key === "ArrowRight" && disclosure) {
+			event.preventDefault();
+			if (disclosure.getAttribute("aria-expanded") === "false")
+				disclosure.click();
+			else group?.querySelector<HTMLElement>("[data-child]")?.focus();
+		}
+		if (event.key === "ArrowLeft" && disclosure) {
+			event.preventDefault();
+			if (target.hasAttribute("data-child"))
+				group?.querySelector<HTMLElement>("[data-entity-name]")?.focus();
+			else if (disclosure.getAttribute("aria-expanded") === "true")
+				disclosure.click();
+		}
+	};
+	return (
+		<nav
+			aria-label="Chats"
+			className="flex h-full min-h-0 flex-col bg-surface p-2 text-ink"
+			onKeyDown={keyDown}
+		>
+			<div className="flex h-8 items-center justify-between px-1">
+				<h2 className="text-body-sm font-medium">Chats</h2>
+				<button
+					type="button"
+					className="rounded-md p-1 hover:bg-elevated"
+					aria-label="New chat"
+					disabled={!ready}
+					onClick={() => onStageDraft(undefined, true)}
+				>
+					<Plus className="size-4" />
+				</button>
+			</div>
+			<input
+				aria-label="Search chats and agents"
+				placeholder="Search chats and agents"
+				className="my-2 h-8 w-full rounded-md border border-control bg-surface px-2 text-body-sm"
+				value={query}
+				onChange={(event) => setQuery(event.target.value)}
+			/>
+			<div className="min-h-0 flex-1 space-y-4 overflow-y-auto p-1">
+				{capabilities.isLoading && (
+					<p aria-live="polite" className="text-meta text-ink-muted">
+						Connecting to chats…
+					</p>
+				)}
+				{capabilities.error && (
+					<p role="alert" className="text-body-sm text-danger">
+						{capabilities.error.message}
+					</p>
+				)}
+				{capabilities.data && !ready && (
+					<p role="alert" className="text-body-sm text-warning">
+						Update the backend to use canonical chats. Existing histories are
+						unchanged.
+					</p>
+				)}
+				{ready && (
+					<>
+						<section>
+							{heading("agents", "Agents", true)}
+							{(query || isOpen("agents", true)) && (
+								<>
+									{profiles.isLoading && (
+										<p aria-live="polite" className="text-meta text-ink-muted">
+											Loading agents…
+										</p>
+									)}
+									{profiles.data?.map((profile) =>
+										entity("agent", profile.name),
+									)}
+									<button
+										type="button"
+										className={cn(rowStyle, "w-full text-ink-muted")}
+										onClick={() => navigate("/agents?create=agent")}
+									>
+										<Plus className="size-4" />
+										Create agent
+									</button>
+								</>
+							)}
+						</section>
+						<section>
+							{heading("teams", "Teams", true)}
+							{(query || isOpen("teams", true)) && (
+								<>
+									{teams.data?.map((team) => entity("team", team.name))}
+									<button
+										type="button"
+										className={cn(rowStyle, "w-full text-ink-muted")}
+										onClick={() => navigate("/agents?create=team")}
+									>
+										<Plus className="size-4" />
+										Create team
+									</button>
+								</>
+							)}
+						</section>
+						<section>
+							<button
+								type="button"
+								data-chat-row
+								className={cn(rowStyle, "w-full", all && "bg-accent-wash")}
+								aria-pressed={all}
+								onClick={() => setAll((value) => !value)}
+							>
+								<List className="size-4" />
+								<span className="flex-1 text-left">All chats</span>
+								<span className="text-meta tabular-nums">
+									{sessions.length}
+								</span>
+							</button>
+						</section>
+						{all ? (
+							<section>{matching.map((row) => sessionRow(row))}</section>
+						) : (
+							<>
+								<section>
+									{heading(
+										"active",
+										"Active chats",
+										true,
+										matching.filter((row) => row.active).length,
+									)}
+									{(query || isOpen("active", true)) &&
+										matching
+											.filter((row) => row.active)
+											.map((row) => sessionRow(row))}
+								</section>
+								<section>
+									{heading(
+										"previous",
+										"Previous chats",
+										false,
+										matching.filter((row) => !row.active).length,
+									)}
+									{(query || isOpen("previous")) &&
+										matching
+											.filter((row) => !row.active)
+											.map((row) => sessionRow(row))}
+								</section>
+							</>
+						)}
+						{!sessions.length && !loading && (
+							<p className="text-meta text-ink-muted">
+								No chats yet. Choose an agent, team or New chat.
+							</p>
+						)}
+						{truncated && (
+							<p className="text-meta text-ink-muted">
+								Showing up to 500 chats. Older chats remain available in the
+								terminal.
+							</p>
+						)}
+					</>
+				)}
+			</div>
+			{(error || profiles.error || teams.error) && (
+				<div role="alert" className="pt-2 text-meta text-danger">
+					<p>{error || profiles.error?.message || teams.error?.message}</p>
+					<button
+						type="button"
+						className="mt-1 underline"
+						onClick={() => {
+							void fetchSessions();
+							void profiles.refetch();
+							void teams.refetch();
+						}}
+					>
+						Retry refresh
+					</button>
+				</div>
+			)}
+		</nav>
+	);
+}

--- a/src/renderer/src/features/chat/components/chat-sidebar.tsx
+++ b/src/renderer/src/features/chat/components/chat-sidebar.tsx
@@ -28,7 +28,13 @@ import {
 	Plus,
 	Users,
 } from "lucide-react";
-import { type KeyboardEvent, useEffect, useMemo, useState } from "react";
+import {
+	type KeyboardEvent,
+	useEffect,
+	useMemo,
+	useRef,
+	useState,
+} from "react";
 import { useNavigate } from "react-router-dom";
 
 type Props = {
@@ -91,6 +97,15 @@ export function ChatSidebar({
 		"session_catalogue",
 		2,
 	);
+	// Losing the backend mid-session must not look like an empty catalogue. Once
+	// the sidebar has been ready we keep its structure and last-known rows
+	// mounted through a capability error, marked stale, instead of replacing the
+	// whole list with a bare error paragraph the user cannot act on.
+	const searchRef = useRef<HTMLInputElement>(null);
+	const wasReady = useRef(false);
+	if (ready) wasReady.current = true;
+	const stale = Boolean(capabilities.error) && wasReady.current;
+	const showList = ready || stale;
 	const profiles = useProfiles(
 		ready && desktopFeatureEnabled(capabilities.data, "profile_catalogue"),
 	);
@@ -149,6 +164,22 @@ export function ChatSidebar({
 				: !row.binding?.team && row.binding?.agent === name,
 		);
 	const draft = activeDraftKey ? drafts[activeDraftKey] : undefined;
+	const bindingName = (row: CanonicalSessionRow) =>
+		row.binding?.team || row.binding?.agent || "";
+	// A first send that failed after allocation but before admission leaves a real
+	// but empty session. It is NOT hidden — it exists on the backend and hiding it
+	// would make the list lie — but an unfinished draft still holding its id is
+	// proof it never carried a message, so say so instead of showing it as an
+	// ordinary untitled chat.
+	const unstarted = useMemo(
+		() =>
+			new Set(
+				Object.values(drafts)
+					.filter((item) => item.sessionId)
+					.map((item) => item.sessionId as string),
+			),
+		[drafts],
+	);
 	const sessionRow = (row: CanonicalSessionRow, nested = false) => (
 		<button
 			key={row.session_id}
@@ -169,12 +200,23 @@ export function ChatSidebar({
 					? "page"
 					: undefined
 			}
-			title={`${row.title || "Untitled chat"}: ${row.status?.label ?? "Recent"}${row.attention?.unseen ? ", unread" : ""}`}
+			title={`${row.title || "Untitled chat"}${bindingName(row) ? ` (${bindingName(row)})` : ""}: ${row.status?.label ?? "Recent"}${row.attention?.unseen ? ", unread" : ""}`}
 			onClick={() => onSelectConversation(row.session_id)}
 		>
 			<Status row={row} />
 			<span className="min-w-0 flex-1 truncate">
 				{row.title || "Untitled chat"}
+				{/* In a flat list nothing else names the profile answering, so two
+				    untitled chats on different agents were indistinguishable. Nested
+				    rows already inherit the identity from their parent. */}
+				{!nested && bindingName(row) && (
+					<span className="ml-1 text-meta text-ink-muted">
+						· {bindingName(row)}
+					</span>
+				)}
+				{unstarted.has(row.session_id) && (
+					<span className="ml-1 text-meta text-ink-muted">· Not sent yet</span>
+				)}
 			</span>
 			{pendingId === row.session_id && (
 				<LoaderCircle
@@ -288,6 +330,13 @@ export function ChatSidebar({
 			}
 			return;
 		}
+		// Arrow navigation was a one-way trip: nothing returned focus to the
+		// search field, so a keyboard user who entered the list was stranded there.
+		if (event.key === "Escape") {
+			event.preventDefault();
+			searchRef.current?.focus();
+			return;
+		}
 		const rows = [
 			...event.currentTarget.querySelectorAll<HTMLElement>("[data-chat-row]"),
 		];
@@ -343,6 +392,7 @@ export function ChatSidebar({
 				</button>
 			</div>
 			<input
+				ref={searchRef}
 				aria-label="Search chats and agents"
 				placeholder="Search chats and agents"
 				className="my-2 h-8 w-full rounded-md border border-control bg-surface px-2 text-body-sm"
@@ -356,18 +406,28 @@ export function ChatSidebar({
 					</p>
 				)}
 				{capabilities.error && (
-					<p role="alert" className="text-body-sm text-danger">
-						{capabilities.error.message}
-					</p>
+					<div role="alert" className="space-y-1 text-body-sm text-danger">
+						<p>
+							{capabilities.error.message}
+							{stale ? " Showing the last chats loaded." : ""}
+						</p>
+						<button
+							type="button"
+							className="underline"
+							onClick={() => void capabilities.refetch()}
+						>
+							Retry
+						</button>
+					</div>
 				)}
-				{capabilities.data && !ready && (
+				{capabilities.data && !ready && !capabilities.error && (
 					<p role="alert" className="text-body-sm text-warning">
 						Update the backend to use canonical chats. Existing histories are
 						unchanged.
 					</p>
 				)}
-				{ready && (
-					<>
+				{showList && (
+					<div className={cn("space-y-4", stale && "opacity-60")}>
 						<section>
 							{heading("agents", "Agents", true)}
 							{(query || isOpen("agents", true)) && (
@@ -417,8 +477,10 @@ export function ChatSidebar({
 							>
 								<List className="size-4" />
 								<span className="flex-1 text-left">All chats</span>
+								{/* The three global counts read as one set, so this must honour
+								    the active filter exactly as Active/Previous do. */}
 								<span className="text-meta tabular-nums">
-									{sessions.length}
+									{matching.length}
 								</span>
 							</button>
 						</section>
@@ -434,9 +496,15 @@ export function ChatSidebar({
 										matching.filter((row) => row.active).length,
 									)}
 									{(query || isOpen("active", true)) &&
-										matching
-											.filter((row) => row.active)
-											.map((row) => sessionRow(row))}
+										(matching.some((row) => row.active) ? (
+											matching
+												.filter((row) => row.active)
+												.map((row) => sessionRow(row))
+										) : (
+											<p className="px-2 text-meta text-ink-muted">
+												Nothing running right now.
+											</p>
+										))}
 								</section>
 								<section>
 									{heading(
@@ -463,7 +531,7 @@ export function ChatSidebar({
 								terminal.
 							</p>
 						)}
-					</>
+					</div>
 				)}
 			</div>
 			{(error || profiles.error || teams.error) && (

--- a/src/renderer/src/features/chat/components/chat-sidebar.tsx
+++ b/src/renderer/src/features/chat/components/chat-sidebar.tsx
@@ -20,6 +20,7 @@ import {
 	Circle,
 	CircleAlert,
 	Clock,
+	HelpCircle,
 	List,
 	LoaderCircle,
 	MessageSquare,
@@ -45,6 +46,9 @@ type Props = {
 const rowStyle =
 	"flex h-8 min-w-0 items-center gap-1 rounded-md px-1 text-body-sm leading-5 hover:bg-elevated focus-visible:outline focus-visible:outline-2 focus-visible:outline-accent focus-visible:outline-offset-2";
 
+/** Resting codes that legitimately render as a plain ring; see `Status`. */
+const KNOWN_RESTING = new Set(["idle", "recent"]);
+
 function Status({ row }: { row: CanonicalSessionRow }) {
 	const code = row.status?.code;
 	const Icon =
@@ -63,7 +67,13 @@ function Status({ row }: { row: CanonicalSessionRow }) {
 							? Clock
 							: code === "attached"
 								? MessageSquare
-								: Circle;
+								: // `idle`/`recent` are ordinary resting states and keep the plain
+									// ring. Anything else is a code this build does not know, so it
+									// must not be normalised into looking like "Recent" — a backend
+									// newer than the UI would silently misreport state.
+									KNOWN_RESTING.has(code ?? "")
+									? Circle
+									: HelpCircle;
 	const ink =
 		code === "busy"
 			? "text-info motion-safe:animate-spin"
@@ -316,7 +326,9 @@ export function ChatSidebar({
 				<ChevronRight className="size-3.5" />
 			)}
 			<span className="flex-1 text-left">{label}</span>
-			{count !== undefined && (
+			{/* A zero badge next to a group that already says it is empty is the
+			    same fact twice; only a non-zero count carries information. */}
+			{Boolean(count) && (
 				<span className="text-meta tabular-nums">{count}</span>
 			)}
 		</button>
@@ -427,7 +439,7 @@ export function ChatSidebar({
 					</p>
 				)}
 				{showList && (
-					<div className={cn("space-y-4", stale && "opacity-60")}>
+					<div className={cn("space-y-4 pb-2", stale && "opacity-60")}>
 						<section>
 							{heading("agents", "Agents", true)}
 							{(query || isOpen("agents", true)) && (
@@ -467,73 +479,89 @@ export function ChatSidebar({
 								</>
 							)}
 						</section>
-						<section>
-							<button
-								type="button"
-								data-chat-row
-								className={cn(rowStyle, "w-full", all && "bg-accent-wash")}
-								aria-pressed={all}
-								onClick={() => setAll((value) => !value)}
-							>
-								<List className="size-4" />
-								<span className="flex-1 text-left">All chats</span>
-								{/* The three global counts read as one set, so this must honour
-								    the active filter exactly as Active/Previous do. */}
-								<span className="text-meta tabular-nums">
-									{matching.length}
-								</span>
-							</button>
-						</section>
-						{all ? (
-							<section>{matching.map((row) => sessionRow(row))}</section>
-						) : (
-							<>
-								<section>
-									{heading(
-										"active",
-										"Active chats",
-										true,
-										matching.filter((row) => row.active).length,
-									)}
-									{(query || isOpen("active", true)) &&
-										(matching.some((row) => row.active) ? (
-											matching
-												.filter((row) => row.active)
-												.map((row) => sessionRow(row))
-										) : (
-											<p className="px-2 text-meta text-ink-muted">
-												Nothing running right now.
-											</p>
-										))}
-								</section>
-								<section>
-									{heading(
-										"previous",
-										"Previous chats",
-										false,
-										matching.filter((row) => !row.active).length,
-									)}
-									{(query || isOpen("previous")) &&
-										matching
-											.filter((row) => !row.active)
-											.map((row) => sessionRow(row))}
-								</section>
-							</>
-						)}
-						{!sessions.length && !loading && (
-							<p className="text-meta text-ink-muted">
-								No chats yet. Choose an agent, team or New chat.
-							</p>
-						)}
-						{truncated && (
-							<p className="text-meta text-ink-muted">
-								Showing up to 500 chats. Older chats remain available in the
-								terminal.
-							</p>
-						)}
 					</div>
 				)}
 			</div>
+			{/* The global partition is NAVIGATION, not a peer of the entity lists.
+			    Sharing one scroll flow pushed Previous below the fold at 16+ sessions
+			    and its disclosure became easy to miss, so it is pinned below the
+			    scrolling entity region and owns its own scroll area. */}
+			{showList && (
+				<div
+					className={cn(
+						"mt-2 max-h-[45%] shrink-0 space-y-4 overflow-y-auto border-t border-hairline pt-2",
+						stale && "opacity-60",
+					)}
+				>
+					<section>
+						<button
+							type="button"
+							data-chat-row
+							className={cn(rowStyle, "w-full", all && "bg-accent-wash")}
+							aria-pressed={all}
+							onClick={() => setAll((value) => !value)}
+						>
+							<List className="size-4" />
+							<span className="flex-1 text-left">All chats</span>
+							{/* The three global counts read as one set, so this must honour
+							    the active filter exactly as Active/Previous do. A zero badge
+							    beside the "No chats yet" sentence just repeats it. */}
+							{matching.length > 0 && (
+								<span className="text-meta tabular-nums">
+									{matching.length}
+								</span>
+							)}
+						</button>
+					</section>
+					{all ? (
+						<section>{matching.map((row) => sessionRow(row))}</section>
+					) : (
+						<>
+							<section>
+								{heading(
+									"active",
+									"Active chats",
+									true,
+									matching.filter((row) => row.active).length,
+								)}
+								{(query || isOpen("active", true)) &&
+									(matching.some((row) => row.active) ? (
+										matching
+											.filter((row) => row.active)
+											.map((row) => sessionRow(row))
+									) : (
+										<p className="px-2 text-meta text-ink-muted">
+											Nothing running right now.
+										</p>
+									))}
+							</section>
+							<section>
+								{heading(
+									"previous",
+									"Previous chats",
+									false,
+									matching.filter((row) => !row.active).length,
+								)}
+								{(query || isOpen("previous")) &&
+									matching
+										.filter((row) => !row.active)
+										.map((row) => sessionRow(row))}
+							</section>
+						</>
+					)}
+					{!sessions.length && !loading && (
+						<p className="text-meta text-ink-muted">
+							No chats yet. Choose an agent, team or New chat.
+						</p>
+					)}
+					{truncated && (
+						<p className="text-meta text-ink-muted">
+							Showing up to 500 chats. Older chats remain available in the
+							terminal.
+						</p>
+					)}
+				</div>
+			)}
 			{(error || profiles.error || teams.error) && (
 				<div role="alert" className="pt-2 text-meta text-danger">
 					<p>{error || profiles.error?.message || teams.error?.message}</p>

--- a/src/renderer/src/features/chat/components/chat-sidebar.tsx
+++ b/src/renderer/src/features/chat/components/chat-sidebar.tsx
@@ -70,8 +70,11 @@ function Status({ row }: { row: CanonicalSessionRow }) {
 								: // `idle`/`recent` are ordinary resting states and keep the plain
 									// ring. Anything else is a code this build does not know, so it
 									// must not be normalised into looking like "Recent" — a backend
-									// newer than the UI would silently misreport state.
-									KNOWN_RESTING.has(code ?? "")
+									// newer than the UI would silently misreport state. An ABSENT
+									// status is a different case: a locally created row carries none
+									// until the next fetch, and the label already reads "Recent", so
+									// treating it as unknown made the icon contradict the label.
+									KNOWN_RESTING.has(code ?? "recent")
 									? Circle
 									: HelpCircle;
 	const ink =

--- a/src/renderer/src/features/chat/components/message-input.tsx
+++ b/src/renderer/src/features/chat/components/message-input.tsx
@@ -47,7 +47,10 @@ import { WaveformAnimation } from "./waveform-animation";
  * Props for the MessageInput component
  */
 type MessageInputProps = {
-	onSendMessage: (content: string, attachments: string[]) => void;
+	onSendMessage: (
+		content: string,
+		attachments: string[],
+	) => undefined | boolean | Promise<undefined | boolean>;
 	isLoading: boolean;
 	conversationId?: string;
 	messages: Message[];
@@ -203,7 +206,7 @@ export const MessageInput = forwardRef<MessageInputHandle, MessageInputProps>(
 		}, [initialSuggestions]);
 
 		const onSubmit = useMemo(
-			() => (message: string) => {
+			() => async (message: string) => {
 				let messageWithReplies = message;
 				if (replies.length > 0) {
 					const replyContent = replies
@@ -211,10 +214,11 @@ export const MessageInput = forwardRef<MessageInputHandle, MessageInputProps>(
 						.join("\n");
 					messageWithReplies = `${replyContent}\n${message}`;
 				}
-				onSendMessage(
+				const accepted = await onSendMessage(
 					messageWithReplies,
 					attachments.map((a) => a.path),
 				);
+				if (accepted === false) return false;
 				if (conversationId) {
 					clearReplies(conversationId);
 					clearAttachments(conversationId);
@@ -525,12 +529,13 @@ export const MessageInput = forwardRef<MessageInputHandle, MessageInputProps>(
 			}
 		};
 
-		const handleSuggestionClick = (suggestion: string) => {
+		const handleSuggestionClick = async (suggestion: string) => {
 			if (isInputDisabled) return;
-			onSendMessage(
+			const accepted = await onSendMessage(
 				suggestion,
 				attachments.map((a) => a.path),
 			);
+			if (accepted === false) return;
 			if (conversationId) {
 				clearAttachments(conversationId);
 			}
@@ -659,7 +664,7 @@ export const MessageInput = forwardRef<MessageInputHandle, MessageInputProps>(
 									</Button>
 								</span>
 							</Tooltip>
-							{conversationId && (
+							{conversationId && !canonicalStop && (
 								<DirectoryIndicator
 									agentId={conversationId}
 									currentWorkingDirectory={agentData?.current_working_directory}

--- a/src/renderer/src/features/command-palette/components/command-palette.tsx
+++ b/src/renderer/src/features/command-palette/components/command-palette.tsx
@@ -152,7 +152,6 @@ export const CommandPalette: FC = () => {
 		isCanvasOpen,
 		setCanvasOpen,
 		isCreateAgentDialogOpen,
-		openCreateAgentDialog,
 		closeCreateAgentDialog,
 	} = useUiPreferencesStore();
 
@@ -205,12 +204,8 @@ export const CommandPalette: FC = () => {
 
 	const handleCreateAgent = useCallback(() => {
 		closeCommandPalette();
-		// Navigate to chat page first if not already there
-		// This navigation logic might be better handled by the dialog itself or a dedicated service
-		// For now, let's keep it simple and open the dialog.
-		// Navigation to /chat if not there can be a separate concern or handled by where the dialog leads.
-		openCreateAgentDialog(); // Use global action
-	}, [closeCommandPalette, openCreateAgentDialog]);
+		navigate("/agents?create=agent");
+	}, [closeCommandPalette, navigate]);
 
 	const handleClearConversation = useCallback(() => {
 		// This will now open the confirmation dialog

--- a/src/renderer/src/shared/api/local-operator/desktop-api.ts
+++ b/src/renderer/src/shared/api/local-operator/desktop-api.ts
@@ -143,24 +143,39 @@ export class DesktopControlError extends Error {
 	 * ES2020, where that option does not exist.
 	 */
 	readonly cause?: unknown;
+	/** Vetted backend rejection category, distinct from connectivity status. */
+	readonly code?: string;
 
-	constructor(status: number | null, message: string, cause?: unknown) {
+	constructor(
+		status: number | null,
+		message: string,
+		cause?: unknown,
+		code?: string,
+	) {
 		super(message);
 		this.name = "DesktopControlError";
 		this.status = status;
 		this.cause = cause;
+		this.code = code;
 	}
 }
 
 export async function desktopResult<T>(request: DesktopRequest): Promise<T> {
 	const response = await desktopRequest(request);
-	const envelope = response.body as { result?: T; detail?: string } | null;
+	const envelope = response.body as {
+		result?: T;
+		detail?: string | { code?: string; message?: string };
+	} | null;
 	if (response.status < 200 || response.status >= 300) {
 		throw new DesktopControlError(
 			response.status,
 			typeof envelope?.detail === "string"
 				? envelope.detail
-				: "This backend does not support the requested desktop control. Update the backend and try again.",
+				: typeof envelope?.detail?.message === "string"
+					? envelope.detail.message
+					: "This backend does not support the requested desktop control. Update the backend and try again.",
+			undefined,
+			typeof envelope?.detail === "object" ? envelope.detail?.code : undefined,
 		);
 	}
 	return envelope?.result as T;

--- a/src/renderer/src/shared/api/local-operator/desktop-hooks.ts
+++ b/src/renderer/src/shared/api/local-operator/desktop-hooks.ts
@@ -56,6 +56,9 @@ export type DesktopFeature =
 	| "settings"
 	| "commands"
 	| "catalogues"
+	| "profile_catalogue"
+	| "team_catalogue"
+	| "session_catalogue"
 	| "lifecycle"
 	| "mcp"
 	| "radient";
@@ -70,9 +73,10 @@ export type DesktopFeature =
 export function desktopFeatureEnabled(
 	capabilities: DesktopCapabilities | null | undefined,
 	feature: DesktopFeature,
+	minimumVersion = 1,
 ): boolean {
 	if (!capabilities || !capabilities.desktop_available) return false;
-	return (capabilities.features?.[feature] ?? 0) >= 1;
+	return (capabilities.features?.[feature] ?? 0) >= minimumVersion;
 }
 
 /** Canonical provider registry rows, including aliases folded into methods. */

--- a/src/renderer/src/shared/api/local-operator/profile-hooks.ts
+++ b/src/renderer/src/shared/api/local-operator/profile-hooks.ts
@@ -1,0 +1,59 @@
+import { useQuery } from "@tanstack/react-query";
+import { retryDesktopQuery } from "./backend-error";
+import { desktopResult } from "./desktop-api";
+
+/** Reusable instructions, never a conversation or a legacy agent history. */
+export type ReusableProfile = {
+	name: string;
+	kind: "role" | "specialist";
+	source: "builtin" | "installed" | "custom";
+	agent_id: string | null;
+	description: string;
+	instructions?: string;
+	packaged_instructions?: string;
+	tools: string[] | null;
+	effort: string | null;
+	delegate: boolean;
+	seed_origin?: string | null;
+	divergent_fields?: string[];
+};
+export type TeamMember = {
+	role: string;
+	count: number;
+	kind: "agent" | "team";
+};
+export type ReusableTeam = {
+	id: string;
+	name: string;
+	description: string;
+	manager: string;
+	members: TeamMember[];
+	instructions?: string;
+	project?: string;
+};
+export type ChatTarget = { kind: "agent" | "team"; name: string };
+
+export function useProfiles(enabled: boolean) {
+	return useQuery({
+		queryKey: ["desktop", "profiles"],
+		enabled,
+		queryFn: () =>
+			desktopResult<{ profiles: ReusableProfile[] }>({
+				op: "profiles.list",
+			}).then((result) => result.profiles),
+		retry: retryDesktopQuery,
+		staleTime: 10_000,
+	});
+}
+export function useTeams(enabled: boolean) {
+	return useQuery({
+		queryKey: ["desktop", "teams"],
+		enabled,
+		queryFn: () =>
+			desktopResult<{ teams: ReusableTeam[] }>({ op: "teams.list" }).then(
+				(result) => result.teams,
+			),
+		retry: retryDesktopQuery,
+		staleTime: 10_000,
+	});
+}

--- a/src/renderer/src/shared/components/common/chat-layout.tsx
+++ b/src/renderer/src/shared/components/common/chat-layout.tsx
@@ -21,7 +21,12 @@ type ChatLayoutProps = {
  * reason — the inline style always overrode it.
  */
 export const ChatLayout: FC<ChatLayoutProps> = ({ sidebar, content }) => {
-	const sidebarWidth = useUiPreferencesStore((s) => s.chatSidebarWidth);
+	// Clamp pre-refactor saved widths at the render boundary without rewriting
+	// persisted sessions or discarding the rest of the user preferences.
+	const savedWidth = useUiPreferencesStore((s) => s.chatSidebarWidth);
+	const sidebarWidth = Number.isFinite(savedWidth)
+		? Math.min(360, Math.max(240, savedWidth))
+		: 280;
 	const setSidebarWidth = useUiPreferencesStore((s) => s.setChatSidebarWidth);
 	const restoreDefaultSidebarWidth = useUiPreferencesStore(
 		(s) => s.restoreDefaultChatSidebarWidth,
@@ -35,8 +40,8 @@ export const ChatLayout: FC<ChatLayoutProps> = ({ sidebar, content }) => {
 			<ResizableDivider
 				sidebarWidth={sidebarWidth}
 				onSidebarWidthChange={setSidebarWidth}
-				minWidth={180}
-				maxWidth={600}
+				minWidth={240}
+				maxWidth={360}
 				onDoubleClick={restoreDefaultSidebarWidth}
 			/>
 			<div className="h-full grow overflow-hidden">{content}</div>

--- a/src/renderer/src/shared/hooks/use-message-input.ts
+++ b/src/renderer/src/shared/hooks/use-message-input.ts
@@ -11,7 +11,9 @@ import { useConversationInputStore } from "../store/conversation-input-store";
  */
 type UseMessageInputOptions = {
 	conversationId?: string;
-	onSubmit?: (message: string) => void;
+	onSubmit?: (
+		message: string,
+	) => undefined | boolean | Promise<undefined | boolean>;
 	scrollToBottom?: () => void;
 };
 
@@ -160,12 +162,20 @@ export const useMessageInput = ({
 		[conversationId, setCurrentInput, resetCurrentHistoryIndex],
 	);
 
-	// Handle form submission
-	const handleSubmit = useCallback(() => {
-		if (!inputValue.trim() || !conversationId) return;
-		onSubmit?.(inputValue);
+	const submittingRef = useRef(false);
+	// Admission, not the keypress, retires a draft. A failed or ambiguous send
+	// must keep its text and attachments, including across navigation/remounts.
+	const handleSubmit = useCallback(async () => {
+		if (!inputValue.trim() || !conversationId || submittingRef.current) return;
+		submittingRef.current = true;
+		try {
+			if ((await onSubmit?.(inputValue)) === false) return;
+		} finally {
+			submittingRef.current = false;
+		}
+
 		addSubmittedMessage(conversationId, inputValue);
-		setInputValue("");
+		if (initializedRef.current === conversationId) setInputValue("");
 		// Cleared BEFORE the store write so a synchronous restore inside
 		// `onSubmit` is not immediately overwritten by this submit's own clear.
 		lastPushedRef.current = "";

--- a/src/renderer/src/shared/store/canonical-sessions-store.ts
+++ b/src/renderer/src/shared/store/canonical-sessions-store.ts
@@ -59,6 +59,20 @@ export type ChatImage = {
 	mime_type: "image/png" | "image/jpeg" | "image/gif" | "image/webp";
 };
 
+/**
+ * Which draft a chat view owns. A staged draft is keyed by its own key, but once
+ * a session exists `draftKey` is null and the send draft lives under
+ * `send:<id>` — reading only `draftKey` there left a failed send's retained text
+ * unreachable. It lives here, beside the drafts it addresses, so the rule is
+ * exercised by the store tests rather than duplicated in an untested component.
+ */
+export function draftIdentityFor(
+	draftKey: string | null,
+	sessionId: string | null | undefined,
+): string | null {
+	return draftKey ?? (sessionId ? `send:${sessionId}` : null);
+}
+
 /** Create and admission are intentionally separate receipts. A response lost
  * between them retains its exact IDs and payload; retry never reallocates or
  * deletes work that may already have been admitted by the owner. */
@@ -97,19 +111,27 @@ export async function admitChatDraft(
 		createRequestId: crypto.randomUUID(),
 		admissionRequestId: crypto.randomUUID(),
 	};
-	// Deliberately NOT pinned to the first attempt. The guard above already
-	// holds the payload identical across a retry, and `mode` is a delivery
-	// instruction rather than payload: a send that first failed while the
-	// session was idle must steer, not queue a new turn, once it is streaming.
-	// A genuinely duplicate admission is deduped by `admissionRequestId`.
-	const images = input.images;
-	const mode = input.mode;
+	// `mode` MUST be pinned once an admission has been issued, even though it
+	// reads like a delivery instruction rather than payload. The server keys its
+	// receipt on a sha256 of the WHOLE request body, `mode` included
+	// (desktop_receipts.py), and raises ReceiptConflict -> HTTP 409 when a retry
+	// of the same requestId hashes differently. So the lost-response case (turn
+	// admitted, response never arrived, session now streaming, UI recomputes
+	// busy=true) would retry as "steer", 409 forever, and report a failure for a
+	// message that actually landed. Pinning keeps the retry an idempotent replay.
+	const images = draft.admissionAttempted
+		? (draft.submittedImages ?? input.images)
+		: input.images;
+	const mode = draft.admissionAttempted
+		? (draft.submittedMode ?? input.mode)
+		: input.mode;
 	store.updateDraft(key, {
 		...draft,
 		pending: true,
 		submittedText: input.text,
 		submittedAttachments: input.attachments,
 		submittedImages: images,
+		submittedMode: mode,
 		error: undefined,
 	});
 	try {

--- a/src/renderer/src/shared/store/canonical-sessions-store.ts
+++ b/src/renderer/src/shared/store/canonical-sessions-store.ts
@@ -43,6 +43,16 @@ export type ChatDraft = {
 	submittedAttachments?: string[];
 	submittedImages?: ChatImage[];
 	submittedMode?: "prompt" | "steer";
+	/**
+	 * True only once an admission request has actually been ISSUED, i.e. its
+	 * outcome is genuinely unknown to us. This is what the unchanged-payload
+	 * guard keys on: a send that failed BEFORE admission (session creation
+	 * refused, provider unconfigured) admitted nothing, so holding the composer
+	 * to that exact text would lock a conversation over a failure we know did
+	 * not land. Only a request that may already be executing must be retried
+	 * byte-for-byte.
+	 */
+	admissionAttempted?: boolean;
 };
 export type ChatImage = {
 	data_b64: string;
@@ -67,13 +77,19 @@ export async function admitChatDraft(
 	const previous = store.drafts[key];
 	if (previous?.pending) return null;
 	if (
-		previous?.submittedText !== undefined &&
+		previous?.admissionAttempted &&
+		previous.submittedText !== undefined &&
 		(previous.submittedText !== input.text ||
 			JSON.stringify(previous.submittedAttachments) !==
-				JSON.stringify(input.attachments))
+				JSON.stringify(input.attachments) ||
+			// Images are payload identity too. Comparing only text/attachments let a
+			// retry that added an image pass the guard and then silently send the
+			// FIRST attempt's images, dropping the new one with no error.
+			JSON.stringify(previous.submittedImages ?? []) !==
+				JSON.stringify(input.images))
 	) {
 		throw new Error(
-			"The previous send has not been confirmed. Retry it unchanged or reconcile its session before sending different input.",
+			"The previous send has not been confirmed. Retry it unchanged, or discard it to send something different.",
 		);
 	}
 	const draft: ChatDraft = previous ?? {
@@ -81,15 +97,19 @@ export async function admitChatDraft(
 		createRequestId: crypto.randomUUID(),
 		admissionRequestId: crypto.randomUUID(),
 	};
-	const images = draft.submittedImages ?? input.images;
-	const mode = draft.submittedMode ?? input.mode;
+	// Deliberately NOT pinned to the first attempt. The guard above already
+	// holds the payload identical across a retry, and `mode` is a delivery
+	// instruction rather than payload: a send that first failed while the
+	// session was idle must steer, not queue a new turn, once it is streaming.
+	// A genuinely duplicate admission is deduped by `admissionRequestId`.
+	const images = input.images;
+	const mode = input.mode;
 	store.updateDraft(key, {
 		...draft,
 		pending: true,
 		submittedText: input.text,
 		submittedAttachments: input.attachments,
 		submittedImages: images,
-		submittedMode: mode,
 		error: undefined,
 	});
 	try {
@@ -107,6 +127,9 @@ export async function admitChatDraft(
 				);
 			store.updateDraft(key, { sessionId: id });
 		}
+		// From here the outcome is unknowable on failure: the owner may have
+		// admitted the command before the response was lost.
+		store.updateDraft(key, { admissionAttempted: true });
 		await desktopResult({
 			op: "sessions.message",
 			sessionId: id,
@@ -158,6 +181,12 @@ type CanonicalSessionsState = {
 	stageDraft: (target?: ChatTarget, fresh?: boolean) => string;
 	updateDraft: (key: string, patch: Partial<ChatDraft>) => void;
 	finishDraft: (key: string, sessionId: string) => void;
+	/**
+	 * Abandon a stuck send. The retained payload is the user's own text, so the
+	 * only safe owner of that decision is the user: we drop our claim that the
+	 * next send must match it, and never touch the session or its transcript.
+	 */
+	discardDraft: (key: string) => void;
 	bindSession: (legacyAgentId: string, sessionId: string) => void;
 	upsertSession: (row: CanonicalSessionRow) => void;
 };
@@ -340,6 +369,12 @@ export const useCanonicalSessionsStore = create<CanonicalSessionsState>()(
 							? { activeDraftKey: null, activeSessionId: sessionId }
 							: {}),
 					};
+				}),
+			discardDraft: (key) =>
+				set((state) => {
+					const drafts = { ...state.drafts };
+					delete drafts[key];
+					return { drafts };
 				}),
 			bindSession: (_legacyAgentId, sessionId) =>
 				get().setActiveSession(sessionId),

--- a/src/renderer/src/shared/store/canonical-sessions-store.ts
+++ b/src/renderer/src/shared/store/canonical-sessions-store.ts
@@ -1,197 +1,377 @@
-/**
- * Canonical desktop session store.
- *
- * Conversations in this app are canonical session records (12-hex session
- * IDs) owned by the backend's desktop session API, not agent profiles. An
- * agent ID is a profile reference a session may carry; it is never the
- * session identity. The store keeps the list, the active session, and the
- * agent->session mapping so list/create/open/reopen preserve identity across
- * restarts and watcher updates never invent a second row for the same
- * session.
- *
- * Rows are merged by session_id: a watcher refresh that returns the same
- * session must update the existing row in place, never append a duplicate,
- * and must not steal the active selection or scroll a reading user.
- */
-
+/** Canonical sessions are the only conversation identities. Profile names stage
+ * drafts; the legacy agent mapping is retained only to resolve old deep links. */
 import { desktopResult } from "@shared/api/local-operator/desktop-api";
+import type { ChatTarget } from "@shared/api/local-operator/profile-hooks";
 import { create } from "zustand";
 import { persist } from "zustand/middleware";
+import {
+	type CompletionAttention,
+	type SessionBinding,
+	type SessionCatalogueStatus,
+	mergeCompletionAttention,
+} from "../../../../shared/desktop-session-contract";
 
 export type CanonicalSessionRow = {
 	session_id: string;
 	title?: string | null;
 	cwd?: string | null;
 	updated_at?: number | null;
-	agent_id?: string | null;
-	/**
-	 * The session's most recent assistant reply, from the canonical transcript.
-	 *
-	 * The conversation list used to render the legacy agent record's
-	 * `last_message`, which canonical sessions never write -- so a conversation
-	 * with a full transcript on disk was labelled "No messages yet" (design
-	 * D19). The transcript is the authority for both the title and this.
-	 */
 	preview?: string | null;
+	attention?: CompletionAttention;
+	live_state?: string;
+	pending?: string | null;
+	active?: boolean;
+	status?: SessionCatalogueStatus;
+	binding?: SessionBinding;
 	[key: string]: unknown;
 };
-
-/** Backend list row: `{id, name, mtime, ...}` (extra fields allowed). */
-type BackendSessionRow = {
+type BackendSessionRow = Omit<CanonicalSessionRow, "session_id"> & {
 	id: string;
 	name: string;
 	mtime: number;
-	[key: string]: unknown;
+};
+export type ChatDraft = {
+	key: string;
+	target?: ChatTarget;
+	createRequestId: string;
+	admissionRequestId: string;
+	sessionId?: string;
+	pending?: boolean;
+	error?: string;
+	errorCode?: string;
+	submittedText?: string;
+	submittedAttachments?: string[];
+	submittedImages?: ChatImage[];
+	submittedMode?: "prompt" | "steer";
+};
+export type ChatImage = {
+	data_b64: string;
+	mime_type: "image/png" | "image/jpeg" | "image/gif" | "image/webp";
 };
 
-function fromBackend(row: BackendSessionRow): CanonicalSessionRow {
-	const { id, name, mtime, ...rest } = row;
-	return { ...rest, session_id: id, title: name, updated_at: mtime };
+/** Create and admission are intentionally separate receipts. A response lost
+ * between them retains its exact IDs and payload; retry never reallocates or
+ * deletes work that may already have been admitted by the owner. */
+export async function admitChatDraft(
+	key: string,
+	input: {
+		text: string;
+		attachments: string[];
+		images: ChatImage[];
+		mode: "prompt" | "steer";
+		cwd: string;
+	},
+	sessionId?: string,
+): Promise<string | null> {
+	const store = useCanonicalSessionsStore.getState();
+	const previous = store.drafts[key];
+	if (previous?.pending) return null;
+	if (
+		previous?.submittedText !== undefined &&
+		(previous.submittedText !== input.text ||
+			JSON.stringify(previous.submittedAttachments) !==
+				JSON.stringify(input.attachments))
+	) {
+		throw new Error(
+			"The previous send has not been confirmed. Retry it unchanged or reconcile its session before sending different input.",
+		);
+	}
+	const draft: ChatDraft = previous ?? {
+		key,
+		createRequestId: crypto.randomUUID(),
+		admissionRequestId: crypto.randomUUID(),
+	};
+	const images = draft.submittedImages ?? input.images;
+	const mode = draft.submittedMode ?? input.mode;
+	store.updateDraft(key, {
+		...draft,
+		pending: true,
+		submittedText: input.text,
+		submittedAttachments: input.attachments,
+		submittedImages: images,
+		submittedMode: mode,
+		error: undefined,
+	});
+	try {
+		let id = sessionId ?? draft.sessionId;
+		if (!id) {
+			id =
+				(await store.createSession(
+					input.cwd,
+					draft.target,
+					draft.createRequestId,
+				)) ?? undefined;
+			if (!id)
+				throw new Error(
+					useCanonicalSessionsStore.getState().error ?? "Chat could not start.",
+				);
+			store.updateDraft(key, { sessionId: id });
+		}
+		await desktopResult({
+			op: "sessions.message",
+			sessionId: id,
+			requestId: draft.admissionRequestId,
+			text: input.text,
+			images: images.length ? images : undefined,
+			mode,
+		});
+		store.finishDraft(key, id);
+		return id;
+	} catch (error) {
+		store.updateDraft(key, {
+			pending: false,
+			errorCode:
+				error instanceof Error &&
+				"code" in error &&
+				typeof error.code === "string"
+					? error.code
+					: undefined,
+			error:
+				error instanceof Error
+					? error.message
+					: "The send could not be confirmed.",
+		});
+		throw error;
+	}
 }
-
 type CanonicalSessionsState = {
 	sessions: CanonicalSessionRow[];
 	activeSessionId: string | null;
-	/** Agent profile -> canonical session mapping, so reopening an agent's
-	 * conversation resumes the same session identity instead of creating a
-	 * new one per launch. */
+	activeDraftKey: string | null;
+	drafts: Record<string, ChatDraft>;
 	sessionByAgent: Record<string, string>;
+	pendingSessionId: string | null;
 	loading: boolean;
+	truncated: boolean;
 	error: string | null;
-	fetchSessions: () => Promise<void>;
-	createSession: (cwd: string, agentId?: string) => Promise<string | null>;
+	cwd: string;
+	setCwd: (cwd: string) => void;
+	fetchSessions: (limit?: number) => Promise<void>;
+	createSession: (
+		cwd: string,
+		target?: ChatTarget,
+		requestId?: string,
+	) => Promise<string | null>;
 	setActiveSession: (sessionId: string | null) => void;
-	/** Point an agent at an existing canonical session (resume/fork/new). The
-	 * previous binding is dropped, not deleted: the old session stays in the
-	 * list and any running owner keeps working. */
-	bindSession: (agentId: string, sessionId: string) => void;
-	/** Merge one row from a watcher/stream update without duplicating or
-	 * reordering the list. */
+	openSession: (sessionId: string) => Promise<boolean>;
+	cancelOpen: () => void;
+	stageDraft: (target?: ChatTarget, fresh?: boolean) => string;
+	updateDraft: (key: string, patch: Partial<ChatDraft>) => void;
+	finishDraft: (key: string, sessionId: string) => void;
+	bindSession: (legacyAgentId: string, sessionId: string) => void;
 	upsertSession: (row: CanonicalSessionRow) => void;
 };
 
-function mergeRows(
+function mergeRow(
+	current: CanonicalSessionRow | undefined,
+	incoming: CanonicalSessionRow,
+): CanonicalSessionRow {
+	return {
+		...current,
+		...incoming,
+		attention: mergeCompletionAttention(
+			current?.attention,
+			incoming.attention,
+			incoming.session_id,
+		),
+	};
+}
+/** Full list responses replace membership; a disappeared row is not immortal.
+ * Stream updates use upsert separately and never imply a complete inventory. */
+export function replaceSessionRows(
 	current: CanonicalSessionRow[],
 	incoming: CanonicalSessionRow[],
 ): CanonicalSessionRow[] {
 	const byId = new Map(current.map((row) => [row.session_id, row]));
-	for (const row of incoming) {
-		byId.set(row.session_id, { ...byId.get(row.session_id), ...row });
-	}
-	// Preserve the incoming order for rows the backend returned; rows it did
-	// not return keep their previous relative order at the tail.
-	const ordered: CanonicalSessionRow[] = [];
-	const seen = new Set<string>();
-	for (const row of incoming) {
-		const merged = byId.get(row.session_id);
-		if (merged && !seen.has(row.session_id)) {
-			ordered.push(merged);
-			seen.add(row.session_id);
-		}
-	}
-	for (const row of current) {
-		if (!seen.has(row.session_id)) ordered.push(row);
-	}
-	return ordered;
+	return [
+		...new Map(
+			incoming.map((row) => [
+				row.session_id,
+				mergeRow(byId.get(row.session_id), row),
+			]),
+		).values(),
+	];
 }
-
+let navigationGeneration = 0;
+let refreshGeneration = 0;
 export const useCanonicalSessionsStore = create<CanonicalSessionsState>()(
 	persist(
 		(set, get) => ({
 			sessions: [],
 			activeSessionId: null,
+			activeDraftKey: null,
+			drafts: {},
 			sessionByAgent: {},
+			pendingSessionId: null,
 			loading: false,
+			truncated: false,
 			error: null,
-
-			fetchSessions: async () => {
+			cwd: "~",
+			setCwd: (cwd) => set({ cwd }),
+			fetchSessions: async (limit = 500) => {
+				const generation = ++refreshGeneration;
 				set({ loading: true, error: null });
 				try {
 					const result = await desktopResult<{
 						sessions: BackendSessionRow[];
-					}>({ op: "sessions.list" });
+						truncated?: boolean;
+					}>({ op: "sessions.list", limit });
+					if (generation !== refreshGeneration) return;
+					const rows = result.sessions.map(({ id, name, mtime, ...rest }) => ({
+						...rest,
+						session_id: id,
+						title: name,
+						updated_at: mtime,
+					}));
 					set((state) => ({
-						sessions: mergeRows(
-							state.sessions,
-							(result.sessions ?? []).map(fromBackend),
-						),
+						sessions: replaceSessionRows(state.sessions, rows),
 						loading: false,
+						truncated: result.truncated === true,
 					}));
 				} catch (error) {
-					set({
-						loading: false,
-						error:
-							error instanceof Error
-								? error.message
-								: "The conversation list could not be loaded.",
-					});
+					if (generation === refreshGeneration)
+						set({
+							loading: false,
+							error:
+								error instanceof Error
+									? error.message
+									: "Chats could not refresh. Retry to reconnect.",
+						});
 				}
 			},
-
-			createSession: async (cwd, agentId) => {
+			createSession: async (cwd, target, requestId = crypto.randomUUID()) => {
 				try {
-					const result = await desktopResult<{ session_id: string }>({
+					const result = await desktopResult<{
+						session_id: string;
+						binding: CanonicalSessionRow["binding"];
+					}>({
 						op: "sessions.create",
-						requestId: crypto.randomUUID(),
+						requestId,
 						cwd,
+						...(target ? { target } : {}),
 					});
-					const row: CanonicalSessionRow = {
+					get().upsertSession({
 						session_id: result.session_id,
 						cwd,
-						agent_id: agentId ?? null,
-					};
-					set((state) => ({
-						sessions: mergeRows(state.sessions, [row]),
-						activeSessionId: result.session_id,
-						sessionByAgent: agentId
-							? { ...state.sessionByAgent, [agentId]: result.session_id }
-							: state.sessionByAgent,
-					}));
+						binding: result.binding,
+					});
 					return result.session_id;
 				} catch (error) {
 					set({
 						error:
 							error instanceof Error
 								? error.message
-								: "The conversation could not be created.",
+								: "Chat could not start. Retry with the same draft.",
 					});
-					return null;
+					throw error;
 				}
 			},
-
-			setActiveSession: (sessionId) => set({ activeSessionId: sessionId }),
-
-			bindSession: (agentId, sessionId) =>
-				set((state) => ({
-					activeSessionId: sessionId,
-					sessionByAgent: { ...state.sessionByAgent, [agentId]: sessionId },
-					sessions: mergeRows(state.sessions, [
-						{ session_id: sessionId, agent_id: agentId },
-					]),
-				})),
-
-			upsertSession: (row) => {
-				const { sessions, activeSessionId } = get();
-				const existing = sessions.find(
-					(candidate) => candidate.session_id === row.session_id,
-				);
-				// A watcher update for the already-active session must not disturb
-				// selection; a new row is appended without becoming active.
-				set({
-					sessions: mergeRows(sessions, [row]),
-					activeSessionId: existing ? activeSessionId : activeSessionId,
-				});
+			setActiveSession: (activeSessionId) => {
+				++navigationGeneration;
+				set({ activeSessionId, activeDraftKey: null, pendingSessionId: null });
 			},
+			openSession: async (sessionId) => {
+				const generation = ++navigationGeneration;
+				set({ pendingSessionId: sessionId, error: null });
+				try {
+					// A candidate read does not acknowledge output or switch the current view.
+					// Only a successful latest intent commits; failed reads keep outgoing work.
+					await desktopResult({ op: "sessions.get", sessionId });
+					if (generation !== navigationGeneration) return false;
+					set({
+						activeSessionId: sessionId,
+						activeDraftKey: null,
+						pendingSessionId: null,
+					});
+					return true;
+				} catch (error) {
+					if (generation === navigationGeneration)
+						set({
+							pendingSessionId: null,
+							error:
+								error instanceof Error
+									? error.message
+									: "Chat could not open. Retry.",
+						});
+					return false;
+				}
+			},
+			cancelOpen: () => {
+				++navigationGeneration;
+				set({ pendingSessionId: null });
+			},
+			stageDraft: (target, fresh = false) => {
+				++navigationGeneration;
+				const key =
+					!fresh && target
+						? `draft:${target.kind}:${target.name}`
+						: `draft:${crypto.randomUUID()}`;
+				const existing = get().drafts[key];
+				set((state) => ({
+					activeDraftKey: key,
+					pendingSessionId: null,
+					error: null,
+					drafts: {
+						...state.drafts,
+						[key]: existing ?? {
+							key,
+							target,
+							createRequestId: crypto.randomUUID(),
+							admissionRequestId: crypto.randomUUID(),
+						},
+					},
+				}));
+				return key;
+			},
+			updateDraft: (key, patch) =>
+				set((state) => ({
+					drafts: {
+						...state.drafts,
+						[key]: { ...state.drafts[key], ...patch },
+					},
+				})),
+			finishDraft: (key, sessionId) =>
+				set((state) => {
+					const drafts = { ...state.drafts };
+					delete drafts[key];
+					return {
+						drafts,
+						...(state.activeDraftKey === key
+							? { activeDraftKey: null, activeSessionId: sessionId }
+							: {}),
+					};
+				}),
+			bindSession: (_legacyAgentId, sessionId) =>
+				get().setActiveSession(sessionId),
+			upsertSession: (row) =>
+				set((state) => {
+					const present = state.sessions.some(
+						(item) => item.session_id === row.session_id,
+					);
+					return {
+						sessions: present
+							? state.sessions.map((item) =>
+									item.session_id === row.session_id
+										? mergeRow(item, row)
+										: item,
+								)
+							: [...state.sessions, row],
+					};
+				}),
 		}),
 		{
 			name: "canonical-sessions-storage",
-			// Only the identity mapping persists: the list and active selection
-			// are re-read from the backend on launch, but the agent -> session
-			// binding is what keeps a reopened agent on the same canonical
-			// conversation instead of minting a new one per launch.
 			partialize: (state) => ({
 				sessionByAgent: state.sessionByAgent,
 				activeSessionId: state.activeSessionId,
+				activeDraftKey: state.activeDraftKey,
+				cwd: state.cwd,
+				drafts: Object.fromEntries(
+					Object.entries(state.drafts).map(([key, draft]) => [
+						key,
+						{ ...draft, pending: false },
+					]),
+				),
 			}),
 		},
 	),

--- a/src/renderer/src/shared/store/ui-preferences-store.ts
+++ b/src/renderer/src/shared/store/ui-preferences-store.ts
@@ -165,7 +165,7 @@ type UiPreferencesState = {
  * Default values for canvas and chat sidebar widths
  */
 const DEFAULT_CANVAS_WIDTH = 800;
-const DEFAULT_CHAT_SIDEBAR_WIDTH = 260;
+const DEFAULT_CHAT_SIDEBAR_WIDTH = 280;
 
 export const useUiPreferencesStore = create<UiPreferencesState>()(
 	persist(
@@ -247,7 +247,7 @@ export const useUiPreferencesStore = create<UiPreferencesState>()(
 
 			setChatSidebarWidth: (width: number) => {
 				set({
-					chatSidebarWidth: width,
+					chatSidebarWidth: Math.min(360, Math.max(240, width)),
 				});
 			},
 

--- a/src/shared/desktop-contract.ts
+++ b/src/shared/desktop-contract.ts
@@ -21,6 +21,55 @@ const sessionImage = z
 		mime_type: z.enum(["image/png", "image/jpeg", "image/gif", "image/webp"]),
 	})
 	.strict();
+const profileName = z
+	.string()
+	.min(1)
+	.max(128)
+	.refine(
+		(name) =>
+			name !== "." &&
+			name !== ".." &&
+			!name.includes("/") &&
+			!name.includes("\\") &&
+			[...name].every(
+				(character) =>
+					character.charCodeAt(0) >= 32 && character.charCodeAt(0) !== 127,
+			),
+	);
+const target = z
+	.object({ kind: z.enum(["agent", "team"]), name: profileName })
+	.strict();
+const profileFields = z
+	.object({
+		kind: z.enum(["role", "specialist"]).optional(),
+		description: z.string().max(8000).optional(),
+		instructions: z.string().max(8000).optional(),
+		tools: z.array(z.string().min(1).max(128)).max(256).optional(),
+		effort: z.string().max(64).optional(),
+		delegate: z.boolean().optional(),
+	})
+	.strict();
+const teamFields = z
+	.object({
+		name: z.string().min(1).max(64).optional(),
+		description: z.string().max(8000).optional(),
+		manager: profileName.optional(),
+		members: z
+			.array(
+				z
+					.object({
+						role: profileName,
+						count: z.number().int().min(1).max(16),
+						kind: z.enum(["agent", "team"]),
+					})
+					.strict(),
+			)
+			.max(128)
+			.optional(),
+		instructions: z.string().max(8000).optional(),
+		project: z.string().max(8000).optional(),
+	})
+	.strict();
 const chains = z.record(z.array(z.string().max(1024)).max(100));
 // Mirrors ScheduleUnit in the renderer's api/local-operator/types.ts and the
 // backend's ScheduleUnit enum. Enumerated rather than free text so the value
@@ -63,6 +112,47 @@ const configUpdate = z
 // The renderer selects an operation; it never supplies a URL, method or headers.
 export const desktopRequestSchema = z.discriminatedUnion("op", [
 	z.object({ op: z.literal("capabilities") }).strict(),
+	z.object({ op: z.literal("profiles.list") }).strict(),
+	z.object({ op: z.literal("profiles.get"), name: profileName }).strict(),
+	z
+		.object({ op: z.literal("profiles.install"), name: profileName, requestId })
+		.strict(),
+	z
+		.object({
+			op: z.literal("profiles.create"),
+			name: profileName,
+			requestId,
+			fields: profileFields.extend({
+				description: z.string().max(8000),
+				instructions: z.string().min(1).max(8000),
+			}),
+		})
+		.strict(),
+	z
+		.object({
+			op: z.literal("profiles.update"),
+			name: profileName,
+			requestId,
+			fields: profileFields,
+		})
+		.strict(),
+	z.object({ op: z.literal("teams.list") }).strict(),
+	z.object({ op: z.literal("teams.get"), name: profileName }).strict(),
+	z
+		.object({
+			op: z.literal("teams.create"),
+			requestId,
+			fields: teamFields.extend({ name: z.string().min(1).max(64) }),
+		})
+		.strict(),
+	z
+		.object({
+			op: z.literal("teams.update"),
+			name: profileName,
+			requestId,
+			fields: teamFields,
+		})
+		.strict(),
 	z
 		.object({
 			op: z.literal("sessions.list"),
@@ -74,6 +164,7 @@ export const desktopRequestSchema = z.discriminatedUnion("op", [
 			op: z.literal("sessions.create"),
 			requestId,
 			cwd: z.string().min(1).max(4096),
+			target: target.optional(),
 		})
 		.strict(),
 	z.object({ op: z.literal("sessions.get"), sessionId }).strict(),
@@ -698,6 +789,54 @@ export function desktopEndpoint(request: DesktopRequest): {
 	switch (request.op) {
 		case "capabilities":
 			return { path: "/v1/capabilities", method: "GET" };
+		case "profiles.list":
+			return { path: "/v1/desktop/profiles", method: "GET" };
+		case "profiles.get":
+			return {
+				path: `/v1/desktop/profiles/${encodeURIComponent(request.name)}`,
+				method: "GET",
+			};
+		case "profiles.install":
+			return {
+				path: "/v1/desktop/profiles/install",
+				method: "POST",
+				body: { request_id: request.requestId, name: request.name },
+			};
+		case "profiles.create":
+			return {
+				path: "/v1/desktop/profiles",
+				method: "POST",
+				body: {
+					request_id: request.requestId,
+					name: request.name,
+					...request.fields,
+				},
+			};
+		case "profiles.update":
+			return {
+				path: `/v1/desktop/profiles/${encodeURIComponent(request.name)}`,
+				method: "PATCH",
+				body: { request_id: request.requestId, ...request.fields },
+			};
+		case "teams.list":
+			return { path: "/v1/desktop/teams", method: "GET" };
+		case "teams.get":
+			return {
+				path: `/v1/desktop/teams/${encodeURIComponent(request.name)}`,
+				method: "GET",
+			};
+		case "teams.create":
+			return {
+				path: "/v1/desktop/teams",
+				method: "POST",
+				body: { request_id: request.requestId, ...request.fields },
+			};
+		case "teams.update":
+			return {
+				path: `/v1/desktop/teams/${encodeURIComponent(request.name)}`,
+				method: "PATCH",
+				body: { request_id: request.requestId, ...request.fields },
+			};
 		case "sessions.list":
 			return {
 				path: `/v1/desktop/sessions?limit=${request.limit ?? 100}`,
@@ -707,7 +846,11 @@ export function desktopEndpoint(request: DesktopRequest): {
 			return {
 				path: "/v1/desktop/sessions",
 				method: "POST",
-				body: { request_id: request.requestId, cwd: request.cwd },
+				body: {
+					request_id: request.requestId,
+					cwd: request.cwd,
+					...(request.target ? { target: request.target } : {}),
+				},
 			};
 		case "sessions.get":
 			return {

--- a/src/shared/desktop-session-contract.ts
+++ b/src/shared/desktop-session-contract.ts
@@ -2,6 +2,22 @@
 // Owner state revisions and HTTP semantic receipt cursors are independent. See
 // docs/desktop-controls.md before implementing replay or notifications.
 export type CanonicalSessionId = string;
+/** Returned by session_catalogue version 2. The backend owns status precedence,
+ * active/previous partition and order; clients must not infer them from read state. */
+export type SessionCatalogueStatus = { code: string; label: string };
+export type SessionBinding = { agent: string | null; team: string | null };
+export type SessionCatalogueRow = {
+	id: CanonicalSessionId;
+	name: string;
+	mtime: number;
+	preview: string;
+	live_state: string;
+	pending: string | null;
+	active: boolean;
+	status: SessionCatalogueStatus;
+	binding: SessionBinding;
+	attention?: CompletionAttention;
+};
 export type CompletionAttention = {
 	conversation_id: string;
 	completion_token: string | null;


### PR DESCRIPTION
## What and why

The chat sidebar listed sessions with no idea who answered them, and the agents page edited a **legacy store** that `/agent` and the `agent` tool never read — so an agent you created in the app did not exist to the runtime. This rebuilds both surfaces on the canonical backend added in damianvtran/local-operator#810.

**Change class: C2 — standard, pre-authorized.** User-visible, so it carries a design round and a UX round in addition to code review and QA.

### Delivery contract

- The agents page creates, edits and extends **the actual `/agent` profiles**, builtin lifecycle included; Install is idempotent and **is not a restore**.
- Teams launch the way `/team` launches them.
- Slack-shaped sidebar: Agents, Teams, then All / Active / Previous (Previous collapsed by default), with per-entity expandable session children.
- **Clicking a name stages a draft and allocates nothing**; the first send creates the session. Retries reuse admission keys.
- The backend owns status, ordering and the active/previous partition. The legacy page and endpoints are untouched.

## Evidence

### Real Electron, real preload bridge, real IPC

QA's final pass drove the **built app** with the real main process and real preload — not a shim — against an isolated backend. **21 checks, 21 PASS, 0 FAIL.**

The headline case is the lost-response retry (F3), armed by destroying the *first* `sessions.message` reply inside the real main process so the admission genuinely lands while the UI believes it failed:

```
step 1  sessions.message mode=prompt -> HTTP 200 {"status":"admitted", replayed:false}, reply destroyed
retry   same requestId, PINNED mode  -> HTTP 200 {"status":"admitted", replayed:true}
transcript: matching_user_rows = 1        (no duplicate turn)
receipts:   1 row, fingerprint len 64, result stored
```

What the **unpinned** code would have sent, measured against the same real receipt store:

```
retry same requestId with mode flipped to "steer" -> HTTP 409 "Request ID was already used with different input"
same retry again                                  -> HTTP 409   (the "409 forever" symptom)
```

Mutation checks confirm the guards can still observe the defects they replace: reverting the `mode` pin fails 2 tests; reverting `draftIdentityFor` fails 1; reverting the image-identity guard fails 1.

> **The frames themselves are NOT attached to this PR.** `gh` cannot upload binaries to a PR, and `AGENTS.md` forbids committing evidence into the tree ("Evidence goes on the PR, never into the repository"), so an agent has no path to attach them. They exist on the review host at `/tmp/lo-design/final-populated-dark.png`, `final-populated-light.png` and `final-stale-dark.png` (3456x1812 each), and attaching them is a manual drag-and-drop step a human must perform. **Until that happens the visual evidence described below is not viewable from this page** — the descriptions are a reviewer's account of frames you cannot yet see, not a substitute for them.

### Before / after frames (designer, round 2 — APPROVE, terminal)

Captured from two worktrees against a seeded catalogue (21 sessions, 3 specialists, 2 teams) in a 537px-tall viewport, dark and light:

- `r2-before-populated-dark.png` → `r2-after-populated-dark.png` — the global partition was pushed below the entity list; it is now pinned and reachable while the entity region scrolls in its own bounds.
- `r2-after-stale-dark.png` — on capability error the sidebar keeps its heading, search, sections and rows, and carries its own Retry. Round 1's bare red paragraph is gone.
- `r2-after-error-dark.png`, `r2-after-midloss-dark.png`, `r2-after-populated-light.png`.

### Gates

`check-types` (main + renderer) clean · `test:desktop` **120 pass / 0 fail** · `lint` **24 warnings, identical to the base commit** — no new debt · `check-themes` 1884 contrast assertions across 12 themes, 0 exceptions · `build` OK.

## Limitations — stated plainly

- **Model inference is synthetic.** A deterministic loopback provider replying `QA_UI_REPLY` backed every turn. Store, IPC, preload, HTTP, receipts, owner processes and durable state are the real runtime. Session titles in the frames read `QA_UI_REPLY` for that reason: what is proven is that a real title replaces `Untitled chat` after real turns, not the wording.
- **Designer and UX captured through a shimmed preload.** Their harnesses inject a preload-equivalent bridge and leave `window.api.desktop` undefined, so those frames exercise the real `/__desktop` HTTP fallback but not Electron IPC. **Two behaviours are therefore covered by QA's real-bridge pass and by nothing in the design/UX artifacts: the command-palette IPC toggle in `app.tsx`, and file-attachment reads via `window.api.readFile`.** `app.tsx` is untouched by this PR, and the attachment helper is byte-identical to the base commit (md5 `f9daa8b4…`) — it only moved.
- **`tests/unit/test_computer_input.py` (backend suite) is an environmental flake and my earlier account of it was wrong.** I called it "passes 5/5 in isolation"; QA measured **4 of 5 isolated runs failing** on a loaded host — a subprocess race on a fixed 12s wall-clock budget, not an assertion about behaviour. It fails on the base tree too and is outside both diffs. Recorded, not fixed.
- No `package.json` version bump: it stays at `0.15.2`, the released version. The only `package.json` change registers the new test file.

## Rollout

**Backend first.** Merge damianvtran/local-operator#810 before this PR. This UI negotiates `session_catalogue` version 2 and, against an older backend, shows a plain "update the backend" notice rather than breaking — but the canonical surfaces do not function until the backend side is live.


