### PR TITLE
feat(notifications): render backend-composed toasts, and stop announcing turns that did not end

### DIFF
--- a/package.json
+++ b/package.json
@@ -65,7 +65,7 @@
     "check-types:main": "tsc --noEmit -p tsconfig.node.json",
     "check-types:renderer": "tsc --noEmit -p tsconfig.app.json",
     "check-types": "pnpm run check-types:main && pnpm run check-types:renderer",
-    "test:desktop": "node --test scripts/linux-sandbox.test.mjs scripts/desktop-contract.test.mjs scripts/transcript-reducer.test.mjs scripts/provider-state.test.mjs scripts/stale-agent.test.mjs scripts/desktop-renderer-transport.test.mjs scripts/provider-grid-error-copy.test.mjs scripts/settings-time-to-error.test.mjs scripts/backend-error-surfaces.test.mjs scripts/canonical-chat.test.mjs scripts/tool-row.test.mjs scripts/attachment-url.test.mjs",
+    "test:desktop": "node --test scripts/linux-sandbox.test.mjs scripts/desktop-contract.test.mjs scripts/desktop-notifier.test.mjs scripts/transcript-reducer.test.mjs scripts/provider-state.test.mjs scripts/stale-agent.test.mjs scripts/desktop-renderer-transport.test.mjs scripts/provider-grid-error-copy.test.mjs scripts/settings-time-to-error.test.mjs scripts/backend-error-surfaces.test.mjs scripts/canonical-chat.test.mjs scripts/tool-row.test.mjs scripts/attachment-url.test.mjs",
     "check-themes": "node scripts/generate-theme-css.mjs --check && node scripts/contrast-contract.mjs",
     "check-evidence": "node scripts/check-evidence.mjs",
     "check-edit-diffs": "node scripts/check-edit-diffs.mjs",

--- a/scripts/desktop-notifier.test.mjs
+++ b/scripts/desktop-notifier.test.mjs
@@ -457,6 +457,54 @@ test("the status leads a snippet body and never a house body", async () => {
 	assert.equal(globalThis.__toasts.at(-1).body, "Stopped with an error");
 });
 
+// T-U15 — Q-1. The third kind of body, which the two-way split above missed.
+test("the status leads the session's own failure text", async () => {
+	const { notifier } = harness();
+
+	// The backend's real shape for a classified failure: NOT a snippet (the
+	// last assistant line would assert success beside a failed state), but not
+	// a house constant either, so nothing in it names the outcome. This is the
+	// default path — the same privacy flag that yields a session name yields
+	// this text — and without the status it reads as routine log noise.
+	notifier.observe(
+		SESSION,
+		completionFrame({
+			kind: "error",
+			status: "Needs attention",
+			body: "anthropic: 429 rate_limit_error - credit balance too low",
+			body_is_snippet: false,
+			body_is_failure: true,
+			dedupe_key: "complete:failure:1",
+			completion_token: "ffffffff-ffff-4fff-8fff-ffffffffffff",
+		}),
+	);
+	await new Promise((resolve) => setImmediate(resolve));
+	assert.equal(
+		globalThis.__toasts.at(-1).body,
+		"Needs attention — anthropic: 429 rate_limit_error - credit balance too low",
+	);
+
+	// The flag is additive and optional on the wire. A backend old enough to
+	// send a failure summary without it degrades to the bare body rather than
+	// throwing on the missing field.
+	notifier.observe(
+		SESSION,
+		completionFrame({
+			kind: "error",
+			status: "Needs attention",
+			body: "anthropic: 429 rate_limit_error - credit balance too low",
+			body_is_snippet: false,
+			dedupe_key: "complete:failure:2",
+			completion_token: "ffffffff-ffff-4fff-8fff-fffffffffff0",
+		}),
+	);
+	await new Promise((resolve) => setImmediate(resolve));
+	assert.equal(
+		globalThis.__toasts.at(-1).body,
+		"anthropic: 429 rate_limit_error - credit balance too low",
+	);
+});
+
 // T-U6
 test("with notification_contract >= 1 an agent_end event raises nothing", async () => {
 	const { notifier, requests } = harness();

--- a/scripts/desktop-notifier.test.mjs
+++ b/scripts/desktop-notifier.test.mjs
@@ -146,19 +146,77 @@ function coldBackend({ contract = 1 } = {}) {
 	const requests = [];
 	const attempts = [];
 	let live = false;
-	const notifier = new DesktopNotifier(() => null, async (input) => {
-		attempts.push(input);
-		if (!live) throw new Error("connect ECONNREFUSED 127.0.0.1:1111");
-		requests.push(input);
-		if (input?.op === "capabilities") {
-			return {
-				status: 200,
-				body: { result: { features: { notification_contract: contract } } },
-			};
-		}
-		return { status: 200, body: { result: { claimed: true } } };
-	});
-	return { notifier, requests, attempts, up: () => { live = true; } };
+	const notifier = new DesktopNotifier(
+		() => null,
+		async (input) => {
+			attempts.push(input);
+			if (!live) throw new Error("connect ECONNREFUSED 127.0.0.1:1111");
+			requests.push(input);
+			if (input?.op === "capabilities") {
+				return {
+					status: 200,
+					body: { result: { features: { notification_contract: contract } } },
+				};
+			}
+			return { status: 200, body: { result: { claimed: true } } };
+		},
+	);
+	return {
+		notifier,
+		requests,
+		attempts,
+		up: () => {
+			live = true;
+		},
+	};
+}
+
+/**
+ * A backend whose capability endpoint can be taken DOWN AFTER it has answered.
+ *
+ * `coldBackend` only goes dead -> live, which is the cold start. R2-1 is the
+ * other direction and it is the one that reaches an ordinary run: a
+ * health-check restart brings `/health` back (which is what gates the ready
+ * hook) while `/v1/capabilities` is still warming, so the re-probe issued by
+ * that hook fails on a backend that never stopped composing.
+ *
+ * The failure is returned as a 503 rather than thrown because that is what the
+ * real transport does with it: `requestDesktop` catches the fetch error and
+ * answers `{status: 503}` (`src/main/desktop-transport.ts`). A test that threw
+ * here would exercise a path production cannot take.
+ */
+function restartableBackend({ contract = 1 } = {}) {
+	const attempts = [];
+	let capabilitiesUp = true;
+	const notifier = new DesktopNotifier(
+		() => null,
+		async (input) => {
+			attempts.push(input);
+			if (input?.op === "capabilities") {
+				if (!capabilitiesUp) {
+					return {
+						status: 503,
+						body: { detail: "The backend could not complete this request." },
+					};
+				}
+				return {
+					status: 200,
+					body: { result: { features: { notification_contract: contract } } },
+				};
+			}
+			return { status: 200, body: { result: { claimed: true } } };
+		},
+	);
+	return {
+		notifier,
+		attempts,
+		capabilitiesDown: () => {
+			capabilitiesUp = false;
+		},
+		capabilitiesUpAgain: () => {
+			capabilitiesUp = true;
+		},
+	};
 }
 
 /** Let every queued microtask and the probe's retry timers drain. */
@@ -307,18 +365,25 @@ test("a transport-failed claim leaves the completion retryable", async () => {
 		// the SAME `dedupe_key`, which is the natural retry.
 		let broken = true;
 		const requests = [];
-		const notifier = new DesktopNotifier(() => null, async (input) => {
-			requests.push(input);
-			if (broken) {
-				if (failure.reject) throw new Error("backend unreachable");
-				return { status: failure.status, body: null };
-			}
-			return { status: 200, body: { result: { claimed: true } } };
-		});
+		const notifier = new DesktopNotifier(
+			() => null,
+			async (input) => {
+				requests.push(input);
+				if (broken) {
+					if (failure.reject) throw new Error("backend unreachable");
+					return { status: failure.status, body: null };
+				}
+				return { status: 200, body: { result: { claimed: true } } };
+			},
+		);
 
 		notifier.observe(SESSION, completionFrame());
 		await new Promise((resolve) => setImmediate(resolve));
-		assert.equal(globalThis.__toasts.length, 0, "still fails closed on the toast");
+		assert.equal(
+			globalThis.__toasts.length,
+			0,
+			"still fails closed on the toast",
+		);
 
 		broken = false;
 		notifier.observe(SESSION, completionFrame());
@@ -504,10 +569,12 @@ test("a downgrade to an older backend restores the legacy completion signal", as
 	// shape of the case: a health-check restart or external-backend discovery
 	// replaces the process, the app does not.
 	let features = { notification_contract: 1 };
-	const notifier = new DesktopNotifier(() => null, async (input) =>
-		input?.op === "capabilities"
-			? { status: 200, body: { result: { features } } }
-			: { status: 200, body: { result: { claimed: true } } },
+	const notifier = new DesktopNotifier(
+		() => null,
+		async (input) =>
+			input?.op === "capabilities"
+				? { status: 200, body: { result: { features } } }
+				: { status: 200, body: { result: { claimed: true } } },
 	);
 
 	await notifier.refreshNotificationContract();
@@ -534,6 +601,183 @@ test("a downgrade to an older backend restores the legacy completion signal", as
 		"an old backend emits no composed frames, so its legacy signal must return",
 	);
 	assert.equal(globalThis.__toasts.at(-1).title, "Turn complete");
+});
+
+// T-U18 — R2-1. The restart that put the double banner back, and kept it back.
+test("a failed re-probe never invalidates a contract the backend already answered", async () => {
+	const { notifier, attempts, capabilitiesDown, capabilitiesUpAgain } =
+		restartableBackend();
+
+	// t0 — the ready hook fires on a healthy backend and the read answers.
+	await notifier.refreshNotificationContract();
+	notifier.observe(SESSION, completionFrame());
+	await settle(50);
+	assert.equal(
+		globalThis.__toasts.length,
+		1,
+		"the composed frame is delivered",
+	);
+	notifier.observe(SESSION, eventFrame("agent_end"));
+	await settle(50);
+	assert.equal(
+		globalThis.__toasts.length,
+		1,
+		"the composed backend owns the toast",
+	);
+
+	// t1 — a health-check restart. `/health` is what gates the ready hook, and
+	// it recovers first; `/v1/capabilities` is still warming, so all three probe
+	// attempts take the failure tail. The backend never stopped composing.
+	capabilitiesDown();
+	await notifier.refreshNotificationContract();
+	const afterProbe = attempts.length;
+
+	// t2 — the next turn on that same still-composing backend. Under the old
+	// state machine the failed probe had reset the contract to 0 while leaving
+	// `contractAnswered` true, so `awaitContract` declined to re-ask and the
+	// legacy toast fired beside the composed frame — two banners for one turn,
+	// and STICKY, because nothing cleared that pair until the next bounce.
+	capabilitiesUpAgain();
+	notifier.observe(SESSION, eventFrame("agent_end"));
+	await settle(1200);
+	assert.equal(
+		globalThis.__toasts.length,
+		1,
+		"a failed probe taught nothing, so the answered contract still holds",
+	);
+	assert.equal(
+		attempts.length,
+		afterProbe,
+		"and no re-ask was needed: the contract was never invalidated",
+	);
+
+	// The stickiness is the reason this is a blocker rather than a major, so it
+	// is asserted rather than assumed: a second turn must not double either.
+	notifier.observe(SESSION, completionFrame({ dedupe_key: "c2" }));
+	await settle(50);
+	notifier.observe(SESSION, eventFrame("agent_end"));
+	await settle(1200);
+	assert.deepEqual(
+		globalThis.__toasts.map((t) => t.title),
+		["Quarterly revenue model", "Quarterly revenue model"],
+		"one banner per turn, on every subsequent turn",
+	);
+});
+
+// T-U18b — R2-1's converse. Not writing on failure must not cost the downgrade
+// path, which is the reason the reset existed at all (design 4.3).
+test("a successful re-read still restores the legacy path on a downgrade", async () => {
+	// A SUCCESSFUL read returning no key is what an old backend looks like, and
+	// it is the only thing entitled to move the contract back to 0. T-U12 covers
+	// the delivery side; this pins that the R2-1 fix did not break the mechanism
+	// by making the failure tail inert.
+	let features = { notification_contract: 1 };
+	let fail = false;
+	const notifier = new DesktopNotifier(
+		() => null,
+		async (input) =>
+			input?.op === "capabilities"
+				? fail
+					? { status: 503, body: null }
+					: { status: 200, body: { result: { features } } }
+				: { status: 200, body: { result: { claimed: true } } },
+	);
+
+	await notifier.refreshNotificationContract();
+	// A failing probe in between changes nothing, in either direction.
+	fail = true;
+	await notifier.refreshNotificationContract();
+	notifier.observe(SESSION, eventFrame("agent_end"));
+	await settle(1200);
+	assert.equal(globalThis.__toasts.length, 0, "still on the composed backend");
+
+	fail = false;
+	features = {};
+	await notifier.refreshNotificationContract();
+	notifier.observe(SESSION, eventFrame("agent_end"));
+	await settle(50);
+	assert.equal(globalThis.__toasts.at(-1)?.title, "Turn complete");
+});
+
+// T-U19 — R2-2. Two ready hooks in one tick raced, and the loser won.
+test("the newest capability read wins even when an older one settles last", async () => {
+	// Probe #1 answers `contract = 1` but is SLOW; probe #2 is started after it
+	// and fails fast against a blip. Ordering by settlement puts the failure
+	// last; ordering by recency — which is what a generation guard buys — puts
+	// probe #2 last and keeps it from being overruled by a read taken earlier.
+	const order = [];
+	let call = 0;
+	const notifier = new DesktopNotifier(
+		() => null,
+		async (input) => {
+			if (input?.op !== "capabilities")
+				return { status: 200, body: { result: { claimed: true } } };
+			call++;
+			if (call === 1) {
+				// Settles AFTER probe #2 has already finished all three attempts.
+				await new Promise((resolve) => setTimeout(resolve, 900));
+				order.push("slow-200");
+				return {
+					status: 200,
+					body: { result: { features: { notification_contract: 1 } } },
+				};
+			}
+			order.push(`fast-503-${call}`);
+			return { status: 503, body: null };
+		},
+	);
+
+	const first = notifier.refreshNotificationContract();
+	const second = notifier.refreshNotificationContract();
+	await Promise.all([first, second]);
+	await settle(1200);
+
+	assert.equal(
+		order.at(-1),
+		"slow-200",
+		"the stale probe really did settle last, which is the race being pinned",
+	);
+	// Probe #2 is the newest read and it learned nothing, so the contract is
+	// whatever it was before — 0, never answered — and the legacy path re-asks
+	// rather than being handed a stale probe's answer.
+	notifier.observe(SESSION, eventFrame("agent_end"));
+	await settle(1200);
+	assert.equal(
+		globalThis.__toasts.length,
+		1,
+		"a never-answered contract falls back to the legacy toast, not to a stale 1",
+	);
+});
+
+// T-U19b — the same guard from the other side: a directly SET contract is the
+// newest reading, so an older in-flight probe must not settle on top of it.
+test("a directly set contract is not overwritten by an older in-flight probe", async () => {
+	const notifier = new DesktopNotifier(
+		() => null,
+		async (input) =>
+			input?.op === "capabilities"
+				? await new Promise((resolve) =>
+						setTimeout(
+							() =>
+								resolve({ status: 200, body: { result: { features: {} } } }),
+							300,
+						),
+					)
+				: { status: 200, body: { result: { claimed: true } } },
+	);
+
+	const stale = notifier.refreshNotificationContract();
+	notifier.setNotificationContract(1);
+	await stale;
+	await settle(50);
+
+	notifier.observe(SESSION, eventFrame("agent_end"));
+	await settle(1200);
+	assert.equal(
+		globalThis.__toasts.length,
+		0,
+		"the newer direct answer stands; the older probe's 200 does not overrule it",
+	);
 });
 
 // T-U8
@@ -649,7 +893,11 @@ test("a gate with no session_name renders unchanged", () => {
 		const { notifier } = harness();
 		notifier.observe(
 			SESSION,
-			gateFrame({ kind: "approval", title: "Run database migration", ...nameless }),
+			gateFrame({
+				kind: "approval",
+				title: "Run database migration",
+				...nameless,
+			}),
 		);
 		assert.equal(
 			globalThis.__toasts.at(-1).title,
@@ -663,30 +911,155 @@ test("a gate with no session_name renders unchanged", () => {
 	}
 });
 
-// T-U16 — D6. An empty detail used to render a banner with a title and no body.
+// T-U16 — D6/D3-2. An empty detail used to render a banner with a title and no
+// body, and then a bare tool name. Both fall back to the house vocabulary now,
+// which is what `compose.py::gate_body` does with the same input.
 test("a gate with an empty detail still renders a body", () => {
 	const { notifier } = harness();
 
 	notifier.observe(SESSION, gateFrame({ detail: "" }));
 	assert.equal(globalThis.__toasts.at(-1).title, "Question");
-	assert.equal(globalThis.__toasts.at(-1).body, "Question");
+	assert.equal(
+		globalThis.__toasts.at(-1).body,
+		"Waiting for your answer",
+		"not 'Question' twice: the body says what is being waited on",
+	);
 
-	// A titled gate with no detail puts the title where the body is, so the
-	// banner says what it is asking about rather than only its category.
+	// D3-2, the case that reaches a real tool: `_describe_path_approval` returns
+	// "" for a blank path argument, so a detail-less `write` approval is not a
+	// malformed payload. It used to render the bare verb `write` as the entire
+	// body — a word, where the backend deliberately shows a sentence.
 	notifier.observe(
 		SESSION,
-		gateFrame({ kind: "approval", title: "Run database migration", detail: "  " }),
+		gateFrame({ kind: "approval", title: "write", detail: "" }),
 	);
-	assert.equal(globalThis.__toasts.at(-1).title, "Approval needed");
-	assert.equal(globalThis.__toasts.at(-1).body, "Run database migration");
+	assert.equal(globalThis.__toasts.at(-1).title, "write");
+	assert.equal(globalThis.__toasts.at(-1).body, "Waiting for approval");
 
-	// Named, with nothing else: the session leads and the category is the body.
+	notifier.observe(
+		SESSION,
+		gateFrame({
+			kind: "approval",
+			title: "Run database migration",
+			detail: "  ",
+		}),
+	);
+	assert.equal(globalThis.__toasts.at(-1).title, "Run database migration");
+	assert.equal(globalThis.__toasts.at(-1).body, "Waiting for approval");
+
+	// Named, with nothing else: the session leads and the house body follows.
 	notifier.observe(
 		SESSION,
 		gateFrame({ detail: "", session_name: "Nightly ETL backfill" }),
 	);
 	assert.equal(globalThis.__toasts.at(-1).title, "Nightly ETL backfill");
-	assert.equal(globalThis.__toasts.at(-1).body, "Question");
+	assert.equal(globalThis.__toasts.at(-1).body, "Waiting for your answer");
+});
+
+// T-U16b — D3-3. A whitespace-only title is truthy, so the fallback never fired
+// and macOS filled the empty title line with the posting app's name.
+test("a whitespace-only gate title falls back to the category", () => {
+	const { notifier } = harness();
+
+	notifier.observe(SESSION, gateFrame({ title: "   " }));
+	assert.equal(globalThis.__toasts.at(-1).title, "Question");
+	assert.equal(
+		globalThis.__toasts.at(-1).body,
+		"Which environment should this deploy to?",
+	);
+
+	notifier.observe(
+		SESSION,
+		gateFrame({
+			kind: "approval",
+			title: "\t\n",
+			detail: "Delete the staging bucket.",
+		}),
+	);
+	assert.equal(globalThis.__toasts.at(-1).title, "Approval needed");
+	assert.equal(globalThis.__toasts.at(-1).body, "Delete the staging bucket.");
+});
+
+// T-U17 — D3-1. THE input the tools actually emit, which the round-2 fixture
+// did not: for a tool approval the title IS the tool name and the detail
+// already leads with it, so the naive join said the word twice.
+//
+// These vectors are `compose.py::gate_body`'s own, from
+// `tests/unit/notifications/test_compose.py::test_a_gate_body_does_not_repeat_the_tool_name`.
+// Duplicating them here is the only drift check available across the two
+// repositories: if the backend's rule changes, this file is where the UI's copy
+// of it is pinned.
+test("a named tool approval does not repeat the tool name", () => {
+	const { notifier } = harness();
+
+	// `build_write_tool` has name="write" and `_approval_description` returns
+	// `f"{action}: {target}"`, so this exact pair is what arrives.
+	notifier.observe(
+		SESSION,
+		gateFrame({
+			kind: "approval",
+			title: "write",
+			detail: "write: /Users/damian/notes.md",
+			session_name: "Nightly ETL backfill",
+		}),
+	);
+	assert.equal(globalThis.__toasts.at(-1).title, "Nightly ETL backfill");
+	assert.equal(
+		globalThis.__toasts.at(-1).body,
+		"write: /Users/damian/notes.md",
+		"not 'write: write: /Users/damian/notes.md'",
+	);
+	assert.equal(
+		globalThis.__toasts.at(-1).body.match(/write:/g).length,
+		1,
+		"the action word appears once",
+	);
+
+	// `_describe_shell_approval` emits "run: <command>" under the title `bash`,
+	// which does NOT overlap — so the prefix must still be applied. This is the
+	// case the rule must not over-correct into dropping the tool name.
+	notifier.observe(
+		SESSION,
+		gateFrame({
+			kind: "approval",
+			title: "bash",
+			detail: "run: rm -rf build/",
+			session_name: "Nightly ETL backfill",
+		}),
+	);
+	assert.equal(
+		globalThis.__toasts.at(-1).body,
+		"bash: run: rm -rf build/",
+		"a non-overlapping detail still gets the tool name",
+	);
+
+	// Case-insensitive, as the backend's `.lower()` comparison is.
+	notifier.observe(
+		SESSION,
+		gateFrame({
+			kind: "approval",
+			title: "Edit",
+			detail: "edit: /Users/d/src/app.ts",
+			session_name: "Quarterly revenue model",
+		}),
+	);
+	assert.equal(globalThis.__toasts.at(-1).body, "edit: /Users/d/src/app.ts");
+
+	// The NAMELESS branch renders the same approval with the tool name on the
+	// title line, so the body must not carry it a second time either.
+	notifier.observe(
+		SESSION,
+		gateFrame({
+			kind: "approval",
+			title: "write",
+			detail: "write: /Users/damian/notes.md",
+		}),
+	);
+	assert.equal(globalThis.__toasts.at(-1).title, "write");
+	assert.equal(
+		globalThis.__toasts.at(-1).body,
+		"write: /Users/damian/notes.md",
+	);
 });
 
 // T-U9

--- a/scripts/desktop-notifier.test.mjs
+++ b/scripts/desktop-notifier.test.mjs
@@ -1,0 +1,439 @@
+import assert from "node:assert/strict";
+import { beforeEach, test } from "node:test";
+import { build } from "esbuild";
+
+/**
+ * Delivery-sink tests for the main-process notifier.
+ *
+ * Bundled in memory from the shipped TypeScript, the same way
+ * `desktop-contract.test.mjs` does, so this guards the real module rather than
+ * a transcription of it. The electron fixture supplies a FAKE `Notification`
+ * that records its constructor arguments: the point of these tests is not that
+ * "a notification happened" but that the exact strings the backend composed
+ * reached the OS boundary unchanged, and that the ones which must NOT reach it
+ * never got there.
+ *
+ * The ordering assertions (T-U2, T-U3) are the load-bearing ones. A toast the
+ * focus gate suppresses must not have claimed cross-surface delivery first, or
+ * the completion is marked delivered while nobody was told and no other
+ * surface can ever tell them. See docs/design/descriptive-notifications.md 7.3.
+ */
+const bundle = await build({
+	stdin: {
+		contents: 'export * from "./src/main/desktop-notifier";',
+		resolveDir: process.cwd(),
+	},
+	bundle: true,
+	format: "esm",
+	platform: "node",
+	write: false,
+	plugins: [
+		{
+			name: "electron-fixture",
+			setup(builder) {
+				builder.onResolve({ filter: /^electron$/ }, () => ({
+					path: "electron",
+					namespace: "fixture",
+				}));
+				builder.onLoad({ filter: /.*/, namespace: "fixture" }, () => ({
+					contents: `
+			export class Notification {
+				static isSupported() { return globalThis.__notifySupported; }
+				constructor(options) { this.options = options; globalThis.__toasts.push(options); }
+				on(event, handler) { this.handlers ??= {}; this.handlers[event] = handler; }
+				show() { globalThis.__shown.push(this); }
+			}
+		`,
+					loader: "js",
+				}));
+			},
+		},
+	],
+});
+const { DesktopNotifier } = await import(
+	`data:text/javascript;base64,${Buffer.from(bundle.outputFiles[0].text).toString("base64")}`
+);
+
+const SESSION = "123456abcdef";
+const TOKEN = "bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb";
+
+/** A composed completion frame, exactly the shape the bridge puts on the wire. */
+function completionFrame(overrides = {}) {
+	return {
+		session_id: SESSION,
+		epoch: "abc123",
+		seq: 7,
+		type: "notification",
+		payload: {
+			contract: 1,
+			kind: "complete",
+			title: "Quarterly revenue model",
+			status: "Complete",
+			body: "Rebuilt the forecast with the Q3 actuals and reconciled the variance.",
+			body_is_snippet: true,
+			title_is_session_name: true,
+			dedupe_key: `complete:${SESSION}:${TOKEN}`,
+			completion_token: TOKEN,
+			session_name: "Quarterly revenue model",
+			focus_policy: "when_unfocused",
+			...overrides,
+		},
+	};
+}
+
+function eventFrame(type) {
+	return {
+		session_id: SESSION,
+		epoch: "abc123",
+		seq: 11,
+		type: "event",
+		payload: { type },
+	};
+}
+
+/**
+ * Build a notifier with a recording request sender.
+ *
+ * `claimed` decides what `sessions.notified` answers; `reject` makes the send
+ * throw, which is the transport failure the notifier must fail closed on.
+ */
+function harness({ claimed = true, status = 200, reject = false } = {}) {
+	const requests = [];
+	const notifier = new DesktopNotifier(
+		() => null,
+		async (input) => {
+			requests.push(input);
+			if (reject) throw new Error("backend unreachable");
+			return { status, body: { result: { claimed } } };
+		},
+	);
+	return { notifier, requests };
+}
+
+/** Report a window as visible+focused, the only state that gates a completion. */
+async function focusWindow(notifier, requests) {
+	await notifier.heartbeat(1, {
+		sessionId: SESSION,
+		subscriptionId: "a".repeat(32),
+		visible: true,
+		focused: true,
+	});
+	// The lease is not part of what these tests measure; drop it so `requests`
+	// reads as the notification path's traffic alone.
+	requests.length = 0;
+}
+
+beforeEach(() => {
+	globalThis.__toasts = [];
+	globalThis.__shown = [];
+	globalThis.__notifySupported = true;
+});
+
+// T-U1
+test("a composed notification reaches the OS with the backend's strings verbatim", async () => {
+	const { notifier, requests } = harness();
+	const frame = completionFrame();
+	notifier.observe(SESSION, frame);
+	// The claim is a real await inside `observe`'s fire-and-forget promise.
+	await new Promise((resolve) => setImmediate(resolve));
+
+	assert.equal(globalThis.__toasts.length, 1);
+	assert.equal(globalThis.__shown.length, 1, "the toast was actually shown");
+	const toast = globalThis.__toasts[0];
+	assert.equal(toast.title, frame.payload.title);
+	// Status leads the body: it is the word the user reads in under a second
+	// and it must survive on the platforms where `subtitle` does not exist.
+	assert.equal(
+		toast.body,
+		`${frame.payload.status} — ${frame.payload.body}`,
+		"status and body are joined, and neither is re-worded",
+	);
+	assert.equal(toast.silent, false);
+	assert.deepEqual(requests, [
+		{ op: "sessions.notified", sessionId: SESSION, completionToken: TOKEN },
+	]);
+});
+
+// T-U2
+test("a focused window suppresses the toast AND never takes the claim", async () => {
+	const { notifier, requests } = harness();
+	await focusWindow(notifier, requests);
+
+	notifier.observe(SESSION, completionFrame());
+	await new Promise((resolve) => setImmediate(resolve));
+
+	assert.equal(globalThis.__toasts.length, 0);
+	// The ordering guarantee. A claim taken here would mark the completion
+	// delivered while nobody was told, and no other surface could ever tell
+	// them: `claim_delivery` returns false from then on, for good.
+	assert.deepEqual(requests, [], "the focus gate runs BEFORE the claim");
+});
+
+// T-U2, the other half: `always` is what a gate carries, and it ignores focus.
+test("focus_policy 'always' toasts even with a focused window", async () => {
+	const { notifier, requests } = harness();
+	await focusWindow(notifier, requests);
+
+	notifier.observe(
+		SESSION,
+		completionFrame({ focus_policy: "always", kind: "ask" }),
+	);
+	await new Promise((resolve) => setImmediate(resolve));
+
+	assert.equal(globalThis.__toasts.length, 1);
+});
+
+// T-U3
+test("two frames with one dedupe_key produce one toast and one claim", async () => {
+	const { notifier, requests } = harness();
+	notifier.observe(SESSION, completionFrame());
+	notifier.observe(SESSION, completionFrame({ title: "renamed since" }));
+	await new Promise((resolve) => setImmediate(resolve));
+
+	assert.equal(globalThis.__toasts.length, 1);
+	assert.equal(
+		requests.length,
+		1,
+		"the dedupe map collapses before the HTTP claim",
+	);
+
+	// A DIFFERENT completion is a different key even on the same session and
+	// the same bridge epoch: keying on `session:epoch:seq` is what re-toasted a
+	// completion that a reconnect merely re-delivered.
+	const other = "cccccccc-cccc-4ccc-8ccc-cccccccccccc";
+	notifier.observe(
+		SESSION,
+		completionFrame({
+			completion_token: other,
+			dedupe_key: `complete:${SESSION}:${other}`,
+		}),
+	);
+	await new Promise((resolve) => setImmediate(resolve));
+	assert.equal(globalThis.__toasts.length, 2);
+});
+
+// T-U4
+test("a lost claim produces no toast", async () => {
+	const { notifier, requests } = harness({ claimed: false });
+	notifier.observe(SESSION, completionFrame());
+	await new Promise((resolve) => setImmediate(resolve));
+
+	assert.equal(requests.length, 1, "the claim was attempted");
+	assert.equal(
+		globalThis.__toasts.length,
+		0,
+		"another surface owns this completion",
+	);
+});
+
+// T-U5
+test("a rejected or failing claim fails closed", async () => {
+	for (const options of [{ reject: true }, { status: 500 }, { status: 404 }]) {
+		globalThis.__toasts = [];
+		const { notifier } = harness(options);
+		notifier.observe(SESSION, completionFrame());
+		await new Promise((resolve) => setImmediate(resolve));
+		assert.equal(
+			globalThis.__toasts.length,
+			0,
+			`failing open would duplicate the banner on every surface: ${JSON.stringify(options)}`,
+		);
+	}
+});
+
+// T-U6
+test("with notification_contract >= 1 an agent_end event raises nothing", async () => {
+	const { notifier, requests } = harness();
+	notifier.setNotificationContract(1);
+
+	notifier.observe(SESSION, eventFrame("agent_end"));
+	notifier.observe(SESSION, eventFrame("turn_end"));
+	await new Promise((resolve) => setImmediate(resolve));
+
+	assert.equal(globalThis.__toasts.length, 0, "the backend owns every toast");
+	assert.deepEqual(requests, []);
+
+	// The latch: a backend swapped underneath a running app can compose before
+	// the capability read is refreshed, so a frame in hand closes the legacy
+	// path on its own.
+	const { notifier: fresh } = harness();
+	fresh.observe(SESSION, completionFrame());
+	await new Promise((resolve) => setImmediate(resolve));
+	globalThis.__toasts = [];
+	fresh.observe(SESSION, eventFrame("agent_end"));
+	assert.equal(
+		globalThis.__toasts.length,
+		0,
+		"a composed frame latches the gate",
+	);
+});
+
+// T-U7
+test("on the legacy path agent_end toasts and turn_end never does", async () => {
+	const { notifier } = harness();
+	assert.equal(globalThis.__toasts.length, 0);
+
+	// `turn_end` is ONE MODEL CALL finishing. An agentic turn is many of them,
+	// and toasting each was the reported defect. It is dropped on every backend
+	// version, which is why this assertion sits on the legacy path too.
+	notifier.observe(SESSION, eventFrame("turn_end"));
+	assert.equal(globalThis.__toasts.length, 0);
+
+	notifier.observe(SESSION, eventFrame("agent_end"));
+	assert.equal(globalThis.__toasts.length, 1, "an old backend keeps a signal");
+	assert.equal(globalThis.__toasts[0].title, "Turn complete");
+	// No status on the canned copy, so no stray separator leaks into the body.
+	assert.equal(globalThis.__toasts[0].body, "The agent finished its turn.");
+});
+
+// T-U7, boundary: an unfetchable capability must land on legacy, not silence.
+test("an absent or malformed capability value falls back to the legacy path", async () => {
+	for (const value of [undefined, null, 0, "1", Number.NaN]) {
+		globalThis.__toasts = [];
+		const { notifier } = harness();
+		notifier.setNotificationContract(value);
+		notifier.observe(SESSION, eventFrame("agent_end"));
+		assert.equal(
+			globalThis.__toasts.length,
+			1,
+			`a missing capability is a transient HTTP failure far more often than an old backend: ${String(value)}`,
+		);
+	}
+});
+
+// T-U8
+test("an unknown future frame type is ignored without throwing", async () => {
+	const { notifier, requests } = harness();
+	for (const frame of [
+		{
+			session_id: SESSION,
+			epoch: "abc123",
+			seq: 3,
+			type: "something_new",
+			payload: {},
+		},
+		{ session_id: SESSION, type: "heartbeat" },
+		{ session_id: SESSION, type: "gap" },
+		{
+			session_id: SESSION,
+			epoch: "abc123",
+			seq: 4,
+			type: "attention",
+			payload: {},
+		},
+	]) {
+		assert.doesNotThrow(() => notifier.observe(SESSION, frame));
+	}
+	await new Promise((resolve) => setImmediate(resolve));
+	assert.equal(globalThis.__toasts.length, 0);
+	assert.deepEqual(requests, []);
+});
+
+// T-U8, the other direction of skew: an unsupported platform stays silent.
+test("no toast and no claim when the platform cannot notify", async () => {
+	globalThis.__notifySupported = false;
+	const { notifier, requests } = harness();
+	notifier.observe(SESSION, completionFrame());
+	await new Promise((resolve) => setImmediate(resolve));
+	assert.equal(globalThis.__toasts.length, 0);
+	assert.deepEqual(requests, [], "isSupported is checked before the claim");
+});
+
+// T-U9
+test("an untitled 'ask' gate says Question, not Approval needed", () => {
+	const { notifier } = harness();
+	const gate = (kind, title) => ({
+		session_id: SESSION,
+		epoch: "abc123",
+		seq: 2,
+		type: "frontend.update",
+		payload: {
+			epoch: "abc123",
+			sequence: 2,
+			changes: {
+				pending_gate: {
+					request_id: `req-${kind}-${title}`,
+					kind,
+					title,
+					detail: "Which environment should this deploy to?",
+					options: [],
+					secret: false,
+					question_index: 0,
+					question_total: 1,
+				},
+			},
+		},
+	});
+
+	// The defect: an untitled question announced an approval, so the user went
+	// looking for a yes/no button and found a question.
+	notifier.observe(SESSION, gate("ask", ""));
+	assert.equal(globalThis.__toasts.at(-1).title, "Question");
+
+	notifier.observe(SESSION, gate("approval", ""));
+	assert.equal(globalThis.__toasts.at(-1).title, "Approval needed");
+
+	// A real title still wins over both fallbacks.
+	notifier.observe(SESSION, gate("ask", "Choose a deploy target"));
+	assert.equal(globalThis.__toasts.at(-1).title, "Choose a deploy target");
+	// A gate carries no status, so the detail is the body with no separator.
+	assert.equal(
+		globalThis.__toasts.at(-1).body,
+		"Which environment should this deploy to?",
+	);
+});
+
+// T-U10
+test("the notification path never emits sessions.seen", async () => {
+	const { notifier, requests } = harness();
+	notifier.observe(SESSION, completionFrame());
+	notifier.observe(
+		SESSION,
+		completionFrame({ kind: "error", dedupe_key: "e1" }),
+	);
+	notifier.observe(SESSION, eventFrame("agent_end"));
+	await new Promise((resolve) => setImmediate(resolve));
+
+	// Notifying is not reading. A delivery claim that advanced the read
+	// watermark would clear the sidebar's unseen mark for a session the user
+	// never opened, which is why these are two separate watermarks and two
+	// separate ops.
+	assert.ok(requests.length > 0, "the path did emit something");
+	for (const request of requests) {
+		assert.notEqual(request.op, "sessions.seen");
+		assert.equal(request.op, "sessions.notified");
+	}
+});
+
+test("refreshNotificationContract reads the capability and survives failure", async () => {
+	for (const [response, expected] of [
+		[
+			{
+				status: 200,
+				body: { result: { features: { notification_contract: 1 } } },
+			},
+			0,
+		],
+		[{ status: 200, body: { result: { features: {} } } }, 1],
+		[{ status: 503, body: null }, 1],
+		["throw", 1],
+	]) {
+		globalThis.__toasts = [];
+		const notifier = new DesktopNotifier(
+			() => null,
+			async () => {
+				if (response === "throw") throw new Error("unreachable");
+				return response;
+			},
+		);
+		await notifier.refreshNotificationContract();
+		notifier.observe(SESSION, eventFrame("agent_end"));
+		// `expected` is the legacy-toast count: 0 once the backend claims the
+		// contract, 1 in every degraded case, because silence loses completions.
+		assert.equal(
+			globalThis.__toasts.length,
+			expected,
+			JSON.stringify(response),
+		);
+	}
+});

--- a/scripts/desktop-notifier.test.mjs
+++ b/scripts/desktop-notifier.test.mjs
@@ -96,18 +96,74 @@ function eventFrame(type) {
  *
  * `claimed` decides what `sessions.notified` answers; `reject` makes the send
  * throw, which is the transport failure the notifier must fail closed on.
+ * `contract` is what `capabilities` reports, so a test can stand up a backend
+ * that advertises the composed contract without reaching past the public API.
  */
-function harness({ claimed = true, status = 200, reject = false } = {}) {
+function harness({
+	claimed = true,
+	status = 200,
+	reject = false,
+	contract = undefined,
+} = {}) {
 	const requests = [];
 	const notifier = new DesktopNotifier(
 		() => null,
 		async (input) => {
 			requests.push(input);
 			if (reject) throw new Error("backend unreachable");
+			if (input?.op === "capabilities") {
+				return {
+					status: 200,
+					body: {
+						result: {
+							features:
+								contract === undefined
+									? {}
+									: { notification_contract: contract },
+						},
+					},
+				};
+			}
 			return { status, body: { result: { claimed } } };
 		},
 	);
 	return { notifier, requests };
+}
+
+/**
+ * A sender that is DEAD until `up()` is called, then answers as a backend
+ * advertising the composed notification contract.
+ *
+ * This is the cold-start harness R1 needed and the original could not express.
+ * Every other harness here constructs a sender that is already answering,
+ * which is precisely why the whole suite missed a capability read issued
+ * before `backendService.start()` had minted the desktop token: against an
+ * always-up sender that read succeeds and the gate closes, while on the
+ * shipped self-managed path it hit a dead port and the legacy toast stayed
+ * live. `requests` records only what actually reached a live backend.
+ */
+function coldBackend({ contract = 1 } = {}) {
+	const requests = [];
+	const attempts = [];
+	let live = false;
+	const notifier = new DesktopNotifier(() => null, async (input) => {
+		attempts.push(input);
+		if (!live) throw new Error("connect ECONNREFUSED 127.0.0.1:1111");
+		requests.push(input);
+		if (input?.op === "capabilities") {
+			return {
+				status: 200,
+				body: { result: { features: { notification_contract: contract } } },
+			};
+		}
+		return { status: 200, body: { result: { claimed: true } } };
+	});
+	return { notifier, requests, attempts, up: () => { live = true; } };
+}
+
+/** Let every queued microtask and the probe's retry timers drain. */
+async function settle(ms = 1200) {
+	await new Promise((resolve) => setTimeout(resolve, ms));
 }
 
 /** Report a window as visible+focused, the only state that gates a completion. */
@@ -241,6 +297,101 @@ test("a rejected or failing claim fails closed", async () => {
 	}
 });
 
+// T-U13 — M1. A failed claim must not burn the dedupe key.
+test("a transport-failed claim leaves the completion retryable", async () => {
+	for (const failure of [{ reject: true }, { status: 503 }, { status: 422 }]) {
+		globalThis.__toasts = [];
+		// Window A's claim fails; the completion is announced nowhere and the
+		// backend never advanced `claim_delivery`, so it is still owed. Design
+		// 7.5: a second Electron window on the same session replays a frame with
+		// the SAME `dedupe_key`, which is the natural retry.
+		let broken = true;
+		const requests = [];
+		const notifier = new DesktopNotifier(() => null, async (input) => {
+			requests.push(input);
+			if (broken) {
+				if (failure.reject) throw new Error("backend unreachable");
+				return { status: failure.status, body: null };
+			}
+			return { status: 200, body: { result: { claimed: true } } };
+		});
+
+		notifier.observe(SESSION, completionFrame());
+		await new Promise((resolve) => setImmediate(resolve));
+		assert.equal(globalThis.__toasts.length, 0, "still fails closed on the toast");
+
+		broken = false;
+		notifier.observe(SESSION, completionFrame());
+		await new Promise((resolve) => setImmediate(resolve));
+		assert.equal(
+			requests.length,
+			2,
+			`the retry re-attempted the claim: ${JSON.stringify(failure)}`,
+		);
+		assert.equal(
+			globalThis.__toasts.length,
+			1,
+			`the completion reached a surface on retry: ${JSON.stringify(failure)}`,
+		);
+	}
+});
+
+// T-U13, the converse: a CLEAN loss keeps the key, because another surface
+// genuinely owns that completion and re-attempting only re-loses the race.
+test("a cleanly lost claim is not retried", async () => {
+	const { notifier, requests } = harness({ claimed: false });
+	notifier.observe(SESSION, completionFrame());
+	await new Promise((resolve) => setImmediate(resolve));
+	notifier.observe(SESSION, completionFrame());
+	await new Promise((resolve) => setImmediate(resolve));
+
+	assert.equal(requests.length, 1, "the backend answered; the key stays spent");
+	assert.equal(globalThis.__toasts.length, 0);
+});
+
+// T-U14 — D2. The status leads only a model-written snippet.
+test("the status leads a snippet body and never a house body", async () => {
+	const { notifier } = harness();
+
+	// A snippet does not say the outcome, so the category in front of it is the
+	// only thing that does.
+	notifier.observe(SESSION, completionFrame());
+	await new Promise((resolve) => setImmediate(resolve));
+	assert.equal(
+		globalThis.__toasts.at(-1).body,
+		"Complete — Rebuilt the forecast with the Q3 actuals and reconciled the variance.",
+	);
+
+	// A house body already names the state. "Complete — Task complete" asserted
+	// one fact twice in the two lines a banner gets, and it is what every user
+	// with the session-name privacy flag off received.
+	notifier.observe(
+		SESSION,
+		completionFrame({
+			body: "Task complete",
+			body_is_snippet: false,
+			dedupe_key: "complete:house:1",
+			completion_token: "dddddddd-dddd-4ddd-8ddd-dddddddddddd",
+		}),
+	);
+	await new Promise((resolve) => setImmediate(resolve));
+	assert.equal(globalThis.__toasts.at(-1).body, "Task complete");
+
+	notifier.observe(
+		SESSION,
+		completionFrame({
+			kind: "error",
+			status: "Needs attention",
+			body: "Stopped with an error",
+			body_is_snippet: false,
+			dedupe_key: "complete:house:2",
+			completion_token: "eeeeeeee-eeee-4eee-8eee-eeeeeeeeeeee",
+		}),
+	);
+	await new Promise((resolve) => setImmediate(resolve));
+	assert.equal(globalThis.__toasts.at(-1).body, "Stopped with an error");
+});
+
 // T-U6
 test("with notification_contract >= 1 an agent_end event raises nothing", async () => {
 	const { notifier, requests } = harness();
@@ -248,23 +399,65 @@ test("with notification_contract >= 1 an agent_end event raises nothing", async 
 
 	notifier.observe(SESSION, eventFrame("agent_end"));
 	notifier.observe(SESSION, eventFrame("turn_end"));
-	await new Promise((resolve) => setImmediate(resolve));
+	await settle(50);
 
 	assert.equal(globalThis.__toasts.length, 0, "the backend owns every toast");
 	assert.deepEqual(requests, []);
+});
 
-	// The latch: a backend swapped underneath a running app can compose before
-	// the capability read is refreshed, so a frame in hand closes the legacy
-	// path on its own.
-	const { notifier: fresh } = harness();
-	fresh.observe(SESSION, completionFrame());
-	await new Promise((resolve) => setImmediate(resolve));
-	globalThis.__toasts = [];
-	fresh.observe(SESSION, eventFrame("agent_end"));
+// T-U11 — R1. The cold-start ordering, which the old harness could not express.
+test("a capability read issued before the backend is up raises no legacy toast", async () => {
+	const { notifier, attempts, up } = coldBackend();
+
+	// Exactly the shipped sequence: the app asks while the backend is still
+	// dead (this is what `app.whenReady()` used to do), the backend comes up,
+	// then the turn's `agent_end` arrives on the stream BEFORE the composed
+	// frame, which follows from the backend's 1 s attention poll.
+	notifier.refreshNotificationContract();
+	await settle();
+	assert.ok(
+		attempts.some((a) => a?.op === "capabilities"),
+		"the read was attempted against the dead port",
+	);
+
+	// NO re-read here, deliberately: this test replays the wiring as it was,
+	// where `app.whenReady()` issued the one and only capability read. Adding a
+	// second read would test the new call site rather than the defect, and the
+	// defect is that a single lost read leaves the gate reading "no contract"
+	// forever. The notifier must recover from it on its own.
+	up();
+
+	notifier.observe(SESSION, eventFrame("agent_end"));
+	await settle(50);
+	notifier.observe(SESSION, completionFrame());
+	await settle(50);
+
+	// The old ordering produced two banners here: "Turn complete" from the
+	// legacy path plus the composed one. That is the defect this PR exists to
+	// remove, and it reproduced on the ordinary self-managed cold start.
+	assert.deepEqual(
+		globalThis.__toasts.map((t) => t.title),
+		["Quarterly revenue model"],
+		"one turn, one banner",
+	);
+});
+
+// T-U11b — the same window without any re-read at all: the legacy toast must
+// wait for an answer rather than assume there is no contract.
+test("agent_end arriving before any capability answer does not toast on a composing backend", async () => {
+	const { notifier, up } = coldBackend();
+
+	// No explicit refresh: the notifier has never asked. A notifier that has
+	// not asked is indistinguishable from one told "no contract", and guessing
+	// "no contract" is exactly the double banner. It must ask, not guess.
+	up();
+	notifier.observe(SESSION, eventFrame("agent_end"));
+	await settle(100);
+
 	assert.equal(
 		globalThis.__toasts.length,
 		0,
-		"a composed frame latches the gate",
+		"the legacy toast is deferred until the contract read settles",
 	);
 });
 
@@ -277,9 +470,11 @@ test("on the legacy path agent_end toasts and turn_end never does", async () => 
 	// and toasting each was the reported defect. It is dropped on every backend
 	// version, which is why this assertion sits on the legacy path too.
 	notifier.observe(SESSION, eventFrame("turn_end"));
+	await settle(50);
 	assert.equal(globalThis.__toasts.length, 0);
 
 	notifier.observe(SESSION, eventFrame("agent_end"));
+	await settle(50);
 	assert.equal(globalThis.__toasts.length, 1, "an old backend keeps a signal");
 	assert.equal(globalThis.__toasts[0].title, "Turn complete");
 	// No status on the canned copy, so no stray separator leaks into the body.
@@ -293,12 +488,52 @@ test("an absent or malformed capability value falls back to the legacy path", as
 		const { notifier } = harness();
 		notifier.setNotificationContract(value);
 		notifier.observe(SESSION, eventFrame("agent_end"));
+		await settle(50);
 		assert.equal(
 			globalThis.__toasts.length,
 			1,
 			`a missing capability is a transient HTTP failure far more often than an old backend: ${String(value)}`,
 		);
 	}
+});
+
+// T-U12 — M2. The capability read is re-readable in BOTH directions, which is
+// what replaced the one-way latch.
+test("a downgrade to an older backend restores the legacy completion signal", async () => {
+	// ONE notifier whose backend is swapped underneath it, which is the real
+	// shape of the case: a health-check restart or external-backend discovery
+	// replaces the process, the app does not.
+	let features = { notification_contract: 1 };
+	const notifier = new DesktopNotifier(() => null, async (input) =>
+		input?.op === "capabilities"
+			? { status: 200, body: { result: { features } } }
+			: { status: 200, body: { result: { claimed: true } } },
+	);
+
+	await notifier.refreshNotificationContract();
+	// A composed frame arrives and is delivered, so this run has genuinely seen
+	// the new backend compose — the state the old one-way latch made permanent.
+	notifier.observe(SESSION, completionFrame());
+	await settle(50);
+	assert.equal(globalThis.__toasts.length, 1);
+	notifier.observe(SESSION, eventFrame("agent_end"));
+	await settle(50);
+	assert.equal(globalThis.__toasts.length, 1, "the new backend owns toasts");
+
+	// Now an OLDER backend. Design 4.3 names this direction explicitly. Under
+	// the one-way latch the session went silent on completions for the rest of
+	// the run: the latch blocked the legacy path and the old backend emits no
+	// composed frames, so nothing was left to tell the user anything.
+	features = {};
+	await notifier.refreshNotificationContract();
+	notifier.observe(SESSION, eventFrame("agent_end"));
+	await settle(50);
+	assert.equal(
+		globalThis.__toasts.length,
+		2,
+		"an old backend emits no composed frames, so its legacy signal must return",
+	);
+	assert.equal(globalThis.__toasts.at(-1).title, "Turn complete");
 });
 
 // T-U8
@@ -337,6 +572,121 @@ test("no toast and no claim when the platform cannot notify", async () => {
 	await new Promise((resolve) => setImmediate(resolve));
 	assert.equal(globalThis.__toasts.length, 0);
 	assert.deepEqual(requests, [], "isSupported is checked before the claim");
+});
+
+/** A `pending_gate` on a frontend update, the way a gate really arrives. */
+function gateFrame(overrides = {}) {
+	return {
+		session_id: SESSION,
+		epoch: "abc123",
+		seq: 2,
+		type: "frontend.update",
+		payload: {
+			epoch: "abc123",
+			sequence: 2,
+			changes: {
+				pending_gate: {
+					request_id: `req-${JSON.stringify(overrides)}`,
+					kind: "ask",
+					title: "",
+					detail: "Which environment should this deploy to?",
+					options: [],
+					secret: false,
+					question_index: 0,
+					question_total: 1,
+					...overrides,
+				},
+			},
+		},
+	};
+}
+
+// T-U15 — D3. A named gate takes the completion banner's shape, so the banner
+// the user is BLOCKED on can be triaged without clicking it.
+test("a gate carrying session_name titles the banner with the session", () => {
+	const { notifier } = harness();
+
+	notifier.observe(
+		SESSION,
+		gateFrame({
+			kind: "approval",
+			title: "Run database migration",
+			detail: "This applies 00061 to the prod-2 cluster.",
+			session_name: "Nightly ETL backfill",
+		}),
+	);
+	assert.equal(globalThis.__toasts.at(-1).title, "Nightly ETL backfill");
+	assert.equal(
+		globalThis.__toasts.at(-1).body,
+		"Run database migration: This applies 00061 to the prod-2 cluster.",
+		"the gate's own title leads the detail",
+	);
+
+	// An untitled ask keeps "Question" as the leading word, named or not.
+	notifier.observe(
+		SESSION,
+		gateFrame({ session_name: "Quarterly revenue model" }),
+	);
+	assert.equal(globalThis.__toasts.at(-1).title, "Quarterly revenue model");
+	assert.equal(
+		globalThis.__toasts.at(-1).body,
+		"Question: Which environment should this deploy to?",
+	);
+});
+
+// T-U15b — D3, the other direction of skew. The field is additive and optional:
+// absent on an older backend, empty when the backend's privacy flag is off.
+// Both must render exactly as they did before this PR, and neither may make the
+// app resolve the name itself — that would leak a name the user opted out of.
+test("a gate with no session_name renders unchanged", () => {
+	for (const nameless of [
+		{},
+		{ session_name: null },
+		{ session_name: "" },
+		{ session_name: "   " },
+	]) {
+		globalThis.__toasts = [];
+		const { notifier } = harness();
+		notifier.observe(
+			SESSION,
+			gateFrame({ kind: "approval", title: "Run database migration", ...nameless }),
+		);
+		assert.equal(
+			globalThis.__toasts.at(-1).title,
+			"Run database migration",
+			JSON.stringify(nameless),
+		);
+		assert.equal(
+			globalThis.__toasts.at(-1).body,
+			"Which environment should this deploy to?",
+		);
+	}
+});
+
+// T-U16 — D6. An empty detail used to render a banner with a title and no body.
+test("a gate with an empty detail still renders a body", () => {
+	const { notifier } = harness();
+
+	notifier.observe(SESSION, gateFrame({ detail: "" }));
+	assert.equal(globalThis.__toasts.at(-1).title, "Question");
+	assert.equal(globalThis.__toasts.at(-1).body, "Question");
+
+	// A titled gate with no detail puts the title where the body is, so the
+	// banner says what it is asking about rather than only its category.
+	notifier.observe(
+		SESSION,
+		gateFrame({ kind: "approval", title: "Run database migration", detail: "  " }),
+	);
+	assert.equal(globalThis.__toasts.at(-1).title, "Approval needed");
+	assert.equal(globalThis.__toasts.at(-1).body, "Run database migration");
+
+	// Named, with nothing else: the session leads and the category is the body.
+	notifier.observe(
+		SESSION,
+		gateFrame({ detail: "", session_name: "Nightly ETL backfill" }),
+	);
+	assert.equal(globalThis.__toasts.at(-1).title, "Nightly ETL backfill");
+	assert.equal(globalThis.__toasts.at(-1).body, "Question");
 });
 
 // T-U9
@@ -392,7 +742,7 @@ test("the notification path never emits sessions.seen", async () => {
 		completionFrame({ kind: "error", dedupe_key: "e1" }),
 	);
 	notifier.observe(SESSION, eventFrame("agent_end"));
-	await new Promise((resolve) => setImmediate(resolve));
+	await settle(50);
 
 	// Notifying is not reading. A delivery claim that advanced the read
 	// watermark would clear the sidebar's unseen mark for a session the user
@@ -401,7 +751,12 @@ test("the notification path never emits sessions.seen", async () => {
 	assert.ok(requests.length > 0, "the path did emit something");
 	for (const request of requests) {
 		assert.notEqual(request.op, "sessions.seen");
-		assert.equal(request.op, "sessions.notified");
+		// `capabilities` is the gate read the legacy path waits on, not a
+		// notification; everything else on this path is the delivery claim.
+		assert.ok(
+			request.op === "sessions.notified" || request.op === "capabilities",
+			`unexpected op on the notification path: ${request.op}`,
+		);
 	}
 });
 
@@ -428,6 +783,12 @@ test("refreshNotificationContract reads the capability and survives failure", as
 		);
 		await notifier.refreshNotificationContract();
 		notifier.observe(SESSION, eventFrame("agent_end"));
+		// The legacy toast waits on an ANSWERED contract read. A 200 answers
+		// immediately; a 503 or a throw never answered, so the toast re-probes
+		// (3 attempts, 250 ms apart) before falling back. Wait past that budget:
+		// the fallback is what keeps a transient HTTP failure from losing a
+		// completion, and the point of this test is that it still happens.
+		await settle(1200);
 		// `expected` is the legacy-toast count: 0 once the backend claims the
 		// contract, 1 in every degraded case, because silence loses completions.
 		assert.equal(

--- a/scripts/notification-evidence.mjs
+++ b/scripts/notification-evidence.mjs
@@ -103,6 +103,17 @@ const SPACING_MS = 9000;
  * as title, CONTEXTS value as status, last assistant line as body for
  * `complete` only) so the captured banner is representative of production and
  * not of prose invented here.
+ *
+ * THE HOUSE BODIES ARE COPIED FROM THE BACKEND, VERBATIM. They are
+ * `local_operator/tui/notify.py`'s `BODY_*` constants — `BODY_COMPLETE`
+ * ("Task complete"), `BODY_ERROR` ("Stopped with an error"),
+ * `BODY_INTERRUPTED` ("Stopped before finishing") — reached through `BODIES`
+ * in `local_operator/notifications/compose.py`. This file is what a reviewer,
+ * a QA round and the next designer judge the shipped copy from, so prose
+ * invented here produces a review of copy that does not exist: an earlier
+ * revision rendered "Task complete." and "The turn ended with an error.",
+ * neither of which any user can receive. If these strings ever drift from the
+ * constants above, the banner is lying about production.
  */
 const FRAMES = [
 	{
@@ -131,7 +142,8 @@ const FRAMES = [
 			// generic title.
 			title: "Local Operator",
 			status: "Complete",
-			body: "Task complete.",
+			// notify.py BODY_COMPLETE. No trailing period: the constant has none.
+			body: "Task complete",
 			body_is_snippet: false,
 			title_is_session_name: false,
 			dedupe_key: "complete:123456abcdef:22222222-2222-4222-8222-222222222222",
@@ -149,7 +161,8 @@ const FRAMES = [
 			status: "Needs attention",
 			// No snippet on an error: the last assistant line predates the failure
 			// and would assert success under a "Needs attention" status.
-			body: "The turn ended with an error.",
+			// notify.py BODY_ERROR, verbatim.
+			body: "Stopped with an error",
 			body_is_snippet: false,
 			title_is_session_name: true,
 			dedupe_key: "complete:123456abcdef:33333333-3333-4333-8333-333333333333",
@@ -160,11 +173,20 @@ const FRAMES = [
 	},
 ];
 
-/** The two gate banners, which travel as `pending_gate`, not as a frame. */
+/**
+ * The gate banners, which travel as `pending_gate`, not as a frame.
+ *
+ * `session_name` is ADDITIVE and OPTIONAL on this payload: absent on a backend
+ * older than the notification contract, and empty when the backend's
+ * `session_names_in_notifications()` privacy flag is off. Both nameless cases
+ * are rendered here beside the named one, because a gate is the banner a user
+ * is BLOCKED on and all three shapes ship.
+ */
 const GATES = [
 	{
 		label: "gate-ask-untitled",
 		// The fixed bug: an untitled question used to announce "Approval needed".
+		// Nameless, so the shape is unchanged from before this PR.
 		gate: {
 			request_id: "gate-ask-1",
 			kind: "ask",
@@ -183,6 +205,51 @@ const GATES = [
 			kind: "approval",
 			title: "Run database migration",
 			detail: "This applies 00061_add_watchlist_release to the prod-2 cluster.",
+			options: [],
+			secret: false,
+			question_index: 0,
+			question_total: 1,
+		},
+	},
+	{
+		label: "gate-approval-named",
+		// With the name present the gate takes the completion banner's shape, so
+		// the banner holding a run hostage can be triaged without clicking it.
+		gate: {
+			request_id: "gate-approval-2",
+			kind: "approval",
+			title: "Run database migration",
+			detail: "This applies 00061_add_watchlist_release to the prod-2 cluster.",
+			options: [],
+			secret: false,
+			question_index: 0,
+			question_total: 1,
+			session_name: "Nightly ETL backfill",
+		},
+	},
+	{
+		label: "gate-ask-named",
+		gate: {
+			request_id: "gate-ask-2",
+			kind: "ask",
+			title: "",
+			detail: "Which environment should this deploy to?",
+			options: [],
+			secret: false,
+			question_index: 0,
+			question_total: 1,
+			session_name: "Quarterly revenue model",
+		},
+	},
+	{
+		label: "gate-ask-empty-detail",
+		// `PendingGateState.detail` defaults to "" and is untrimmed on the wire,
+		// which used to render a banner with a title and no body at all.
+		gate: {
+			request_id: "gate-ask-3",
+			kind: "ask",
+			title: "",
+			detail: "",
 			options: [],
 			secret: false,
 			question_index: 0,
@@ -227,11 +294,24 @@ async function main() {
 	// without the notifier under test knowing it is being observed. Installed
 	// BEFORE the bundle is imported: the bundle binds `Notification` at module
 	// evaluation, so a later reassignment would never be seen.
+	/**
+	 * Every set of constructor arguments that actually reached the OS.
+	 *
+	 * The log below is printed FROM THIS, never from the payload. An earlier
+	 * revision re-derived the expected title and body in the print loop, which
+	 * made the artifact incapable of showing a rendering change: it reported
+	 * `status — body` for every banner while the notifier had already stopped
+	 * joining them. An evidence script that composes its own copy is the D1
+	 * defect in a second place, so the only strings this file prints are the
+	 * ones the notifier passed to `new Notification()`.
+	 */
+	const constructed = [];
 	globalThis.__realElectron = {
 		Notification: new Proxy(Notification, {
 			construct(target, args) {
 				const instance = new target(...args);
 				const title = args[0]?.title;
+				constructed.push({ title, body: args[0]?.body });
 				instance.on("show", () =>
 					osEvents.push({ title, event: "show", at: Date.now() }),
 				);
@@ -289,15 +369,27 @@ async function main() {
 		},
 	);
 
-	for (const { label, payload } of FRAMES) {
+	/**
+	 * Report what the notifier really constructed for the frame just fed to it.
+	 *
+	 * Reads the tail of `constructed` rather than re-deriving the strings, so a
+	 * suppressed banner prints as `(no notification raised)` instead of copy
+	 * that was never sent.
+	 */
+	const report = (label) => {
+		const toast = constructed.at(-1);
 		console.log(`\n[${label}]`);
-		console.log(`  title : ${payload.title}`);
-		console.log(`  body  : ${payload.status} — ${payload.body}`);
-		sent.push({
-			label,
-			title: payload.title,
-			body: `${payload.status} — ${payload.body}`,
-		});
+		if (!toast || sent.some((s) => s.toast === toast)) {
+			console.log("  (no notification raised)");
+			sent.push({ label, raised: false });
+			return;
+		}
+		console.log(`  title : ${toast.title}`);
+		console.log(`  body  : ${toast.body}`);
+		sent.push({ label, raised: true, ...toast, toast });
+	};
+
+	for (const { label, payload } of FRAMES) {
 		notifier.observe("123456abcdef", {
 			session_id: "123456abcdef",
 			epoch: "abc123",
@@ -305,16 +397,14 @@ async function main() {
 			type: "notification",
 			payload,
 		});
+		// The composed path claims delivery over HTTP before it shows anything,
+		// so the toast does not exist yet on the turn of this loop.
+		await new Promise((resolve) => setTimeout(resolve, 250));
+		report(label);
 		await new Promise((resolve) => setTimeout(resolve, SPACING_MS));
 	}
 
 	for (const { label, gate } of GATES) {
-		const expected =
-			gate.title || (gate.kind === "ask" ? "Question" : "Approval needed");
-		console.log(`\n[${label}]`);
-		console.log(`  title : ${expected}`);
-		console.log(`  body  : ${gate.detail}`);
-		sent.push({ label, title: expected, body: gate.detail });
 		notifier.observe("123456abcdef", {
 			session_id: "123456abcdef",
 			epoch: "abc123",
@@ -326,12 +416,13 @@ async function main() {
 				changes: { pending_gate: gate },
 			},
 		});
+		report(label);
 		await new Promise((resolve) => setTimeout(resolve, SPACING_MS));
 	}
 
 	writeFileSync(
 		join(OUTDIR, "payloads.json"),
-		`${JSON.stringify({ sent, claims, osEvents }, null, 2)}\n`,
+		`${JSON.stringify({ sent: sent.map(({ toast: _t, ...rest }) => rest), claims, osEvents }, null, 2)}\n`,
 	);
 	console.log(`\nclaims posted: ${claims.length} (one per completion frame)`);
 	console.log(

--- a/scripts/notification-evidence.mjs
+++ b/scripts/notification-evidence.mjs
@@ -171,6 +171,35 @@ const FRAMES = [
 			focus_policy: "when_unfocused",
 		},
 	},
+	{
+		label: "error-with-failure-summary",
+		payload: {
+			contract: 1,
+			kind: "error",
+			title: "Nightly ETL backfill",
+			status: "Needs attention",
+			// The DEFAULT error shape, not an exotic one: the privacy flag that
+			// yields a session name is the same one that yields this text, so a
+			// classified failure renders here rather than the house sentence
+			// above. Copied from a real provider envelope as the backend's
+			// `_compose_body` returns it (`session_incident.raw`, bounded to
+			// BACKGROUND_SNIPPET_MAX_CHARS) — never the last assistant line,
+			// which predates the failure.
+			//
+			// This fixture exists because its absence is how Q-1 survived two
+			// review and two design rounds: every frame anyone rendered happened
+			// to take the status-bearing path, so the one banner that loses its
+			// status was the one nobody ever looked at.
+			body: "anthropic: 429 rate_limit_error - your credit balance is too low to access the Claude API",
+			body_is_snippet: false,
+			body_is_failure: true,
+			title_is_session_name: true,
+			dedupe_key: "complete:123456abcdef:44444444-4444-4444-8444-444444444444",
+			completion_token: "44444444-4444-4444-8444-444444444444",
+			session_name: "Nightly ETL backfill",
+			focus_policy: "when_unfocused",
+		},
+	},
 ];
 
 /**

--- a/scripts/notification-evidence.mjs
+++ b/scripts/notification-evidence.mjs
@@ -242,6 +242,61 @@ const GATES = [
 		},
 	},
 	{
+		label: "gate-approval-tool-named",
+		// THE SHAPE THE TOOLS ACTUALLY EMIT, which the hand-written fixtures above
+		// do not: `build_write_tool` has `name="write"` and
+		// `_approval_description` returns `f"{action}: {target}"`, so the title IS
+		// the tool name and the detail already leads with it. The naive
+		// `${title}: ${detail}` join rendered this as
+		// "write: write: /Users/damian/notes.md" and every hand-written fixture
+		// here chose a non-overlapping pair that hid it (design round 2, D3-1).
+		// A fixture that mirrors the real emitter is what stops the next one.
+		gate: {
+			request_id: "gate-approval-3",
+			kind: "approval",
+			title: "write",
+			detail: "write: /Users/damian/notes.md",
+			options: [],
+			secret: false,
+			question_index: 0,
+			question_total: 1,
+			session_name: "Nightly ETL backfill",
+		},
+	},
+	{
+		label: "gate-approval-tool-nameless",
+		// The same approval with the privacy flag off. The named banner above must
+		// not be WORSE than this one, which was the finding's whole point.
+		gate: {
+			request_id: "gate-approval-4",
+			kind: "approval",
+			title: "write",
+			detail: "write: /Users/damian/notes.md",
+			options: [],
+			secret: false,
+			question_index: 0,
+			question_total: 1,
+		},
+	},
+	{
+		label: "gate-approval-empty-detail",
+		// Reachable without a malformed payload: `_describe_path_approval` returns
+		// "" for a blank path argument. Used to render the bare verb `write` as
+		// the entire body; the backend refuses that in favour of the house
+		// vocabulary (D3-2).
+		gate: {
+			request_id: "gate-approval-5",
+			kind: "approval",
+			title: "write",
+			detail: "",
+			options: [],
+			secret: false,
+			question_index: 0,
+			question_total: 1,
+			session_name: "Nightly ETL backfill",
+		},
+	},
+	{
 		label: "gate-ask-empty-detail",
 		// `PendingGateState.detail` defaults to "" and is untrimmed on the wire,
 		// which used to render a banner with a title and no body at all.

--- a/scripts/notification-evidence.mjs
+++ b/scripts/notification-evidence.mjs
@@ -1,0 +1,345 @@
+/**
+ * Render real macOS/Windows/Linux notification banners from the SHIPPED
+ * notifier, so a reviewer sees the actual OS surface rather than a mock.
+ *
+ * Usage (Electron will not take a bare script as an entry point, so the script
+ * stages itself into a throwaway app directory and re-execs into it):
+ *
+ *     node scripts/notification-evidence.mjs [outdir]      # default /tmp/notification-evidence
+ *
+ * It always runs against an ISOLATED `--user-data-dir`. Sharing the default
+ * profile with a Local Operator instance the operator already has open makes
+ * `app.whenReady()` block indefinitely behind the running app's singleton lock,
+ * and would put this run's state into their real profile.
+ *
+ * Why this exists. `scripts/desktop-notifier.test.mjs` proves the right STRINGS
+ * reach the `Notification` boundary, with a fake constructor. It cannot prove
+ * how the OS lays them out, and the one genuinely undecided rendering question
+ * in this change — whether the state category reads well leading the body, or
+ * belongs in the macOS-only `subtitle` — is answerable only by looking at a
+ * rendered frame (docs/design/descriptive-notifications.md 8.3, 11.2).
+ *
+ * So this boots a REAL Electron main process, constructs the real
+ * `DesktopNotifier` from the built bundle, feeds it the exact `notification`
+ * frames the backend composes, and lets the real `new Notification()` reach
+ * the OS. A tiny loopback server stands in for the backend's
+ * `POST /notified`, answering `{claimed: true}`, because the notifier fails
+ * closed and would otherwise show nothing at all — which is itself the point:
+ * a banner appearing here is proof the claim path ran.
+ *
+ * It opens NO window on purpose. A visible focused window is exactly the state
+ * the `when_unfocused` gate suppresses, so a headless main process is not a
+ * shortcut here, it is the condition under test.
+ *
+ * Capturing the banner is the operator's job (`screencapture -x out.png` while
+ * it is on screen, or a Notification Center shot) because macOS exposes no API
+ * to screenshot its own banner. This script paces the toasts and prints what it
+ * sent, so the capture can be matched to the payload with no guesswork.
+ *
+ * It also records each notification's `show` and `failed` events. That is the
+ * OS ACCEPTING the notification, one layer below the pixels: if the banner does
+ * not appear despite a `show`, the cause is a delivery policy (an undecided
+ * permission prompt, Do Not Disturb, an unsigned bundle macOS declines to
+ * register) rather than anything in this change. Recording it keeps the
+ * distinction visible instead of leaving a blank screenshot to interpret.
+ *
+ * NOTE on bundles: run this from a PACKAGED app. macOS refuses to register
+ * notifications for a bare `electron` dev binary, so `new Notification()`
+ * succeeds and nothing is ever displayed. `pnpm exec electron-builder --dir`
+ * then point the app's `Resources/app` at this file.
+ */
+
+import { spawnSync } from "node:child_process";
+import { mkdirSync, writeFileSync } from "node:fs";
+import { createServer } from "node:http";
+import { dirname, join } from "node:path";
+import { fileURLToPath, pathToFileURL } from "node:url";
+
+const HERE = dirname(fileURLToPath(import.meta.url));
+const REPO = dirname(HERE);
+const OUT = process.argv[2] || "/tmp/notification-evidence";
+
+/**
+ * Under plain node, stage an Electron app directory around this file and
+ * re-exec into it. Electron treats a bare script path as an app to LOAD, which
+ * silently boots the whole product instead of this harness; only a directory
+ * with a `package.json` naming `main` runs the file we mean.
+ */
+if (!process.versions.electron) {
+	const stage = join(OUT, "app");
+	mkdirSync(stage, { recursive: true });
+	writeFileSync(
+		join(stage, "package.json"),
+		`${JSON.stringify({ name: "notification-evidence", version: "0.0.0", main: "main.mjs", type: "module" }, null, 2)}\n`,
+	);
+	// Re-export rather than copy: one source of truth for the payloads, and the
+	// staged directory stays a two-line shim a reviewer can read at a glance.
+	writeFileSync(
+		join(stage, "main.mjs"),
+		`import ${JSON.stringify(pathToFileURL(fileURLToPath(import.meta.url)).href)};\n`,
+	);
+	const electron = join(
+		REPO,
+		"node_modules/electron/dist/Electron.app/Contents/MacOS/Electron",
+	);
+	const result = spawnSync(
+		electron,
+		[stage, `--user-data-dir=${join(OUT, "userdata")}`],
+		{ stdio: "inherit", env: { ...process.env, NOTIFY_EVIDENCE_OUT: OUT } },
+	);
+	process.exit(result.status ?? 1);
+}
+
+const { app, Notification } = await import("electron");
+const OUTDIR = process.env.NOTIFY_EVIDENCE_OUT || OUT;
+
+/** Seconds a banner stays legible before the next one replaces it. */
+const SPACING_MS = 9000;
+
+/**
+ * The frames under test, one per kind the user can actually receive.
+ *
+ * Strings are written the way the BACKEND composer renders them (session name
+ * as title, CONTEXTS value as status, last assistant line as body for
+ * `complete` only) so the captured banner is representative of production and
+ * not of prose invented here.
+ */
+const FRAMES = [
+	{
+		label: "complete-with-snippet",
+		payload: {
+			contract: 1,
+			kind: "complete",
+			title: "Quarterly revenue model",
+			status: "Complete",
+			body: "Rebuilt the forecast with the Q3 actuals and reconciled the 4.2% variance against the ledger.",
+			body_is_snippet: true,
+			title_is_session_name: true,
+			dedupe_key: "complete:123456abcdef:11111111-1111-4111-8111-111111111111",
+			completion_token: "11111111-1111-4111-8111-111111111111",
+			session_name: "Quarterly revenue model",
+			focus_policy: "when_unfocused",
+		},
+	},
+	{
+		label: "complete-privacy-flag-off",
+		payload: {
+			contract: 1,
+			kind: "complete",
+			// The privacy flag off means no session name AND no snippet: one flag
+			// gates both, so a banner can never leak conversation content under a
+			// generic title.
+			title: "Local Operator",
+			status: "Complete",
+			body: "Task complete.",
+			body_is_snippet: false,
+			title_is_session_name: false,
+			dedupe_key: "complete:123456abcdef:22222222-2222-4222-8222-222222222222",
+			completion_token: "22222222-2222-4222-8222-222222222222",
+			session_name: null,
+			focus_policy: "when_unfocused",
+		},
+	},
+	{
+		label: "error",
+		payload: {
+			contract: 1,
+			kind: "error",
+			title: "Nightly ETL backfill",
+			status: "Needs attention",
+			// No snippet on an error: the last assistant line predates the failure
+			// and would assert success under a "Needs attention" status.
+			body: "The turn ended with an error.",
+			body_is_snippet: false,
+			title_is_session_name: true,
+			dedupe_key: "complete:123456abcdef:33333333-3333-4333-8333-333333333333",
+			completion_token: "33333333-3333-4333-8333-333333333333",
+			session_name: "Nightly ETL backfill",
+			focus_policy: "when_unfocused",
+		},
+	},
+];
+
+/** The two gate banners, which travel as `pending_gate`, not as a frame. */
+const GATES = [
+	{
+		label: "gate-ask-untitled",
+		// The fixed bug: an untitled question used to announce "Approval needed".
+		gate: {
+			request_id: "gate-ask-1",
+			kind: "ask",
+			title: "",
+			detail: "Which environment should this deploy to?",
+			options: [],
+			secret: false,
+			question_index: 0,
+			question_total: 1,
+		},
+	},
+	{
+		label: "gate-approval",
+		gate: {
+			request_id: "gate-approval-1",
+			kind: "approval",
+			title: "Run database migration",
+			detail: "This applies 00061_add_watchlist_release to the prod-2 cluster.",
+			options: [],
+			secret: false,
+			question_index: 0,
+			question_total: 1,
+		},
+	},
+];
+
+async function main() {
+	mkdirSync(OUTDIR, { recursive: true });
+	if (!Notification.isSupported()) {
+		console.error(
+			"This platform reports no notification support; nothing to capture.",
+		);
+		app.exit(1);
+		return;
+	}
+
+	// Stand in for the backend's claim route. Recording every request is what
+	// makes the run auditable: the log below is proof the claim ran BEFORE each
+	// banner, in the order the design pins.
+	const claims = [];
+	const server = createServer((req, res) => {
+		claims.push({ at: Date.now(), path: req.url, method: req.method });
+		res.setHeader("Content-Type", "application/json");
+		res.end(JSON.stringify({ result: { claimed: true } }));
+	});
+	await new Promise((resolve) => server.listen(0, "127.0.0.1", resolve));
+
+	// Bundle the SHIPPED source and hand it the REAL `Notification` class off a
+	// global. Not a mock: this is Electron's own constructor, reaching the real
+	// OS notification centre. The indirection exists only because the bundle is
+	// imported from a `data:` URL, which cannot resolve the bare `electron`
+	// specifier; the fake-constructor version of this proof already lives in
+	// scripts/desktop-notifier.test.mjs and is a different claim entirely.
+	/**
+	 * OS-level acceptance per toast. `show` means the notification centre took
+	 * it; `failed` means the platform refused it and names why.
+	 */
+	const osEvents = [];
+	// Wrap the real class so every instance reports what the OS did with it,
+	// without the notifier under test knowing it is being observed. Installed
+	// BEFORE the bundle is imported: the bundle binds `Notification` at module
+	// evaluation, so a later reassignment would never be seen.
+	globalThis.__realElectron = {
+		Notification: new Proxy(Notification, {
+			construct(target, args) {
+				const instance = new target(...args);
+				const title = args[0]?.title;
+				instance.on("show", () =>
+					osEvents.push({ title, event: "show", at: Date.now() }),
+				);
+				instance.on("failed", (_event, error) =>
+					osEvents.push({ title, event: "failed", error: String(error) }),
+				);
+				return instance;
+			},
+		}),
+	};
+	const { build } = await import("esbuild");
+	const bundle = await build({
+		stdin: {
+			contents: 'export * from "./src/main/desktop-notifier";',
+			resolveDir: REPO,
+		},
+		bundle: true,
+		format: "esm",
+		platform: "node",
+		write: false,
+		plugins: [
+			{
+				name: "real-electron",
+				setup(builder) {
+					builder.onResolve({ filter: /^electron$/ }, () => ({
+						path: "electron",
+						namespace: "real",
+					}));
+					builder.onLoad({ filter: /.*/, namespace: "real" }, () => ({
+						contents:
+							"export const Notification = globalThis.__realElectron.Notification;",
+						loader: "js",
+					}));
+				},
+			},
+		],
+	});
+	const { DesktopNotifier } = await import(
+		`data:text/javascript;base64,${Buffer.from(bundle.outputFiles[0].text).toString("base64")}`
+	);
+
+	const sent = [];
+	const notifier = new DesktopNotifier(
+		() => null,
+		async (input) => {
+			const response = await fetch(
+				`http://127.0.0.1:${server.address().port}/v1/desktop/sessions/${input.sessionId}/notified`,
+				{
+					method: "POST",
+					headers: { "Content-Type": "application/json" },
+					body: JSON.stringify({ completion_token: input.completionToken }),
+				},
+			);
+			return { status: response.status, body: await response.json() };
+		},
+	);
+
+	for (const { label, payload } of FRAMES) {
+		console.log(`\n[${label}]`);
+		console.log(`  title : ${payload.title}`);
+		console.log(`  body  : ${payload.status} — ${payload.body}`);
+		sent.push({
+			label,
+			title: payload.title,
+			body: `${payload.status} — ${payload.body}`,
+		});
+		notifier.observe("123456abcdef", {
+			session_id: "123456abcdef",
+			epoch: "abc123",
+			seq: 1,
+			type: "notification",
+			payload,
+		});
+		await new Promise((resolve) => setTimeout(resolve, SPACING_MS));
+	}
+
+	for (const { label, gate } of GATES) {
+		const expected =
+			gate.title || (gate.kind === "ask" ? "Question" : "Approval needed");
+		console.log(`\n[${label}]`);
+		console.log(`  title : ${expected}`);
+		console.log(`  body  : ${gate.detail}`);
+		sent.push({ label, title: expected, body: gate.detail });
+		notifier.observe("123456abcdef", {
+			session_id: "123456abcdef",
+			epoch: "abc123",
+			seq: 2,
+			type: "frontend.update",
+			payload: {
+				epoch: "abc123",
+				sequence: 2,
+				changes: { pending_gate: gate },
+			},
+		});
+		await new Promise((resolve) => setTimeout(resolve, SPACING_MS));
+	}
+
+	writeFileSync(
+		join(OUTDIR, "payloads.json"),
+		`${JSON.stringify({ sent, claims, osEvents }, null, 2)}\n`,
+	);
+	console.log(`\nclaims posted: ${claims.length} (one per completion frame)`);
+	console.log(
+		`OS accepted : ${osEvents.filter((e) => e.event === "show").length} shown, ${osEvents.filter((e) => e.event === "failed").length} failed`,
+	);
+	console.log(`payload log: ${join(OUTDIR, "payloads.json")}`);
+	server.close();
+	app.exit(0);
+}
+
+app.whenReady().then(main);

--- a/src/main/backend/backend-service.ts
+++ b/src/main/backend/backend-service.ts
@@ -75,6 +75,36 @@ export class BackendServiceManager {
 	private streamObserver: ((sessionId: string, data: string) => void) | null =
 		null;
 
+	/**
+	 * Called every time the backend becomes reachable and authenticated.
+	 *
+	 * The desktop token is minted inside `start()`, so anything that must query
+	 * the backend cannot be issued from `app.whenReady()` — at that point the
+	 * port is dead on the ordinary self-managed cold start and the request is
+	 * lost. This fires after the health check passes, which is the first moment
+	 * `requestDesktop` can succeed.
+	 *
+	 * It fires AGAIN on every restart and on external-backend discovery, on
+	 * purpose: the backend underneath a running app can be replaced by a
+	 * different version, and a capability read taken once at startup would
+	 * outlive the backend it described.
+	 */
+	private backendReadyObserver: (() => void) | null = null;
+
+	onBackendReady(observer: (() => void) | null): void {
+		this.backendReadyObserver = observer;
+	}
+
+	private notifyBackendReady(): void {
+		try {
+			this.backendReadyObserver?.();
+		} catch (error) {
+			// A consumer's failure must never take down backend startup: the
+			// backend is up either way, and this is a notification, not a step.
+			logger.error("Backend-ready observer threw:", LogFileType.BACKEND, error);
+		}
+	}
+
 	getStreamRelay(): DesktopStreamRelay {
 		if (!this.streamRelay || this.streamRelayUrl !== this.backendUrl) {
 			this.streamRelay?.dispose();
@@ -499,6 +529,7 @@ export class BackendServiceManager {
 					LogFileType.BACKEND,
 				);
 				this.isExternalBackend = true;
+				this.notifyBackendReady();
 				return true;
 			}
 		} catch (error) {
@@ -535,6 +566,9 @@ export class BackendServiceManager {
 							LogFileType.BACKEND,
 						);
 						this.isExternalBackend = true;
+						// Fired AFTER the URL rotates, so a consumer re-reading
+						// capabilities queries the address the app actually uses.
+						this.notifyBackendReady();
 						return true;
 					}
 				}
@@ -573,6 +607,7 @@ export class BackendServiceManager {
 				"Backend Service Manager is disabled. Skipping backend start.",
 				LogFileType.BACKEND,
 			);
+			this.notifyBackendReady();
 			return true;
 		}
 
@@ -581,6 +616,7 @@ export class BackendServiceManager {
 			this.isRunning = true;
 			this.startupMode = LocalOperatorStartupMode.EXISTING_SERVER;
 			this.startHealthCheck();
+			this.notifyBackendReady();
 			return true;
 		}
 
@@ -754,6 +790,7 @@ export class BackendServiceManager {
 				if (await this.checkHealth()) {
 					this.isRunning = true;
 					this.startHealthCheck();
+					this.notifyBackendReady();
 					return true;
 				}
 

--- a/src/main/backend/backend-service.ts
+++ b/src/main/backend/backend-service.ts
@@ -616,7 +616,16 @@ export class BackendServiceManager {
 			this.isRunning = true;
 			this.startupMode = LocalOperatorStartupMode.EXISTING_SERVER;
 			this.startHealthCheck();
-			this.notifyBackendReady();
+			// NO `notifyBackendReady()` here. `checkExistingBackend()` already
+			// fired it on both paths that can return true from HERE — its
+			// `isDisabled` early return is unreachable at this point, because the
+			// disabled branch above returns first — and it fires it AFTER the
+			// alternative-URL rotation, which is the ordering a consumer re-reading
+			// capabilities needs. Firing again raised two concurrent capability
+			// probes on the ordinary external-backend start, doubling that traffic
+			// and letting the OLDER read decide the result by settling last
+			// (review round 2, R2-2). The notifier is also generation-guarded now,
+			// so a duplicate is no longer incorrect — it is merely wasted.
 			return true;
 		}
 

--- a/src/main/desktop-ipc.ts
+++ b/src/main/desktop-ipc.ts
@@ -19,8 +19,15 @@ const OPERATION_ID = /^[a-zA-Z0-9_-]{1,128}$/;
  * because `DesktopNotifier` holds its own reference to the same underlying
  * sender and calls it directly. Guarding only the IPC entry would leave that
  * path unguarded — harmless while the notifier emits nothing but
- * `sessions.watch`, but it is exactly how a future main-process caller would
- * acquire an ungated `sessions.seen`.
+ * `sessions.watch` and `sessions.notified`, but it is exactly how a future
+ * main-process caller would acquire an ungated `sessions.seen`.
+ *
+ * The guard is deliberately scoped to `sessions.seen` alone. `sessions.notified`
+ * must NOT be gated on it: it claims cross-surface DELIVERY of a notification,
+ * which by definition fires when the window is not in the foreground, so a
+ * foreground requirement there would refuse every legitimate claim. The two
+ * watermarks are separate on purpose — a delivery claim never marks anything
+ * read (docs/design/descriptive-notifications.md 7.2).
  *
  * The renderer's own visibility test cannot establish this: an occluded,
  * hidden or minimized window still reports `visibilityState === "visible"` and

--- a/src/main/desktop-notifier.ts
+++ b/src/main/desktop-notifier.ts
@@ -486,7 +486,17 @@ export class DesktopNotifier {
 				return;
 			}
 		}
-		this.show(sessionId, n.title, n.status, n.body, n.body_is_snippet);
+		// `body_is_failure` is additive and optional on the wire (see the type):
+		// absent from a backend that predates the flag, which falls through to the
+		// bare body it rendered before the flag existed rather than throwing.
+		this.show(
+			sessionId,
+			n.title,
+			n.status,
+			n.body,
+			n.body_is_snippet,
+			n.body_is_failure ?? false,
+		);
 	}
 
 	/**
@@ -643,15 +653,28 @@ export class DesktopNotifier {
 	 * which macOS truncates the BODY with its own ellipsis. That is why the join
 	 * is spent sparingly below.
 	 *
-	 * `isSnippet` decides whether the status earns its place. A model-written
-	 * snippet does not say the outcome, so the category in front of it is the
-	 * only thing that does. The house bodies ("Task complete", "Stopped with an
-	 * error") already name the state, so prefixing them renders "Complete — Task
-	 * complete": one fact asserted twice in the two lines a banner gets, which is
-	 * what every user with the session-name privacy flag off would have received.
-	 * `body_is_snippet` is the backend's own flag for exactly this difference, so
-	 * this app still re-words nothing (design 8.4). Gates pass `status = ""` and
-	 * are unaffected either way.
+	 * WHETHER THE BODY NAMES THE OUTCOME ITSELF decides whether the status earns
+	 * its place, and the backend sends two flags for the two kinds of body that
+	 * do not. A model-written snippet describes the work, and the session's own
+	 * recorded failure text describes the cause ("anthropic: 429
+	 * rate_limit_error - credit balance too low"); neither says whether the turn
+	 * succeeded, so the category in front of it is the only thing that does. The
+	 * house bodies ("Task complete", "Stopped with an error") already name the
+	 * state, so prefixing them renders "Complete — Task complete": one fact
+	 * asserted twice in the two lines a banner gets, which is what every user
+	 * with the session-name privacy flag off would have received.
+	 *
+	 * Reading only `body_is_snippet` split the world in two where the backend
+	 * made it three, and it inverted the intent of the failure text (design
+	 * round 1, D4): a raw 429 envelope under a session name reads as routine log
+	 * noise, so the ONE banner that demands action was the one that never said
+	 * anything had gone wrong — and it was worse with the privacy flag ON (the
+	 * default, which is what produces the failure text) than off, where the user
+	 * at least got "Stopped with an error" (QA round 1, Q-1).
+	 *
+	 * These are the backend's own flags for exactly this difference, so this app
+	 * still re-words nothing (design 8.4). Gates pass `status = ""` and are
+	 * unaffected either way.
 	 */
 	private show(
 		sessionId: string,
@@ -659,8 +682,9 @@ export class DesktopNotifier {
 		status: string,
 		body: string,
 		isSnippet = false,
+		isFailure = false,
 	): void {
-		const lead = isSnippet && status ? `${status} — ` : "";
+		const lead = (isSnippet || isFailure) && status ? `${status} — ` : "";
 		const notification = new Notification({
 			title,
 			body: `${lead}${body}`.slice(0, MAX_BODY_CHARS),

--- a/src/main/desktop-notifier.ts
+++ b/src/main/desktop-notifier.ts
@@ -14,6 +14,14 @@
  * (gates) and by the backend-minted `dedupe_key` (composed notifications)
  * across every window, so two windows on one session yield one toast.
  *
+ * Which path raises a completion is decided by ONE fact, read from the
+ * backend: `features.notification_contract`. The legacy `agent_end` toast is
+ * deferred until that read settles rather than racing it, because `agent_end`
+ * arrives before the composed frame and a guess of "no contract" while the
+ * answer is still in flight is exactly the two-banners-per-turn defect. The
+ * read is re-issued every time the backend becomes reachable, which is also
+ * how a downgrade to an older backend gets its legacy signal back.
+ *
  * Completion content is COMPOSED BY THE BACKEND and rendered here verbatim.
  * Only the backend can read the `display.notification_session_name` privacy
  * flag, only it can apply the snippet-iff-complete rule (a failed turn's last
@@ -52,6 +60,19 @@ const NOTIFY_TTL_MS = 10 * 60 * 1000;
 const MAX_DEDUPE_KEYS = 2048;
 
 /**
+ * Bounded retry for the capability read.
+ *
+ * The read is issued once the backend service reports itself up, so the first
+ * attempt normally answers. These retries cover the narrow window where
+ * `/health` is answering but `/v1/capabilities` transiently is not. The budget
+ * is deliberately under a second in total: while a probe is unsettled the
+ * legacy completion toast is DEFERRED, not dropped, and a user waiting on a
+ * completion banner must never wait longer than they would notice.
+ */
+const CONTRACT_PROBE_ATTEMPTS = 3;
+const CONTRACT_PROBE_RETRY_MS = 250;
+
+/**
  * Longest a composed notification's rendered body may be.
  *
  * The backend already bounds and sanitises each part; this is the belt-and-
@@ -81,19 +102,29 @@ export class DesktopNotifier {
 	 */
 	private notificationContract = 0;
 	/**
-	 * Whether a composed `notification` frame has ever arrived on this run.
+	 * The capability read in flight, or the last one that settled.
 	 *
-	 * The capability fetch and the frame stream are two different round trips,
-	 * and only the second one is proof. A backend swapped underneath a running
-	 * app (the health check restarts one, external-backend discovery finds
-	 * another) can start composing notifications while `notificationContract` is
-	 * still the stale 0 read at connect — and 0 means the legacy `agent_end`
-	 * toast fires too, which is the double banner this whole change exists to
-	 * remove. A frame in hand cannot be stale, so it latches the gate shut on
-	 * its own. One-way on purpose: a backend that has composed once owns
-	 * notifications for the rest of the run.
+	 * `null` only before the first read is ever issued.
 	 */
-	private sawComposedNotification = false;
+	private contractProbe: Promise<void> | null = null;
+	/**
+	 * Whether a capability read has ever come back with a real HTTP answer.
+	 *
+	 * This is the distinction that closes the double-banner window BY
+	 * CONSTRUCTION. A `notificationContract` of 0 has three causes that look
+	 * identical on the field alone: the backend answered and has no contract
+	 * (old backend, legacy path is correct), nobody has asked yet, and the ask
+	 * never reached a backend at all. Only the first is an answer. The other two
+	 * are the cold start the review reproduced — the read went to a port nothing
+	 * was listening on, was swallowed, and the legacy `agent_end` toast then
+	 * fired alongside the composed frame, two banners for one turn.
+	 *
+	 * So the legacy path re-asks until it has a genuine answer rather than
+	 * reading an unanswered 0 as "no contract". Failing toward the legacy path
+	 * rather than toward silence (design 4.3) is preserved: once a bounded probe
+	 * really has failed at the moment the toast is due, the toast is raised.
+	 */
+	private contractAnswered = false;
 
 	constructor(
 		private readonly window: () => BrowserWindow | null,
@@ -105,40 +136,104 @@ export class DesktopNotifier {
 	}
 
 	/**
-	 * Record what the connected backend advertises for `notification_contract`.
-	 *
-	 * Called at backend-connect and again whenever the backend URL rotates
-	 * (external-backend discovery), because the app can move from a new backend
-	 * to an old one without restarting. A non-number or a failed fetch resets to
-	 * 0 rather than keeping a stale claim: keeping `1` against a backend that
-	 * emits no frames is the one way this gate goes silent.
-	 */
-	/**
 	 * Read `features.notification_contract` from the connected backend.
 	 *
-	 * Called once the backend is reachable and BEFORE any window exists, so the
-	 * gate is settled before the first frame can arrive. A throw or a non-200
-	 * leaves the gate at 0, which is the legacy path rather than silence: see
-	 * `notificationContract`.
+	 * Call this every time the backend becomes reachable — first start, a health
+	 * check restarting it, external-backend discovery rotating the URL. It is
+	 * wired to `BackendServiceManager.onBackendReady` for exactly that reason:
+	 * issuing it earlier (inside `app.whenReady()`) queries a port nothing is
+	 * listening on yet on the ordinary self-managed cold start, and a swallowed
+	 * failure there leaves the gate on the legacy path against a backend that
+	 * composes — two banners for one turn.
+	 *
+	 * Re-reading is also the downgrade story the design names (4.3): an app
+	 * pointed from a new backend at an old one re-reads 0 and gets its legacy
+	 * completion signal back. The previous one-way latch could not do that.
+	 *
+	 * A throw or a non-200 after the bounded retry leaves the gate at 0, which
+	 * is the legacy path rather than silence: see `notificationContract`.
 	 */
-	async refreshNotificationContract(): Promise<void> {
-		try {
-			const response = await this.request({ op: "capabilities" });
-			if (response.status !== 200) return;
-			const body = response.body as {
-				result?: { features?: Record<string, unknown> };
-			} | null;
-			this.setNotificationContract(
-				body?.result?.features?.notification_contract,
-			);
-		} catch {
-			// Unfetchable is treated as absent, deliberately. A missing capability
-			// response is a transient HTTP failure far more often than it is an old
-			// backend, and going silent on a transient failure loses completions.
+	refreshNotificationContract(): Promise<void> {
+		const probe = this.probeNotificationContract();
+		this.contractProbe = probe;
+		return probe;
+	}
+
+	private async probeNotificationContract(): Promise<void> {
+		for (let attempt = 0; attempt < CONTRACT_PROBE_ATTEMPTS; attempt++) {
+			try {
+				const response = await this.request({ op: "capabilities" });
+				if (response.status === 200) {
+					const body = response.body as {
+						result?: { features?: Record<string, unknown> };
+					} | null;
+					// A 200 is an ANSWER even when the key is absent: that is an old
+					// backend, and retrying would only delay the legacy path it wants.
+					this.applyNotificationContract(
+						body?.result?.features?.notification_contract,
+					);
+					this.contractAnswered = true;
+					return;
+				}
+			} catch {
+				// Unfetchable is retried, then treated as absent. A missing capability
+				// response is a transient HTTP failure far more often than it is an
+				// old backend, and going silent on a transient failure loses
+				// completions.
+			}
+			if (attempt + 1 < CONTRACT_PROBE_ATTEMPTS) {
+				await new Promise((resolve) =>
+					setTimeout(resolve, CONTRACT_PROBE_RETRY_MS),
+				);
+			}
+		}
+		// Every attempt failed, so nothing was learned. Reset rather than keep a
+		// stale claim (holding `1` against a backend that emits no frames is the
+		// one way this gate goes silent on completions altogether) and leave
+		// `contractAnswered` alone, so the legacy path re-asks rather than reading
+		// this 0 as an old backend's answer.
+		this.applyNotificationContract(undefined);
+	}
+
+	/**
+	 * Block until a capability read has ANSWERED against the current backend,
+	 * or until a fresh bounded probe has failed here and now.
+	 *
+	 * Issuing the probe itself when none has answered is what makes the legacy
+	 * path safe by construction rather than by call-site discipline. The failure
+	 * the review reproduced is a read fired before the backend existed: it is
+	 * not enough to move that call later, because any read can lose its race
+	 * with a backend that is still starting, and a swallowed one leaves a 0 that
+	 * reads exactly like an old backend. Re-asking at the moment the answer is
+	 * actually needed cannot be beaten by a slow start.
+	 *
+	 * Loops rather than awaiting once because a backend rotation can start a
+	 * new probe while we are waiting on the old one, and the legacy path must
+	 * never be decided on the previous backend's answer.
+	 */
+	private async awaitContract(): Promise<void> {
+		if (!this.contractAnswered) this.refreshNotificationContract();
+		let awaited: Promise<void> | null = null;
+		while (this.contractProbe !== awaited) {
+			awaited = this.contractProbe;
+			await awaited;
 		}
 	}
 
+	/**
+	 * Record the contract version a backend reported.
+	 *
+	 * Being told the value directly IS an answer, so this also stops the legacy
+	 * path issuing a probe of its own and overwriting it. The probe's own
+	 * failure path uses `applyNotificationContract` instead, which resets the
+	 * value WITHOUT claiming anything was learned.
+	 */
 	setNotificationContract(version: unknown): void {
+		this.applyNotificationContract(version);
+		this.contractAnswered = true;
+	}
+
+	private applyNotificationContract(version: unknown): void {
 		this.notificationContract =
 			typeof version === "number" && Number.isFinite(version) && version > 0
 				? version
@@ -193,30 +288,45 @@ export class DesktopNotifier {
 			return;
 		}
 		if (frame.type === "notification") {
-			this.sawComposedNotification = true;
 			void this.composed(sessionId, frame.payload);
 			return;
 		}
 		if (frame.type === "event") {
-			// LEGACY PATH ONLY. A backend advertising `notification_contract` owns
-			// every completion toast, so this must stay silent against it or the
-			// user gets two banners for one turn.
-			//
 			// `turn_end` is dropped unconditionally, on every backend version: it
 			// is ONE MODEL CALL finishing (local_operator/tui/events.py,
 			// TurnBoundaryEnd), and an agentic turn is many of them. Toasting it
-			// was the reported defect — "Turn complete" per step.
-			//
-			// `agent_end` survives here only because dropping it too would leave an
-			// old backend with no completion signal at all. It is still wrong (it
-			// arrives while `task` children run), which is exactly what the
-			// backend-composed path fixes. The event itself is NEVER filtered out
-			// of the stream: the transcript reducer settles on it.
-			if (this.notificationContract > 0 || this.sawComposedNotification) return;
-			if (String(frame.payload.type ?? "") === "agent_end") {
-				this.turn(sessionId, frame.seq);
-			}
+			// was the reported defect — "Turn complete" per step. Dropped here,
+			// synchronously, because no backend answer can make it notifiable.
+			if (String(frame.payload.type ?? "") !== "agent_end") return;
+			void this.legacyTurn(sessionId, frame.seq);
 		}
+	}
+
+	/**
+	 * The legacy completion toast, raised only against a backend that composes
+	 * none of its own.
+	 *
+	 * DEFERRED, never raced. A backend advertising `notification_contract` owns
+	 * every completion toast, so this must stay silent against it or the user
+	 * gets two banners for one turn: the legacy one here plus the composed frame.
+	 * `agent_end` is published the moment the turn's last model call returns,
+	 * while the composed frame follows from the backend's 1 s attention poll
+	 * (design 6.1) — so the event reliably arrives FIRST, and any check that
+	 * reacts to a frame already in hand closes the window one frame too late.
+	 * Waiting for the capability read to settle is what closes it by
+	 * construction. The wait is bounded by `CONTRACT_PROBE_*` and only ever
+	 * applies before the first answer of a run.
+	 *
+	 * `agent_end` survives on this path only because dropping it too would leave
+	 * an old backend with no completion signal at all. It is still wrong (it
+	 * arrives while `task` children run), which is exactly what the
+	 * backend-composed path fixes. The event itself is NEVER filtered out of the
+	 * stream: the transcript reducer settles on it.
+	 */
+	private async legacyTurn(sessionId: string, seq: number): Promise<void> {
+		await this.awaitContract();
+		if (this.notificationContract > 0) return;
+		this.turn(sessionId, seq);
 	}
 
 	/**
@@ -244,35 +354,55 @@ export class DesktopNotifier {
 			// available to another surface (a TUI on this machine), while a claim
 			// taken for a toast we then suppressed would be delivered to nobody,
 			// for good. See docs/design/descriptive-notifications.md 7.3.
-			const won = await this.claimDelivery(sessionId, n.completion_token);
-			if (!won) return;
+			const outcome = await this.claimDelivery(sessionId, n.completion_token);
+			if (outcome !== "won") {
+				// A FAILED claim is not a lost one. On a transport error or a non-200
+				// the backend never advanced `claim_delivery`, so the completion is
+				// still unclaimed and still owed to somebody — but the local dedupe
+				// key is already spent, and the natural retry (design 7.5: two
+				// Electron windows on one session produce two frames with the SAME
+				// `dedupe_key`) would be swallowed for the full TTL. Release the key
+				// so the next frame can re-attempt. A clean `{claimed: false}` KEEPS
+				// it: another surface legitimately owns this one and re-attempting
+				// would just re-lose the same race.
+				if (outcome === "failed") this.delivered.delete(n.dedupe_key);
+				return;
+			}
 		}
-		this.show(sessionId, n.title, n.status, n.body);
+		this.show(sessionId, n.title, n.status, n.body, n.body_is_snippet);
 	}
 
 	/**
 	 * Ask the backend whether this surface owns this completion's toast.
 	 *
-	 * Fails CLOSED. A rejected or non-200 claim yields no toast, because the
-	 * failure mode of failing open is the duplicate banner on every surface this
-	 * whole mechanism exists to prevent — and the durable signal survives either
-	 * way: the session stays unseen in the sidebar.
+	 * Fails CLOSED on the TOAST: neither `lost` nor `failed` shows anything,
+	 * because the failure mode of failing open is the duplicate banner on every
+	 * surface this whole mechanism exists to prevent.
+	 *
+	 * The two non-winning outcomes are still reported separately, because they
+	 * differ in who owns the completion afterwards. `lost` means the backend
+	 * answered and another surface has it. `failed` means the backend was never
+	 * reached or never answered cleanly, so nothing was claimed anywhere and the
+	 * completion is still owed to somebody — see the caller.
 	 */
 	private async claimDelivery(
 		sessionId: string,
 		completionToken: string,
-	): Promise<boolean> {
+	): Promise<"won" | "lost" | "failed"> {
 		try {
 			const response = await this.request({
 				op: "sessions.notified",
 				sessionId,
 				completionToken,
 			});
-			if (response.status !== 200) return false;
+			// A non-200 includes the local 422 the transport returns for a schema
+			// miss, so a backend minting a non-UUID completion token retries rather
+			// than silently losing every completion.
+			if (response.status !== 200) return "failed";
 			const body = response.body as { result?: { claimed?: unknown } } | null;
-			return body?.result?.claimed === true;
+			return body?.result?.claimed === true ? "won" : "lost";
 		} catch {
-			return false;
+			return "failed";
 		}
 	}
 
@@ -283,20 +413,61 @@ export class DesktopNotifier {
 		return false;
 	}
 
+	/**
+	 * Raise the banner for a pending approval or question.
+	 *
+	 * A gate is worth a toast even when the window is focused: the user may be
+	 * reading another conversation in the same window.
+	 *
+	 * When the backend supplies `session_name`, the banner takes the SHAPE of a
+	 * completion banner — session name as the title, the gate's own title
+	 * leading the detail. Without it, a gate named only its category while
+	 * completions named their session, so the banner a user can safely ignore
+	 * identified itself and the banner holding a run hostage did not; with two
+	 * or three sessions running, that one cannot be triaged without clicking,
+	 * which is the action the user was deciding whether to take.
+	 *
+	 * The name is rendered ONLY as the backend sent it. `session_name` is
+	 * additive and optional: it is absent on an older backend and empty when the
+	 * `session_names_in_notifications()` privacy flag is off. The backend owns
+	 * that decision because only it can read the flag, so this app must never
+	 * resolve the name from a snapshot instead — doing so would leak a name the
+	 * user opted out of, on every gate, forever.
+	 */
 	private gate(sessionId: string, gate: PendingDesktopGate): void {
 		const { request_id: requestId, kind, title, detail } = gate;
 		const key = `gate:${sessionId}:${this.epochs.get(sessionId) ?? ""}:${requestId}`;
 		if (!this.claim(key)) return;
-		// A gate is worth a toast even when the window is focused: the user
-		// may be reading another conversation in the same window.
-		//
 		// The fallback is kind-aware because an untitled `ask` used to announce
 		// "Approval needed" — the wrong promise entirely: the user goes looking
 		// for a yes/no button and finds a question. `kind` is already on the wire.
 		const fallback = kind === "ask" ? "Question" : "Approval needed";
-		// No status: a gate's own title/detail is the whole card, and inventing a
-		// state category here would be this app composing copy the backend owns.
-		this.show(sessionId, title || fallback, "", detail);
+		const sessionName = gate.session_name?.trim() || "";
+		if (!sessionName) {
+			// No name to lead with, so the shape is unchanged from today: category
+			// or gate title up top, detail below. An empty detail would otherwise
+			// render a bodiless banner — `PendingGateState.detail` defaults to ""
+			// and is untrimmed on the wire — so the title falls back into the body
+			// and the category takes the title, which is the only pair of strings
+			// available here that says anything.
+			if (!detail.trim()) {
+				this.show(sessionId, fallback, "", title.trim() || fallback);
+				return;
+			}
+			this.show(sessionId, title || fallback, "", detail);
+			return;
+		}
+		// Named: the gate's own title leads the detail, so the banner says which
+		// session AND what it is asking. `fallback` stands in when the gate is
+		// untitled, keeping "Question" for an ask that has none.
+		const gateTitle = title.trim() || fallback;
+		const gateDetail = detail.trim();
+		this.show(
+			sessionId,
+			sessionName,
+			"",
+			gateDetail ? `${gateTitle}: ${gateDetail}` : gateTitle,
+		);
 	}
 
 	/**
@@ -333,18 +504,37 @@ export class DesktopNotifier {
 	 * state category would simply vanish and those users would read a bare
 	 * snippet with no indication of whether the turn succeeded or failed. One
 	 * shape that degrades on no platform beats a second, platform-forked one.
-	 * The strings themselves are the backend's, unchanged; only the join is
-	 * ours, and it is the first thing the OS shows before it clips.
+	 * The strings themselves are the backend's, unchanged; only the join is ours.
+	 *
+	 * The design doc's stated reason for keeping the status out of the title —
+	 * "macOS clips a title at ~43 characters" — is FALSE on a current macOS
+	 * banner: rendered frames show an 80-character title wrapping across two
+	 * lines, not clipping (design review round 1). The real constraint is a
+	 * total budget of roughly five text lines for title and body together, after
+	 * which macOS truncates the BODY with its own ellipsis. That is why the join
+	 * is spent sparingly below.
+	 *
+	 * `isSnippet` decides whether the status earns its place. A model-written
+	 * snippet does not say the outcome, so the category in front of it is the
+	 * only thing that does. The house bodies ("Task complete", "Stopped with an
+	 * error") already name the state, so prefixing them renders "Complete — Task
+	 * complete": one fact asserted twice in the two lines a banner gets, which is
+	 * what every user with the session-name privacy flag off would have received.
+	 * `body_is_snippet` is the backend's own flag for exactly this difference, so
+	 * this app still re-words nothing (design 8.4). Gates pass `status = ""` and
+	 * are unaffected either way.
 	 */
 	private show(
 		sessionId: string,
 		title: string,
 		status: string,
 		body: string,
+		isSnippet = false,
 	): void {
+		const lead = isSnippet && status ? `${status} — ` : "";
 		const notification = new Notification({
 			title,
-			body: `${status ? `${status} — ` : ""}${body}`.slice(0, MAX_BODY_CHARS),
+			body: `${lead}${body}`.slice(0, MAX_BODY_CHARS),
 			silent: false,
 		});
 		notification.on("click", () => {

--- a/src/main/desktop-notifier.ts
+++ b/src/main/desktop-notifier.ts
@@ -80,6 +80,69 @@ const CONTRACT_PROBE_RETRY_MS = 250;
  */
 const MAX_BODY_CHARS = 240;
 
+/** `rstrip(":")` from the backend's `gate_body`, hoisted per `useTopLevelRegex`. */
+const TRAILING_COLONS = /:+$/;
+
+/**
+ * The house body for a gate with nothing to say, COPIED FROM THE BACKEND.
+ *
+ * These are `local_operator/tui/notify.py`'s `BODY_APPROVAL` and `BODY_ASK`,
+ * reached through `BODIES` in `local_operator/notifications/compose.py`. They
+ * are duplicated here rather than fetched because a gate banner must render
+ * with no extra round trip, and the backend does not put them on the
+ * `pending_gate` payload (unlike a completion, which arrives pre-composed).
+ *
+ * IF THESE DRIFT FROM THE BACKEND CONSTANTS THE TWO SURFACES SAY DIFFERENT
+ * WORDS FOR THE SAME STATE. `gateBody` below mirrors `compose.py::gate_body`
+ * and is pinned against that function's own test vectors in
+ * `scripts/desktop-notifier.test.mjs` (T-U17), which is the only drift check
+ * available across two repositories.
+ */
+const GATE_BODIES: Record<string, string> = {
+	ask: "Waiting for your answer",
+	approval: "Waiting for approval",
+};
+
+/**
+ * The body for a parked `ask`/`approval`: the action, or the sentence.
+ *
+ * A DIRECT MIRROR of `local_operator/notifications/compose.py::gate_body`,
+ * down to the trailing-colon trim, so the desktop banner and the backend's own
+ * OS fallback cannot word the same gate differently.
+ *
+ * NOT `${gateTitle}: ${gateDetail}`. A tool's `describe_approval` already
+ * leads with its own action word (`_describe_path_approval` emits `"write:
+ * /path"`) and the gate's title IS the tool name, so the naive form rendered
+ * every file and shell approval as `"write: write: /path"` — on the banner the
+ * user is actually blocked on (design review round 2, D3-1). The prefix is
+ * applied only when the detail does not already carry it.
+ *
+ * An empty detail falls back to the house vocabulary rather than to the bare
+ * tool name: `write` alone says less than `Waiting for approval`, and it is
+ * reachable without a malformed payload — `_describe_path_approval` returns
+ * `""` for a blank path argument (D3-2).
+ *
+ * `gateTitle` is passed EMPTY when the caller already shows it on the title
+ * line, which is the one input shape the backend never has: there the title
+ * slot is the session name, so the gate title has nowhere else to go.
+ */
+function gateBody(kind: string, gateTitle: string, gateDetail: string): string {
+	let subject = (gateDetail ?? "").trim();
+	if (
+		subject &&
+		gateTitle &&
+		!subject.toLowerCase().startsWith(gateTitle.toLowerCase())
+	) {
+		// `rstrip(":")` in the original: a detail that itself ends in a colon
+		// would otherwise render a dangling separator.
+		subject = `${gateTitle}: ${subject}`
+			.trim()
+			.replace(TRAILING_COLONS, "")
+			.trim();
+	}
+	return subject || GATE_BODIES[kind] || GATE_BODIES.approval;
+}
+
 type WatchState = {
 	visible: boolean;
 	focused: boolean;
@@ -108,6 +171,24 @@ export class DesktopNotifier {
 	 */
 	private contractProbe: Promise<void> | null = null;
 	/**
+	 * Generation of the newest capability read, so the LAST-STARTED one wins.
+	 *
+	 * Probes are not idempotent and they overlap: the backend-ready hook can
+	 * fire twice in a tick (external-backend discovery and `start()` both
+	 * reported ready), a health-check restart can fire it while an earlier probe
+	 * is still retrying, and `awaitContract` starts one of its own. Without this
+	 * the shared fields are written by whichever probe SETTLES last, which on a
+	 * transient blip is the older read — a successful answer clobbered by a
+	 * stale failure, decided by timing rather than by recency (review round 2,
+	 * R2-2).
+	 *
+	 * A superseded probe therefore writes nothing at all and returns. It is not
+	 * cancelled — its in-flight `fetch` is left to settle on its own, because
+	 * the only cost is one wasted response and the alternative is threading an
+	 * `AbortSignal` through the desktop transport for no user-visible gain.
+	 */
+	private contractGeneration = 0;
+	/**
 	 * Whether a capability read has ever come back with a real HTTP answer.
 	 *
 	 * This is the distinction that closes the double-banner window BY
@@ -123,6 +204,12 @@ export class DesktopNotifier {
 	 * reading an unanswered 0 as "no contract". Failing toward the legacy path
 	 * rather than toward silence (design 4.3) is preserved: once a bounded probe
 	 * really has failed at the moment the toast is due, the toast is raised.
+	 *
+	 * ONCE TRUE THIS AND `notificationContract` MOVE ONLY TOGETHER. A failed
+	 * probe that reset the value while leaving this true produced a pair meaning
+	 * "we were told there is no contract" when in fact we were told nothing, and
+	 * `awaitContract` then declined to re-ask — the double banner returned and
+	 * STAYED, every turn, until the next backend bounce (review round 2, R2-1).
 	 */
 	private contractAnswered = false;
 
@@ -154,45 +241,66 @@ export class DesktopNotifier {
 	 * is the legacy path rather than silence: see `notificationContract`.
 	 */
 	refreshNotificationContract(): Promise<void> {
-		const probe = this.probeNotificationContract();
+		const generation = ++this.contractGeneration;
+		const probe = this.probeNotificationContract(generation);
 		this.contractProbe = probe;
 		return probe;
 	}
 
-	private async probeNotificationContract(): Promise<void> {
+	private async probeNotificationContract(generation: number): Promise<void> {
 		for (let attempt = 0; attempt < CONTRACT_PROBE_ATTEMPTS; attempt++) {
+			let response: DesktopResponse | null = null;
 			try {
-				const response = await this.request({ op: "capabilities" });
-				if (response.status === 200) {
-					const body = response.body as {
-						result?: { features?: Record<string, unknown> };
-					} | null;
-					// A 200 is an ANSWER even when the key is absent: that is an old
-					// backend, and retrying would only delay the legacy path it wants.
-					this.applyNotificationContract(
-						body?.result?.features?.notification_contract,
-					);
-					this.contractAnswered = true;
-					return;
-				}
+				response = await this.request({ op: "capabilities" });
 			} catch {
-				// Unfetchable is retried, then treated as absent. A missing capability
-				// response is a transient HTTP failure far more often than it is an
-				// old backend, and going silent on a transient failure loses
+				// Unfetchable is retried, then treated as nothing learned. A missing
+				// capability response is a transient HTTP failure far more often than
+				// it is an old backend, and going silent on a transient failure loses
 				// completions.
+			}
+			// Checked AFTER the await and before any write: a newer read has been
+			// started against a backend this one may no longer describe, and the
+			// newest read is the only one entitled to decide.
+			if (generation !== this.contractGeneration) return;
+			if (response?.status === 200) {
+				const body = response.body as {
+					result?: { features?: Record<string, unknown> };
+				} | null;
+				// A 200 is an ANSWER even when the key is absent: that is an old
+				// backend, and retrying would only delay the legacy path it wants.
+				this.applyNotificationContract(
+					body?.result?.features?.notification_contract,
+				);
+				this.contractAnswered = true;
+				return;
 			}
 			if (attempt + 1 < CONTRACT_PROBE_ATTEMPTS) {
 				await new Promise((resolve) =>
 					setTimeout(resolve, CONTRACT_PROBE_RETRY_MS),
 				);
+				if (generation !== this.contractGeneration) return;
 			}
 		}
-		// Every attempt failed, so nothing was learned. Reset rather than keep a
-		// stale claim (holding `1` against a backend that emits no frames is the
-		// one way this gate goes silent on completions altogether) and leave
-		// `contractAnswered` alone, so the legacy path re-asks rather than reading
-		// this 0 as an old backend's answer.
-		this.applyNotificationContract(undefined);
+		// EVERY ATTEMPT FAILED, SO NOTHING IS WRITTEN. A failure teaches nothing
+		// about the backend, and the two fields this could touch mean different
+		// things together than apart:
+		//
+		// - Never answered: `notificationContract` is already 0 (the only writers
+		//   are the 200 path and `setNotificationContract`, both of which set
+		//   `contractAnswered`), so a reset here was always a no-op. The legacy
+		//   path re-asks on the next `awaitContract`, which is the cold-start fix.
+		// - Already answered: resetting the value while leaving `contractAnswered`
+		//   true asserted "the backend told us it has no contract" on the strength
+		//   of a read that reached no backend at all. A health-check restart whose
+		//   `/health` recovers before `/v1/capabilities` finishes warming hit this
+		//   on an ordinary run, and the legacy toast then fired against a still
+		//   composing backend on EVERY subsequent turn (R2-1).
+		//
+		// Holding a stale `1` cannot go silent on completions in exchange: the
+		// legacy toast is raised by `agent_end`, which arrives on the same backend
+		// stream, so a backend too unreachable to answer this read emits no turn
+		// to announce either. The downgrade direction (design 4.3) is carried by a
+		// SUCCESSFUL re-read returning no key, which is unaffected here.
 	}
 
 	/**
@@ -224,15 +332,24 @@ export class DesktopNotifier {
 	 * Record the contract version a backend reported.
 	 *
 	 * Being told the value directly IS an answer, so this also stops the legacy
-	 * path issuing a probe of its own and overwriting it. The probe's own
-	 * failure path uses `applyNotificationContract` instead, which resets the
-	 * value WITHOUT claiming anything was learned.
+	 * path issuing a probe of its own and overwriting it.
+	 *
+	 * Bumps the generation for the same reason a probe does: this is the newest
+	 * reading of the backend, so an older probe still in flight must not settle
+	 * on top of it.
 	 */
 	setNotificationContract(version: unknown): void {
+		this.contractGeneration++;
 		this.applyNotificationContract(version);
 		this.contractAnswered = true;
 	}
 
+	/**
+	 * Normalise a reported contract value. Both callers are ANSWERS and both
+	 * set `contractAnswered` themselves; nothing else may write this field.
+	 * That invariant is the fix for R2-1, so a third caller that resets the
+	 * value without answering re-opens it.
+	 */
 	private applyNotificationContract(version: unknown): void {
 		this.notificationContract =
 			typeof version === "number" && Number.isFinite(version) && version > 0
@@ -444,29 +561,41 @@ export class DesktopNotifier {
 		const fallback = kind === "ask" ? "Question" : "Approval needed";
 		const sessionName = gate.session_name?.trim() || "";
 		if (!sessionName) {
-			// No name to lead with, so the shape is unchanged from today: category
-			// or gate title up top, detail below. An empty detail would otherwise
-			// render a bodiless banner — `PendingGateState.detail` defaults to ""
-			// and is untrimmed on the wire — so the title falls back into the body
-			// and the category takes the title, which is the only pair of strings
-			// available here that says anything.
-			if (!detail.trim()) {
-				this.show(sessionId, fallback, "", title.trim() || fallback);
-				return;
-			}
-			this.show(sessionId, title || fallback, "", detail);
+			// No name to lead with, so the shape is unchanged: the gate's own title
+			// up top, the detail below. `title.trim()` because a whitespace-only
+			// title is truthy and would render a banner with no title at all, which
+			// macOS fills with the posting app's name (D3-3).
+			//
+			// The gate title is passed to `gateBody` as EMPTY: it is already on the
+			// title line here, so prefixing the body with it would say the same word
+			// twice. What `gateBody` still supplies is the empty-detail case —
+			// `PendingGateState.detail` defaults to "" and is untrimmed on the wire,
+			// and it is reachable from a real tool (`_describe_path_approval`
+			// returns "" for a blank path) — where the house vocabulary says what the
+			// banner wants, rather than a bare verb or no body at all (D3-2).
+			this.show(
+				sessionId,
+				title.trim() || fallback,
+				"",
+				gateBody(kind, "", detail),
+			);
 			return;
 		}
-		// Named: the gate's own title leads the detail, so the banner says which
-		// session AND what it is asking. `fallback` stands in when the gate is
-		// untitled, keeping "Question" for an ask that has none.
-		const gateTitle = title.trim() || fallback;
-		const gateDetail = detail.trim();
+		// Named: the session takes the title line, so the gate's own title has to
+		// lead the body or the banner never says what is being asked. `fallback`
+		// stands in when the gate is untitled, keeping "Question" for an ask that
+		// has none.
+		//
+		// Through `gateBody` rather than a join of its own: for a tool approval the
+		// title IS the tool name and the detail already leads with it, so the naive
+		// form rendered "write: write: /Users/damian/notes.md" — a worse banner with
+		// the privacy flag ON than off, the inverse of what this change is for
+		// (D3-1).
 		this.show(
 			sessionId,
 			sessionName,
 			"",
-			gateDetail ? `${gateTitle}: ${gateDetail}` : gateTitle,
+			gateBody(kind, title.trim() || fallback, detail),
 		);
 	}
 

--- a/src/main/desktop-notifier.ts
+++ b/src/main/desktop-notifier.ts
@@ -9,9 +9,26 @@
  *
  * Frames come from the existing stream relay (one subscription per window,
  * no second connection): a `pending_gate` appearing in a snapshot or update
- * raises a gate notification; a turn-ending event raises a completion one.
- * Dedupe is by `session:epoch:request_id` (gates) and `session:epoch:seq`
- * (turns) across every window, so two windows on one session yield one toast.
+ * raises a gate notification, and a backend-composed `notification` frame
+ * raises a completion or error one. Dedupe is by `session:epoch:request_id`
+ * (gates) and by the backend-minted `dedupe_key` (composed notifications)
+ * across every window, so two windows on one session yield one toast.
+ *
+ * Completion content is COMPOSED BY THE BACKEND and rendered here verbatim.
+ * Only the backend can read the `display.notification_session_name` privacy
+ * flag, only it can apply the snippet-iff-complete rule (a failed turn's last
+ * assistant line is the success sentence from before the failure), and only
+ * one composer keeps the TUI, the detached-runtime fallback and this app
+ * saying the same words. This class must never re-word a title, status or
+ * body. See docs/design/descriptive-notifications.md 2 and 8.
+ *
+ * A completion toast also CLAIMS delivery before it fires, because a TUI on
+ * the same machine can see the same completion. The claim is taken last, only
+ * once the toast is certain: a claim taken for a banner we then suppress would
+ * mark the completion delivered while nobody was told, and no other surface
+ * could ever tell them (7.3). It is not a read receipt and must never touch
+ * `sessions.seen`, which would clear the sidebar's unseen mark for a session
+ * the user never opened.
  *
  * Clicking a notification asks the renderer to open that conversation. It
  * never answers a gate: approval is an explicit in-app action with identity
@@ -25,10 +42,22 @@
 
 import { type BrowserWindow, Notification } from "electron";
 import type { DesktopResponse } from "../shared/desktop-contract";
-import type { DesktopSessionFrame } from "../shared/desktop-session-contract";
+import type {
+	DesktopNotification,
+	DesktopSessionFrame,
+	PendingDesktopGate,
+} from "../shared/desktop-session-contract";
 
 const NOTIFY_TTL_MS = 10 * 60 * 1000;
 const MAX_DEDUPE_KEYS = 2048;
+
+/**
+ * Longest a composed notification's rendered body may be.
+ *
+ * The backend already bounds and sanitises each part; this is the belt-and-
+ * braces bound on the CONCATENATION, which no single backend field describes.
+ */
+const MAX_BODY_CHARS = 240;
 
 type WatchState = {
 	visible: boolean;
@@ -41,6 +70,30 @@ export class DesktopNotifier {
 	private readonly epochs = new Map<string, string>();
 	/** Window state per (window id) used to decide whether a toast is needed. */
 	private readonly windows = new Map<number, WatchState>();
+	/**
+	 * `features.notification_contract` from `/v1/capabilities`; 0 means legacy.
+	 *
+	 * A HARD switch, not a heuristic. At >= 1 the backend owns every completion
+	 * toast and the legacy event path must stay silent or one turn produces two
+	 * banners. Absent or unfetchable stays 0 on purpose: a missing capability
+	 * response is a transient HTTP failure far more often than it is an old
+	 * backend, and failing toward silence would lose completions outright.
+	 */
+	private notificationContract = 0;
+	/**
+	 * Whether a composed `notification` frame has ever arrived on this run.
+	 *
+	 * The capability fetch and the frame stream are two different round trips,
+	 * and only the second one is proof. A backend swapped underneath a running
+	 * app (the health check restarts one, external-backend discovery finds
+	 * another) can start composing notifications while `notificationContract` is
+	 * still the stale 0 read at connect — and 0 means the legacy `agent_end`
+	 * toast fires too, which is the double banner this whole change exists to
+	 * remove. A frame in hand cannot be stale, so it latches the gate shut on
+	 * its own. One-way on purpose: a backend that has composed once owns
+	 * notifications for the rest of the run.
+	 */
+	private sawComposedNotification = false;
 
 	constructor(
 		private readonly window: () => BrowserWindow | null,
@@ -49,6 +102,47 @@ export class DesktopNotifier {
 
 	get canNotify(): boolean {
 		return Notification.isSupported();
+	}
+
+	/**
+	 * Record what the connected backend advertises for `notification_contract`.
+	 *
+	 * Called at backend-connect and again whenever the backend URL rotates
+	 * (external-backend discovery), because the app can move from a new backend
+	 * to an old one without restarting. A non-number or a failed fetch resets to
+	 * 0 rather than keeping a stale claim: keeping `1` against a backend that
+	 * emits no frames is the one way this gate goes silent.
+	 */
+	/**
+	 * Read `features.notification_contract` from the connected backend.
+	 *
+	 * Called once the backend is reachable and BEFORE any window exists, so the
+	 * gate is settled before the first frame can arrive. A throw or a non-200
+	 * leaves the gate at 0, which is the legacy path rather than silence: see
+	 * `notificationContract`.
+	 */
+	async refreshNotificationContract(): Promise<void> {
+		try {
+			const response = await this.request({ op: "capabilities" });
+			if (response.status !== 200) return;
+			const body = response.body as {
+				result?: { features?: Record<string, unknown> };
+			} | null;
+			this.setNotificationContract(
+				body?.result?.features?.notification_contract,
+			);
+		} catch {
+			// Unfetchable is treated as absent, deliberately. A missing capability
+			// response is a transient HTTP failure far more often than it is an old
+			// backend, and going silent on a transient failure loses completions.
+		}
+	}
+
+	setNotificationContract(version: unknown): void {
+		this.notificationContract =
+			typeof version === "number" && Number.isFinite(version) && version > 0
+				? version
+				: 0;
 	}
 
 	/**
@@ -89,20 +183,96 @@ export class DesktopNotifier {
 		if (frame.type === "snapshot") {
 			this.epochs.set(sessionId, frame.payload.frontend.epoch);
 			const gate = frame.payload.frontend.snapshot.pending_gate;
-			if (gate) this.gate(sessionId, gate.request_id, gate.title, gate.detail);
+			if (gate) this.gate(sessionId, gate);
 			return;
 		}
 		if (frame.type === "frontend.update") {
 			this.epochs.set(sessionId, frame.payload.epoch);
 			const gate = frame.payload.changes.pending_gate;
-			if (gate) this.gate(sessionId, gate.request_id, gate.title, gate.detail);
+			if (gate) this.gate(sessionId, gate);
+			return;
+		}
+		if (frame.type === "notification") {
+			this.sawComposedNotification = true;
+			void this.composed(sessionId, frame.payload);
 			return;
 		}
 		if (frame.type === "event") {
-			const eventType = String(frame.payload.type ?? "");
-			if (eventType === "agent_end" || eventType === "turn_end") {
+			// LEGACY PATH ONLY. A backend advertising `notification_contract` owns
+			// every completion toast, so this must stay silent against it or the
+			// user gets two banners for one turn.
+			//
+			// `turn_end` is dropped unconditionally, on every backend version: it
+			// is ONE MODEL CALL finishing (local_operator/tui/events.py,
+			// TurnBoundaryEnd), and an agentic turn is many of them. Toasting it
+			// was the reported defect — "Turn complete" per step.
+			//
+			// `agent_end` survives here only because dropping it too would leave an
+			// old backend with no completion signal at all. It is still wrong (it
+			// arrives while `task` children run), which is exactly what the
+			// backend-composed path fixes. The event itself is NEVER filtered out
+			// of the stream: the transcript reducer settles on it.
+			if (this.notificationContract > 0 || this.sawComposedNotification) return;
+			if (String(frame.payload.type ?? "") === "agent_end") {
 				this.turn(sessionId, frame.seq);
 			}
+		}
+	}
+
+	/**
+	 * Deliver one backend-composed notification.
+	 *
+	 * The order of these four checks is load-bearing and is the whole of 7.3.
+	 * Dedupe and the focus gate run BEFORE the claim so a toast we are not going
+	 * to show never burns the cross-surface claim; the claim runs immediately
+	 * before delivery so the claimant really is the deliverer.
+	 */
+	private async composed(
+		sessionId: string,
+		n: DesktopNotification,
+	): Promise<void> {
+		// Keyed on the backend's own string and nothing else: the bridge epoch
+		// resets on reconnect, so any locally derived key re-toasts a completion
+		// that was merely re-delivered.
+		if (!this.claim(n.dedupe_key)) return;
+		// A gate arrives as `always` because the user may be reading another
+		// conversation in the same window; a completion is only news when nobody
+		// is looking. The backend decides which; this app does not second-guess it.
+		if (n.focus_policy === "when_unfocused" && this.anyFocused()) return;
+		if (n.completion_token) {
+			// Claim LAST, immediately before delivery: an unclaimed completion stays
+			// available to another surface (a TUI on this machine), while a claim
+			// taken for a toast we then suppressed would be delivered to nobody,
+			// for good. See docs/design/descriptive-notifications.md 7.3.
+			const won = await this.claimDelivery(sessionId, n.completion_token);
+			if (!won) return;
+		}
+		this.show(sessionId, n.title, n.status, n.body);
+	}
+
+	/**
+	 * Ask the backend whether this surface owns this completion's toast.
+	 *
+	 * Fails CLOSED. A rejected or non-200 claim yields no toast, because the
+	 * failure mode of failing open is the duplicate banner on every surface this
+	 * whole mechanism exists to prevent — and the durable signal survives either
+	 * way: the session stays unseen in the sidebar.
+	 */
+	private async claimDelivery(
+		sessionId: string,
+		completionToken: string,
+	): Promise<boolean> {
+		try {
+			const response = await this.request({
+				op: "sessions.notified",
+				sessionId,
+				completionToken,
+			});
+			if (response.status !== 200) return false;
+			const body = response.body as { result?: { claimed?: unknown } } | null;
+			return body?.result?.claimed === true;
+		} catch {
+			return false;
 		}
 	}
 
@@ -113,25 +283,33 @@ export class DesktopNotifier {
 		return false;
 	}
 
-	private gate(
-		sessionId: string,
-		requestId: string,
-		title: string,
-		detail: string,
-	): void {
+	private gate(sessionId: string, gate: PendingDesktopGate): void {
+		const { request_id: requestId, kind, title, detail } = gate;
 		const key = `gate:${sessionId}:${this.epochs.get(sessionId) ?? ""}:${requestId}`;
 		if (!this.claim(key)) return;
 		// A gate is worth a toast even when the window is focused: the user
 		// may be reading another conversation in the same window.
-		this.show(sessionId, title || "Approval needed", detail);
+		//
+		// The fallback is kind-aware because an untitled `ask` used to announce
+		// "Approval needed" — the wrong promise entirely: the user goes looking
+		// for a yes/no button and finds a question. `kind` is already on the wire.
+		const fallback = kind === "ask" ? "Question" : "Approval needed";
+		// No status: a gate's own title/detail is the whole card, and inventing a
+		// state category here would be this app composing copy the backend owns.
+		this.show(sessionId, title || fallback, "", detail);
 	}
 
+	/**
+	 * Legacy completion toast: canned copy, reached only against a backend that
+	 * does not advertise `notification_contract`. Keyed on `session:epoch:seq`
+	 * as it always was — an old backend mints no `dedupe_key` to key on.
+	 */
 	private turn(sessionId: string, seq: number): void {
 		const key = `turn:${sessionId}:${this.epochs.get(sessionId) ?? ""}:${seq}`;
 		if (!this.claim(key)) return;
 		// Completion is only news when nobody is looking.
 		if (this.anyFocused()) return;
-		this.show(sessionId, "Turn complete", "The agent finished its turn.");
+		this.show(sessionId, "Turn complete", "", "The agent finished its turn.");
 	}
 
 	private claim(key: string): boolean {
@@ -147,10 +325,26 @@ export class DesktopNotifier {
 		return true;
 	}
 
-	private show(sessionId: string, title: string, body: string): void {
+	/**
+	 * Render one toast.
+	 *
+	 * `status` leads the body rather than riding `subtitle`. Electron's
+	 * `subtitle` option is documented macOS-only, so on Windows and Linux the
+	 * state category would simply vanish and those users would read a bare
+	 * snippet with no indication of whether the turn succeeded or failed. One
+	 * shape that degrades on no platform beats a second, platform-forked one.
+	 * The strings themselves are the backend's, unchanged; only the join is
+	 * ours, and it is the first thing the OS shows before it clips.
+	 */
+	private show(
+		sessionId: string,
+		title: string,
+		status: string,
+		body: string,
+	): void {
 		const notification = new Notification({
 			title,
-			body: body.slice(0, 240),
+			body: `${status ? `${status} — ` : ""}${body}`.slice(0, MAX_BODY_CHARS),
 			silent: false,
 		});
 		notification.on("click", () => {

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -417,15 +417,26 @@ app
 			(input) => backendService.requestDesktop(input),
 		);
 		const desktopNotifier = new DesktopNotifier(() => mainWindow, sendDesktop);
-		// Settle the notification gate before any window can subscribe to a
-		// stream. Until the backend confirms `features.notification_contract`,
-		// the notifier stays on its legacy path, which is the safe default: a
-		// missing capability is far more often a transient HTTP failure than an
-		// old backend, and failing toward silence loses completions outright.
-		// Not awaited: a slow or unreachable backend must not delay first paint,
-		// and the notifier latches the gate shut on its own the moment a composed
-		// frame arrives. See docs/design/descriptive-notifications.md 4.3.
-		void desktopNotifier.refreshNotificationContract();
+		// Read `features.notification_contract` whenever the backend becomes
+		// reachable, NOT here: the desktop token is minted inside
+		// `backendService.start()` below, so a capability request issued now
+		// would hit a dead port on the ordinary self-managed cold start, be
+		// swallowed, and leave the notifier on its legacy path against a backend
+		// that composes — two banners for one turn, which is the defect this
+		// change exists to remove.
+		//
+		// Registering the observer (rather than calling after `start()`) is what
+		// keeps it correct on every later transition too: a health-check restart
+		// or external-backend discovery can put a DIFFERENT backend version
+		// underneath a running app, in both directions. Re-reading is also the
+		// downgrade path in docs/design/descriptive-notifications.md 4.3.
+		//
+		// Not awaited: a slow backend must not delay first paint. The notifier
+		// defers the legacy toast until the read settles, so nothing can slip
+		// through the window in between.
+		backendService.onBackendReady(() => {
+			void desktopNotifier.refreshNotificationContract();
+		});
 		backendService.observeStream((sessionId, data) => {
 			try {
 				desktopNotifier.observe(sessionId, JSON.parse(data));

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -417,6 +417,15 @@ app
 			(input) => backendService.requestDesktop(input),
 		);
 		const desktopNotifier = new DesktopNotifier(() => mainWindow, sendDesktop);
+		// Settle the notification gate before any window can subscribe to a
+		// stream. Until the backend confirms `features.notification_contract`,
+		// the notifier stays on its legacy path, which is the safe default: a
+		// missing capability is far more often a transient HTTP failure than an
+		// old backend, and failing toward silence loses completions outright.
+		// Not awaited: a slow or unreachable backend must not delay first paint,
+		// and the notifier latches the gate shut on its own the moment a composed
+		// frame arrives. See docs/design/descriptive-notifications.md 4.3.
+		void desktopNotifier.refreshNotificationContract();
 		backendService.observeStream((sessionId, data) => {
 			try {
 				desktopNotifier.observe(sessionId, JSON.parse(data));

--- a/src/shared/desktop-contract.ts
+++ b/src/shared/desktop-contract.ts
@@ -241,6 +241,19 @@ export const desktopRequestSchema = z.discriminatedUnion("op", [
 			completionToken: z.string().uuid(),
 		})
 		.strict(),
+	// Cross-surface delivery claim, NOT a read receipt. `claim_delivery`
+	// serialises the observers that can see one completion (a TUI, this app) so
+	// exactly one of them toasts it. It deliberately never advances the read
+	// watermark: routing a notification must not clear the sidebar's unseen mark
+	// for a session the user never opened, which is why this is its own op and
+	// not a reuse of `sessions.seen`.
+	z
+		.object({
+			op: z.literal("sessions.notified"),
+			sessionId,
+			completionToken: z.string().uuid(),
+		})
+		.strict(),
 	z
 		.object({
 			op: z.literal("sessions.watch"),
@@ -1139,6 +1152,12 @@ export function desktopEndpoint(request: DesktopRequest): {
 		case "sessions.seen":
 			return {
 				path: `/v1/desktop/sessions/${request.sessionId}/seen`,
+				method: "POST",
+				body: { completion_token: request.completionToken },
+			};
+		case "sessions.notified":
+			return {
+				path: `/v1/desktop/sessions/${request.sessionId}/notified`,
 				method: "POST",
 				body: { completion_token: request.completionToken },
 			};

--- a/src/shared/desktop-session-contract.ts
+++ b/src/shared/desktop-session-contract.ts
@@ -73,6 +73,51 @@ export type PendingDesktopGate = {
 	question_index: number;
 	question_total: number;
 };
+/**
+ * One composed notification, as the backend rendered it.
+ *
+ * The strings are authoritative: the backend owns wording parity across the
+ * TUI, the detached-runtime fallback and this app, and it is the only place
+ * that can read the `display.notification_session_name` privacy flag. A UI
+ * that composed locally would either re-read that config over HTTP on every
+ * toast or ship a banner the user opted out of — and an old signed binary
+ * would keep leaking the name forever, because the opt-out is a backend
+ * setting it has never heard of.
+ *
+ * The structured fields travel BESIDE the strings so a future surface can
+ * re-render (localisation, a narrower budget) without this app re-deriving a
+ * rule it cannot see. Missing fields degrade honestly rather than throwing:
+ * `contract` versions the payload SHAPE, additive fields do not bump it, and
+ * an unknown future `kind` must render as text rather than crash a toast.
+ *
+ * See docs/design/descriptive-notifications.md 4.1 and 8.1 — these names are
+ * the wire contract, not a local convenience.
+ */
+export type DesktopNotification = {
+	/** Payload shape version. 1 today; additive fields do not bump it. */
+	contract: number;
+	kind: "complete" | "error" | "interrupted" | "ask" | "approval";
+	title: string;
+	/** Short state category ("Complete", "Needs attention"). */
+	status: string;
+	body: string;
+	/** True when `body` is model-written text rather than a house constant. */
+	body_is_snippet: boolean;
+	/** False when the privacy flag is off or the session has no stored name. */
+	title_is_session_name: boolean;
+	/**
+	 * Opaque; key the dedupe map on this and NOTHING else. In particular not on
+	 * `session:epoch:seq`: `acquire()` mints a new bridge epoch and resets the
+	 * sequence to 0, so the same completion re-delivered after a detached
+	 * interval would get a different key and toast twice.
+	 */
+	dedupe_key: string;
+	/** Durable completion identity; the argument to `sessions.notified`. */
+	completion_token: string | null;
+	session_name: string | null;
+	/** `when_unfocused` for completions; `always` for a gate. */
+	focus_policy: "when_unfocused" | "always";
+};
 export type CanonicalFrontendState = {
 	attention?: CompletionAttention;
 	state_version: number;
@@ -193,6 +238,12 @@ export type DesktopSessionFrame =
 			}
 	  >
 	| Receipt<"event", { type: string; [key: string]: unknown }>
+	// Additive and replay-exempt: an older renderer falls through every branch
+	// of the frame loop, advances its receipt cursor on `seq`, and paints
+	// nothing. Deliberately NOT an `event`, which is a typed canonical
+	// AgentEvent the transcript reducer paints, nor a `frontend.update`, which
+	// is a field delta of persistent state — a notification is a one-shot edge.
+	| Receipt<"notification", DesktopNotification>
 	| { session_id: CanonicalSessionId; type: "heartbeat" | "gap" };
 export type DesktopAdmission = {
 	status: "admitted";

--- a/src/shared/desktop-session-contract.ts
+++ b/src/shared/desktop-session-contract.ts
@@ -115,6 +115,24 @@ export type DesktopNotification = {
 	body: string;
 	/** True when `body` is model-written text rather than a house constant. */
 	body_is_snippet: boolean;
+	/**
+	 * True when `body` is the session's own recorded failure text rather than a
+	 * house constant — a provider envelope such as
+	 * `anthropic: 429 rate_limit_error - credit balance too low`.
+	 *
+	 * A separate flag from `body_is_snippet` because the two are never both
+	 * true and a surface has to tell them apart: both carry untrusted,
+	 * non-house text, but only the failure text is the reason the user has to
+	 * act. The backend is the only side that can read it, so a surface that
+	 * ignores it renders the state-naming status for a snippet and drops it for
+	 * the one banner that demands action.
+	 *
+	 * OPTIONAL because it is additive: the backend added it after the first
+	 * contract-1 payloads shipped and additive fields do not bump `contract`. A
+	 * backend old enough to emit a failure summary without the flag degrades to
+	 * the bare body, which is exactly what it rendered before the flag existed.
+	 */
+	body_is_failure?: boolean;
 	/** False when the privacy flag is off or the session has no stored name. */
 	title_is_session_name: boolean;
 	/**

--- a/src/shared/desktop-session-contract.ts
+++ b/src/shared/desktop-session-contract.ts
@@ -72,6 +72,18 @@ export type PendingDesktopGate = {
 	secret: boolean;
 	question_index: number;
 	question_total: number;
+	/**
+	 * The session's display name, for the notification banner only.
+	 *
+	 * ADDITIVE and OPTIONAL: absent on any backend older than the composed
+	 * notification contract, and empty when the
+	 * `session_names_in_notifications()` privacy flag is off. The backend owns
+	 * that decision because it is the only side that can read the flag, so a
+	 * surface rendering this must use the field as sent and must never resolve
+	 * the name from a snapshot as a fallback — that would leak a name the user
+	 * opted out of. Absent and empty are the same case here: no name.
+	 */
+	session_name?: string | null;
 };
 /**
  * One composed notification, as the backend rendered it.


### PR DESCRIPTION
## What and why

The desktop app toasted **"Turn complete — The agent finished its turn."** on both
`agent_end` and `turn_end`, with no session name, no status and no message
context. Two defects in one banner: one correctness bug and one content gap.

Release: patch — desktop notifications now name the session, its status and the last line, and stop announcing turns that have not finished.

`turn_end` is **one model call finishing** (`local_operator/tui/events.py`,
`TurnBoundaryEnd`) and an agentic turn is many of them, so the user got a
"complete" banner per step — the loud half of the report. `agent_end` is the
parent's logical end but routinely arrives **while `task` children are still
running**: the `task` tool returns at registration, and the TUI's own notifier
refuses that case while `running_children > 0`. So the app notified on a per-step
event the TUI has never treated as notifiable, and on a parent end the TUI
deliberately suppresses. Both banners asserted something false, and the canned
copy could not say which session they were about.

**Change class: C2 — standard.** The user-visible surface is an OS toast, not an
in-app screen: no palette, token or component changes, so no theme gate applies.

Implements section 8 (and the skew rules in 4.3) of
`docs/design/descriptive-notifications.md`. **The design was already decided; this
does not redesign it.** One deviation is called out under "Decision taken" below,
which the design explicitly delegates to the coder.

**Merge order: the backend PR lands first.** This PR is safe to merge whenever —
the capability gate below makes it correct against any backend version — but it
delivers nothing until a backend composes the frames.

## The change

### 1. The strings come from the backend, verbatim

`src/shared/desktop-session-contract.ts` gains the `DesktopNotification` payload
type and one `Receipt<"notification", …>` arm on the frame union. The app renders
`title` / `status` / `body` and **never composes or re-words them**, because only
the backend can read the `display.notification_session_name` privacy flag, only it
can apply the snippet-iff-complete rule (a failed turn's last assistant line is
the success sentence from *before* the failure), and one composer is what keeps
the TUI, the detached-runtime fallback and this app saying the same words. A UI
that composed locally would leak an opted-out session name forever, because the
opt-out is a backend setting a shipped binary has never heard of.

The frame is additive and replay-exempt: an older renderer falls through every
branch, advances its receipt cursor on `seq`, and paints nothing.

### 2. Dedupe on the backend's key, not on the sequence

Keyed on `dedupe_key` and nothing else. The old completion key was
`turn:{session}:{frontendEpoch}:{seq}`, and `acquire()` mints a fresh bridge epoch
and resets the sequence to 0 — so a completion re-delivered after a detached
interval got a *different* key and toasted twice.

### 3. The claim order is load-bearing

```
isSupported? → local TTL dedupe? → focus gate? → POST /notified → new Notification()
```

A completion claims cross-surface delivery through the new
`POST /v1/desktop/sessions/{id}/notified`, and the claim is **last**. A claim
taken for a banner we then suppress would mark the completion delivered while
nobody was told — and no other surface could ever tell them, because
`claim_delivery` returns `false` from then on, for good. Conversely an unclaimed
completion stays available to a TUI observer on the same machine. The claim
**fails closed** (rejected, non-200, or `claimed: false` ⇒ no toast) because the
failure mode of failing open is a duplicate banner on every surface.

`src/main/desktop-ipc.ts`: the new op is deliberately **not** routed through
`guardForegroundReceipts`. That guard demands a focused window, which is the exact
opposite of when a notification fires. It stays scoped to `sessions.seen` alone,
and the reasoning is now written into its docstring — notifying is not reading,
and a delivery claim must never clear the sidebar's unseen mark for a session the
user never opened.

### 4. The capability gate, and why it fails toward noise

`features.notification_contract` is read from `/v1/capabilities` **every time the
backend becomes reachable** — first start, a health-check restart, or
external-backend discovery rotating the URL. At `>= 1` the legacy heuristics are
dropped entirely. Absent or unfetchable is treated as **absent**, not as silence:
a missing capability response is a transient HTTP failure far more often than it
is an old backend, and going silent on a transient failure loses completions.

The read is tied to backend readiness rather than to `app.whenReady()`, because
the desktop token is minted inside `backendService.start()`: a read issued at app
ready hits a dead port on the ordinary self-managed cold start, is swallowed, and
leaves the gate on the legacy path against a backend that composes — two banners
for one turn (review round 1, R1).

On the legacy path `turn_end` is dropped **unconditionally** — it is a per-step
event on every backend version, so dropping it is safe against all of them and
fixes the loudest half of the bug even against an old backend. `agent_end` is kept
there only so an old backend retains *some* completion signal.

`agent_end` is **never filtered out of the stream itself**: the transcript reducer
settles on it, and suppressing it to fix a notification would break transcript
settling on every UI version.

One addition beyond the doc, and the reason for it: the legacy `agent_end` toast
is **deferred until a capability read has answered**, not raced against one. The
value `0` has three causes that look identical on the field alone — the backend
answered and has no contract, nobody has asked yet, and the ask never reached a
backend at all — and only the first is an answer. So the gate tracks whether a
read was *answered*, re-asking under a bounded budget (3 attempts, 250 ms apart)
if none has. That closes the double-banner window by construction: `agent_end`
arrives before the composed frame, so anything reacting to a frame already in
hand closes it one frame too late, and any single read can lose its race with a
backend that is still starting.

An earlier revision used a one-way latch on the first composed frame instead.
It was removed: it closed too late for the cold start, and it was not reversible,
so an app pointed at an *older* backend went silent on completions for the rest
of the run — the downgrade direction design §4.3 names explicitly. Re-reading
covers both directions (review round 1, R1/M2).

### 5. The gate fallback bug

An untitled `ask` announced **"Approval needed"**, so the user went looking for a
yes/no button and found a question. It now says **"Question"**, using the `kind`
already on the wire. `approval` is unchanged.

Two further gate fixes came out of the design round:

- **Gates now name their session** when the backend supplies it. This PR gave
  completions a session identity and left gates without one, so the banner a user
  can safely ignore identified itself while the banner *holding a run hostage* did
  not (D3). `PendingDesktopGate` gains an **additive optional** `session_name`
  that the backend PR is adding; when present the gate takes the completion
  banner's shape (session name as title, the gate's own title leading the detail).
  The name is never resolved locally — only the backend can read the
  `session_names_in_notifications()` privacy flag, so deriving it here would leak
  a name the user opted out of. Absent, empty and whitespace all render exactly as
  before, which covers old backends and privacy-off alike.
- **An empty `detail` no longer renders a bodiless banner** (D6).
  `PendingGateState.detail` defaults to `""` and is untrimmed on the wire, so the
  gate title falls into the body and the category takes the title.

## Decision taken: `status — body`, not `subtitle`

Section 8.3 leaves this one open and says to decide it from a rendered frame
rather than from the docs. **Chose the concatenation.** Electron's `subtitle` is
documented macOS-only, so on Windows and Linux the state category would simply
vanish and those users would read a bare snippet with no indication of whether the
turn succeeded or failed. One shape that degrades on no platform beats a
platform-forked one. The strings are still the backend's, unchanged; only the join
is ours.

**The join is now conditional, and the doc's stated reason for it was wrong.**
Rendered banners (design round 1) show macOS *wraps* a long title rather than
clipping it at ~43 characters; the real constraint is a ~5-line total budget for
title and body together, after which the *body* is truncated. The conclusion
survives — for the `subtitle` reason above, not the clipping one — and the shipped
comment now says so.

Applied unconditionally, the join also said the same thing twice on every
non-snippet banner: `A session finished` / `Complete — Task complete`, which is
what **every** user with the session-name privacy flag off receives (D2). The
status now leads **only** a model-written snippet, keyed on the payload's own
`body_is_snippet`. House bodies render bare. §8.4 is intact: the strings remain
the backend's and the flag deciding the join is the backend's too.

## Gates

| Gate | Result |
|---|---|
| `pnpm lint` | pass — 24 warnings, **0 errors**, identical to the pre-change baseline on this branch |
| `pnpm check-types` | pass — main and renderer projects both clean |
| `pnpm test:desktop` | pass — **217/217**, including the 23 new ones |
| `pnpm build` | pass — real `electron-vite build`, exit 0 |
| `pnpm check-themes` | **not run, and not applicable** — no palette, token or component touched; `git diff --stat` covers only `src/main/*`, `src/shared/*` and `scripts/` |

## Evidence

### The delivery sink: 23 new tests, T-U1..T-U16

`scripts/desktop-notifier.test.mjs`, registered in `test:desktop`. It bundles the
**shipped** TypeScript in memory (same esbuild harness as
`desktop-contract.test.mjs`) and extends the electron fixture with a fake
`Notification` that records constructor arguments. The point is not that "a
notification happened" — it is that the exact strings reached the OS boundary, and
that the ones which must not reach it never got there.

Covered: verbatim strings (T-U1); focus gate suppresses **and takes no claim**
(T-U2); one `dedupe_key` ⇒ one toast and one claim (T-U3); lost claim (T-U4);
rejected/500/404 all fail closed (T-U5); `contract >= 1` silences `agent_end`
(T-U6); legacy `agent_end` toasts while `turn_end` never does (T-U7); unknown
future frame type ignored without throwing (T-U8); untitled `ask` ⇒ "Question"
(T-U9); `sessions.seen` never emitted (T-U10). Plus: `focus_policy: "always"`
ignores focus, an unsupported platform claims nothing, and every degraded
capability value lands on legacy rather than on silence.

**The ordering test bites.** Mutating the source to claim before the focus gate —
the exact regression section 7.3 exists to prevent — fails T-U2 alone and leaves
the other 13 green:

```
✖ a focused window suppresses the toast AND never takes the claim
ℹ pass 13   ℹ fail 1
```

### The real OS boundary

`scripts/notification-evidence.mjs` (new, reusable) stages an Electron app around
itself and drives the **real** `DesktopNotifier` with the **real** Electron
`Notification` class — no mock — against a loopback stand-in for `/notified`. Run
from a packaged `electron-builder --dir` bundle. Output from the real run:

```
[complete-with-snippet]
  title : Quarterly revenue model
  body  : Complete — Rebuilt the forecast with the Q3 actuals and reconciled the 4.2% variance against the ledger.

[complete-privacy-flag-off]
  title : Local Operator
  body  : Complete — Task complete.

[error]
  title : Nightly ETL backfill
  body  : Needs attention — The turn ended with an error.

[gate-ask-untitled]
  title : Question
  body  : Which environment should this deploy to?

[gate-approval]
  title : Run database migration
  body  : This applies 00061_add_watchlist_release to the prod-2 cluster.

claims posted: 3 (one per completion frame)
```

**3 claims for 3 completions, 0 for the 2 gates** — the gate path takes no
delivery claim, as designed.

### What I could NOT capture, plainly

**No screenshot of a rendered macOS banner.** I did not get one, and I am not
implying otherwise. Two blockers, both environmental:

1. A dev `electron` binary is not registered with macOS Notification Center, so
   `new Notification()` succeeds, `isSupported()` returns true, and nothing is
   ever displayed. Confirmed with a minimal probe: `show` fired, no banner.
2. Packaging a real app got further — the app ran, the notifier ran, the claims
   posted — but this machine could not code-sign it (no valid Developer ID
   identity), and macOS raised the **"Local Operator Notifications"** permission
   prompt for the ad-hoc-signed bundle and held delivery behind it. Answering that
   prompt is an operator action, not an agent one.

Mid-run the machine also hit **"Your system has run out of application memory"**
(11.8 GB of 13 GB swap in use, from other sessions on this shared box). I stopped
launching app instances at that point, killed only my own, and removed my
`dist/` (743 MB) and temp bundles rather than keep pushing.

So the honest state at round 1: **the exact strings reaching the real Electron
`Notification` constructor are proven, in a real Electron process, and the claim
ordering is proven by a mutation test.** The harness is committed under
`scripts/`, so capturing the banner on a machine with a signed build is a single
command.

**Pixels now exist.** The design round obtained rendered macOS banners by posting
the exact composed strings through an already-registered system bundle, and the
remediation round re-captured the two banners D2 changes plus D3's new gate shape
(`/tmp/notif-r2-frames/*.png` on the review box; transcriptions in the design
remediation comment). That method proves macOS's own line breaking and layout for
these strings; it does not prove this app's icon and attribution, does not
exercise Electron's `Notification` options, and says nothing about Windows or
Linux.

## Review round 1 remediation

Round 1 (reviewer + designer) is answered in one batched commit,
`e954ff3398c3a022c906626e1a340943c1f5a83f`. Per-finding replies are in the
`### Agent review remediation — round 1` and `### Design review remediation —
round 1` comments.

| Finding | Disposition |
|---|---|
| **R1** blocker — capability read fired before the backend existed | fixed — read tied to backend-ready, legacy toast deferred behind an *answered* read |
| **M1** major — a failed claim burned the dedupe key | fixed — `claimDelivery` distinguishes `lost` from `failed`; only a clean loss keeps the key |
| **M2** major — the latch was irreversible and its JSDoc lied | fixed by removal — the capability is re-read in both directions |
| **D1** major — evidence artifact rendered copy that will never ship | fixed — fixtures match `notify.py`'s `BODY_*`, and the script now logs the strings actually sent |
| **D2** major — `status — body` said one fact twice | fixed — status leads only a `body_is_snippet` body |
| **D3** major — gate banners named no session | fixed — renders the backend's additive optional `session_name`; absent/empty unchanged |
| **D6** nit — empty gate detail rendered a bodiless banner | fixed — guard added |
| **D4** major — the error banner says only that something stopped | agreed, **backend's fix**; holds the feature's release, not this PR |
| **D5**, **D7** | no action, as the designer scoped them |
| reviewer's **m2**, **m3**, **n1** | not addressed — speculative hardening against a `contract: 2` that does not exist |

Each fix is mutation-verified: reverting it alone fails its test and no other.

## Not addressed

- `docs/desktop-controls.md` does not list the new op. Its control-operation
  section predates several existing ops and is not a per-op registry, so adding
  one row seemed like scope creep; flagging rather than deciding.
- **D3's `session_name` is not yet exercisable end to end.** The field is
  additive and optional on the pending-gate payload and the backend PR is still
  adding it, so the UI is implemented against the contract and proven at its own
  boundary (absent/empty/whitespace all covered). The named shape needs QA's
  cross-repo pass.
- The backend PR is not open yet, so the frame shape here is validated against the
  design document, not against a live emitter. Cross-checking the two is the first
  thing the QA round should do.

