### PR TITLE
chore(release): bump version to 0.16.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "local-operator-ui",
-  "version": "0.15.2",
+  "version": "0.16.0",
   "productName": "Local Operator",
   "description": "User interface for AI agent assistants that run Python code safely on your device through an intuitive chat interface. Supports local and cloud LLM models with built-in security features.",
   "main": "./out/main/index.js",


### PR DESCRIPTION
## What and why

Release bump for the canonical chat feature. **Change class C0** — one file, one line, no code.

`package.json`: `0.15.2` → `0.16.0`.

### Bump class: minor

Judged from this repository's own precedent rather than from the size of the diff. `v0.15.0` was a minor for replacing renderer-side copies of provider auth, commands, settings and session state with the backend's own authorities. This release is the same class of change one layer up: the agents page now edits the actual `/agent` profiles instead of a separate legacy store, and the chat sidebar is rebuilt on the canonical session catalogue. A user opening the app finds both surfaces materially different, and the app now requires a backend carrying `session_catalogue` v2 to use them.

Not a major: nothing is removed, the legacy page and its endpoints remain, and against an older backend the app degrades to a notice rather than breaking.

### Window contents

| PR | merge SHA |
|---|---|
| #99 | `3baa1398caac94957611981214f30cb7bea02a97` |
