### PR TITLE
fix(release,update): notarize the disk images at an absolute path, and state the watchdog's platform

### DIFF
--- a/scripts/notarize-artifacts.mjs
+++ b/scripts/notarize-artifacts.mjs
@@ -32,7 +32,7 @@ import {
 	statSync,
 	writeFileSync,
 } from "node:fs";
-import { basename, join } from "node:path";
+import { basename, join, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 import { notarize } from "@electron/notarize";
 import { loadBuildEnv } from "./build-env.mjs";
@@ -191,19 +191,30 @@ export async function notarizeArtifacts({ dist, artifactPaths, log = console.log
 	}
 	if (env.loaded) log(`Loaded build environment from ${env.path}`);
 
-	const discovered = existsSync(dist) ? readdirSync(dist) : [];
+	// Absolute paths, resolved once here so every consumer below gets the same
+	// one. `--dist dist` (the default, and what CI runs) makes these paths
+	// relative to the working directory, and `@electron/notarize` resolves a
+	// relative `appPath` for a `.dmg`/`.pkg` against ITS OWN submission temp dir
+	// (`path.resolve(dir, opts.appPath)` in lib/notarytool.js), where the image
+	// of course does not exist - the 0.17.2 release failed in the notarytool
+	// submission for exactly that reason. The app bundle never hit it because
+	// `afterSign` is handed an absolute `appOutDir` by electron-builder. The
+	// staple and re-hash use the same path, so resolving at discovery keeps one
+	// answer for submit, staple, hash, size and the transient-zip cleanup.
+	const distDir = resolve(dist);
+	const discovered = existsSync(distDir) ? readdirSync(distDir) : [];
 	const dmgs = dmgArtifacts(
 		artifactPaths ??
 			discovered
 				.filter((name) => name.endsWith(".dmg"))
-				.map((name) => join(dist, name)),
-	);
+				.map((name) => join(distDir, name)),
+	).map((dmgPath) => resolve(dmgPath));
 	if (dmgs.length === 0) {
-		log(`No disk images found in ${dist}`);
+		log(`No disk images found in ${distDir}`);
 		return { notarized: [] };
 	}
 
-	const ymlFiles = updateYmlFiles(dist);
+	const ymlFiles = updateYmlFiles(distDir);
 	const notarized = [];
 
 	for (const dmgPath of dmgs) {

--- a/scripts/update-robustness.test.mjs
+++ b/scripts/update-robustness.test.mjs
@@ -12,7 +12,7 @@ import {
 	writeFileSync,
 } from "node:fs";
 import { homedir, tmpdir } from "node:os";
-import { dirname, join } from "node:path";
+import { dirname, isAbsolute, join, relative, resolve } from "node:path";
 import { after, before, test } from "node:test";
 import { build } from "esbuild";
 
@@ -123,6 +123,70 @@ const {
 	rewriteUpdateMetadata,
 	updateUpdateYmlEntry,
 } = await import("./notarize-artifacts.mjs");
+
+/**
+ * The disk image step's real code, bundled with the notarizer stubbed.
+ *
+ * The property this covers is the path the step hands the notarizer, and only a
+ * stub can read it: the real `@electron/notarize` uploads to Apple, which no
+ * developer machine and no CI runner can reach, so a wrong path there is a
+ * failure that exists only in a release build. 0.17.2 shipped a relative one -
+ * `@electron/notarize`'s `lib/notarytool.js` does `path.resolve(dir, opts.appPath)`
+ * for a `.dmg`/`.pkg` with `dir` its own submission temp dir, so the image was
+ * looked for inside that temp dir and the step reported "The file couldn't be
+ * opened because it doesn't exist".
+ *
+ * Bundled rather than imported so the fixture can be substituted, the same
+ * mechanic the Electron fixture below uses. Everything else in the bundle is the
+ * shipped module: the discovery, the absolute-path resolution, the submit →
+ * staple → re-hash → rewrite ordering, and the failure handling.
+ */
+const notarizeStepBundle = await build({
+	stdin: {
+		contents: 'export * from "./scripts/notarize-artifacts.mjs";',
+		resolveDir: process.cwd(),
+	},
+	bundle: true,
+	format: "esm",
+	platform: "node",
+	write: false,
+	// `build-env.mjs` reaches dotenv, a CJS dependency esbuild cannot `require`
+	// from ESM output without the shim the Electron fixture also carries.
+	banner: {
+		js: 'import { createRequire as __loCreateRequire } from "node:module"; const require = __loCreateRequire(import.meta.url);',
+	},
+	plugins: [
+		{
+			name: "notarize-fixture",
+			setup(builder) {
+				builder.onResolve({ filter: /^@electron\/notarize$/ }, () => ({
+					path: "@electron/notarize",
+					namespace: "notarize-fixture",
+				}));
+				builder.onLoad(
+					{ filter: /.*/, namespace: "notarize-fixture" },
+					() => ({
+						loader: "js",
+						contents: `
+							export const notarize = async (opts) => {
+								globalThis.__loNotarizeCalls.push({ appPath: opts.appPath, tool: opts.tool });
+								const behavior = globalThis.__loNotarizeBehavior;
+								if (behavior) await behavior(opts);
+							};
+						`,
+					}),
+				);
+			},
+		},
+	],
+});
+const notarizeStepDir = mkdtempSync(join(tmpdir(), "lo-notarize-step-"));
+const notarizeStepFile = join(notarizeStepDir, "notarize-artifacts.mjs");
+writeFileSync(notarizeStepFile, notarizeStepBundle.outputFiles[0].text);
+// Imported from a real path rather than a `data:` URL: the banner shim needs an
+// `import.meta.url` that `createRequire` can resolve.
+const { notarizeArtifacts } = await import(notarizeStepFile);
+rmSync(notarizeStepDir, { recursive: true, force: true });
 const {
 	artifactChecks,
 	discoverApp,
@@ -1874,6 +1938,248 @@ test("stapling fails when the entry is listed but nothing was rewritten", () => 
 			}),
 		/no update metadata was found to re-hash it in/,
 	);
+});
+
+/**
+ * The notarizer is handed an absolute path, whatever form `--dist` took.
+ *
+ * Why absolute is the assertion rather than "the file exists": the failure this
+ * covers only shows up inside `@electron/notarize`, which resolves the path
+ * against its own temp dir before uploading, so a relative path that is perfectly
+ * valid from the working directory is invalid by the time it is used. 0.17.2's
+ * publish run failed in the submission step with "The file couldn't be opened
+ * because it doesn't exist" for a path under `T/electron-notarize-*`, which is
+ * that temp dir - the image was never there. `--dist dist` is the default and
+ * what CI runs, so the relative case is the one that shipped the bug; the
+ * absolute case and a relative entry in `artifactPaths` are here because the two
+ * spellings of the same directory must not disagree.
+ *
+ * The image is real (a few bytes) and the metadata is real, because the step
+ * hashes and rewrites them after the staple; only the notarizer is a stub.
+ */
+test("the notarization step hands the notarizer an absolute path", async () => {
+	const root = tempDir("lo-notarize-");
+	const dist = join(root, "dist");
+	mkdirSync(dist, { recursive: true });
+	const imageName = "local-operator-ui-0.18.0-universal.dmg";
+	const imagePath = join(dist, imageName);
+	writeFileSync(imagePath, "disk image");
+	const ymlPath = join(dist, "latest-mac.yml");
+	writeFileSync(
+		ymlPath,
+		[
+			"version: 0.18.0",
+			"files:",
+			`  - url: ${imageName}`,
+			"    sha512: PRE_STAPLE",
+			"    size: 10",
+			"",
+		].join("\n"),
+		"utf8",
+	);
+
+	const platform = Object.getOwnPropertyDescriptor(process, "platform");
+	const savedEnv = {
+		NOTARIZE: process.env.NOTARIZE,
+		APPLE_ID: process.env.APPLE_ID,
+		APPLE_ID_PASSWORD: process.env.APPLE_ID_PASSWORD,
+		APPLE_TEAM_ID: process.env.APPLE_TEAM_ID,
+	};
+	try {
+		// The step is darwin-only and `test:desktop` runs on Linux CI, but the bug
+		// is a path resolution mistake with nothing macOS about it, so the platform
+		// check is satisfied rather than skipped. Restored in the `finally`.
+		Object.defineProperty(process, "platform", {
+			value: "darwin",
+			configurable: true,
+		});
+		process.env.NOTARIZE = "true";
+		process.env.APPLE_ID = "test@example.invalid";
+		process.env.APPLE_ID_PASSWORD = "test-app-specific-password";
+		process.env.APPLE_TEAM_ID = "TESTTEAM01";
+		globalThis.__loNotarizeCalls = [];
+		delete globalThis.__loNotarizeBehavior;
+
+		// The default CI invocation: `--dist` relative to the working directory.
+		const relativeDist = relative(process.cwd(), dist);
+		assert.equal(isAbsolute(relativeDist), false, relativeDist);
+		await notarizeArtifacts({ dist: relativeDist, log: () => {} });
+		assert.equal(globalThis.__loNotarizeCalls.length, 1);
+		assert.equal(globalThis.__loNotarizeCalls[0].tool, "notarytool");
+		assert.equal(
+			isAbsolute(globalThis.__loNotarizeCalls[0].appPath),
+			true,
+			`a relative --dist reached the notarizer as ${globalThis.__loNotarizeCalls[0].appPath}`,
+		);
+		assert.equal(globalThis.__loNotarizeCalls[0].appPath, resolve(dist, imageName));
+		// The staple, hash and rewrite all finished on that same file: a wrong path
+		// here would have thrown before the rewrite, leaving the pre-staple hash.
+		assert.match(readFileSync(ymlPath, "utf8"), /sha512: [A-Za-z0-9+/=]{16}/);
+		assert.equal(readFileSync(ymlPath, "utf8").includes("PRE_STAPLE"), false);
+
+		// An absolute `--dist`, and a relative entry in `artifactPaths`, resolve to
+		// the same absolute image.
+		for (const invocation of [
+			{ dist },
+			{ dist, artifactPaths: [relative(process.cwd(), imagePath)] },
+		]) {
+			globalThis.__loNotarizeCalls.length = 0;
+			await notarizeArtifacts({ ...invocation, log: () => {} });
+			assert.equal(globalThis.__loNotarizeCalls.length, 1);
+			assert.equal(globalThis.__loNotarizeCalls[0].appPath, resolve(imagePath));
+		}
+	} finally {
+		if (platform) Object.defineProperty(process, "platform", platform);
+		for (const [key, value] of Object.entries(savedEnv)) {
+			if (value === undefined) delete process.env[key];
+			else process.env[key] = value;
+		}
+		delete globalThis.__loNotarizeCalls;
+		delete globalThis.__loNotarizeBehavior;
+	}
+});
+
+/**
+ * A rejected notarization fails the step, and the CLI exits non-zero.
+ *
+ * The release that hit this bug reported "Disk image notarization failed" and
+ * failed the job, so the loud half is not the regression - it is the property the
+ * fix must not trade away, and the reason it is asserted through the real
+ * entrypoint (a child process running the shipped script with the notarizer
+ * stubbed by a module resolution hook) rather than only through the exported
+ * function: a catch added around the submission later would leave the first
+ * assertion green and turn this step into a silent no-op that ships an
+ * unnotarized image.
+ *
+ * The stub also records the path it was handed, so this doubles as a check that
+ * the relative `--dist` the CI invocation uses reaches the notarizer absolute on
+ * the real command line.
+ */
+test("a rejected notarization fails the step and exits non-zero", async () => {
+	const root = tempDir("lo-notarize-fail-");
+	const dist = join(root, "dist");
+	mkdirSync(dist, { recursive: true });
+	const imageName = "local-operator-ui-0.18.0-universal.dmg";
+	writeFileSync(join(dist, imageName), "disk image");
+	const ymlPath = join(dist, "latest-mac.yml");
+	const preStapleYml = [
+		"version: 0.18.0",
+		"files:",
+		`  - url: ${imageName}`,
+		"    sha512: PRE_STAPLE",
+		"    size: 10",
+		"",
+	].join("\n");
+	writeFileSync(ymlPath, preStapleYml, "utf8");
+
+	const platform = Object.getOwnPropertyDescriptor(process, "platform");
+	const savedEnv = {
+		NOTARIZE: process.env.NOTARIZE,
+		APPLE_ID: process.env.APPLE_ID,
+		APPLE_ID_PASSWORD: process.env.APPLE_ID_PASSWORD,
+		APPLE_TEAM_ID: process.env.APPLE_TEAM_ID,
+	};
+	try {
+		Object.defineProperty(process, "platform", {
+			value: "darwin",
+			configurable: true,
+		});
+		process.env.NOTARIZE = "true";
+		process.env.APPLE_ID = "test@example.invalid";
+		process.env.APPLE_ID_PASSWORD = "test-app-specific-password";
+		process.env.APPLE_TEAM_ID = "TESTTEAM01";
+		globalThis.__loNotarizeCalls = [];
+		globalThis.__loNotarizeBehavior = async () => {
+			throw new Error("stubbed notarization rejected");
+		};
+		await assert.rejects(
+			notarizeArtifacts({ dist, log: () => {} }),
+			/stubbed notarization rejected/,
+		);
+		// Nothing after the submission ran: the image was not re-hashed, so its
+		// metadata still describes the bytes on disk rather than a staple that never
+		// happened.
+		assert.equal(readFileSync(ymlPath, "utf8"), preStapleYml);
+	} finally {
+		if (platform) Object.defineProperty(process, "platform", platform);
+		for (const [key, value] of Object.entries(savedEnv)) {
+			if (value === undefined) delete process.env[key];
+			else process.env[key] = value;
+		}
+		delete globalThis.__loNotarizeCalls;
+		delete globalThis.__loNotarizeBehavior;
+	}
+
+	// A module resolution hook substitutes the notarizer for the child, because the
+	// shipped script imports it directly; no build step or source rewrite is
+	// involved, so the entrypoint under test is the file the release runs.
+	const hookDir = join(root, "hook");
+	mkdirSync(hookDir, { recursive: true });
+	const probeFile = join(root, "notarized-path.txt");
+	writeFileSync(
+		join(hookDir, "register.mjs"),
+		[
+			'import { register } from "node:module";',
+			// The step is darwin-only and this suite runs on Linux CI, so the platform
+			// it checks is satisfied rather than skipped. The bug is a path resolution
+			// mistake with nothing macOS about it: the submission never gets far enough
+			// for Apple to be involved, and the stub answers instead of the service.
+			'Object.defineProperty(process, "platform", { value: "darwin", configurable: true });',
+			'register("./resolve.mjs", import.meta.url);',
+			"",
+		].join("\n"),
+	);
+	writeFileSync(
+		join(hookDir, "resolve.mjs"),
+		[
+			"export async function resolve(specifier, context, next) {",
+			'\tif (specifier === "@electron/notarize") {',
+			'\t\treturn { url: new URL("./stub.mjs", import.meta.url).href, shortCircuit: true };',
+			"\t}",
+			"\treturn next(specifier, context);",
+			"}",
+			"",
+		].join("\n"),
+	);
+	writeFileSync(
+		join(hookDir, "stub.mjs"),
+		[
+			'import { writeFileSync } from "node:fs";',
+			"export async function notarize(opts) {",
+			"\twriteFileSync(process.env.LO_NOTARIZE_PROBE_FILE, opts.appPath);",
+			'\tthrow new Error("stubbed notarization rejected");',
+			"}",
+			"",
+		].join("\n"),
+	);
+
+	const result = spawnSync(
+		process.execPath,
+		[
+			"--import",
+			join(hookDir, "register.mjs"),
+			"scripts/notarize-artifacts.mjs",
+			"--dist",
+			relative(process.cwd(), dist),
+		],
+		{
+			cwd: process.cwd(),
+			encoding: "utf8",
+			env: {
+				...process.env,
+				NOTARIZE: "true",
+				APPLE_ID: "test@example.invalid",
+				APPLE_ID_PASSWORD: "test-app-specific-password",
+				APPLE_TEAM_ID: "TESTTEAM01",
+				LO_NOTARIZE_PROBE_FILE: probeFile,
+			},
+		},
+	);
+	assert.notEqual(result.status, 0, `expected a non-zero exit, got ${result.status}`);
+	assert.match(result.stderr, /Disk image notarization failed/);
+	assert.match(result.stderr, /stubbed notarization rejected/);
+	assert.equal(isAbsolute(readFileSync(probeFile, "utf8")), true);
+	assert.equal(readFileSync(probeFile, "utf8"), resolve(dist, imageName));
 });
 
 /**

--- a/scripts/update-robustness.test.mjs
+++ b/scripts/update-robustness.test.mjs
@@ -82,6 +82,7 @@ const {
 	readInstallIdentity,
 	resolveCommandPath,
 	watchdogIsOurs,
+	watchdogSignals,
 	watchdogSwapTarget,
 	writePendingInstallMarker,
 } = install;
@@ -519,14 +520,19 @@ test("the watchdog is built from the app's pid and the ShipIt job, not a name pa
 
 	// No name probe survives in the executable part of the script (the comments
 	// mention pgrep to explain why it is gone), and both real signals are in it:
-	// the app's own pid, and the job label.
+	// the app's own pid, and the job label - asked of the probe the plan resolved
+	// for the platform it is planned for, which on macOS is `launchctl`. Naming
+	// the command in the script is what made the darwin branch unassertable off a
+	// Mac and what let the swap-landed case pass here and fail on ubuntu-latest.
 	const code = plan.script
 		.split("\n")
 		.filter((line) => !line.trimStart().startsWith("#"))
 		.join("\n");
 	assert.doesNotMatch(code, /pgrep/);
 	assert.match(code, /kill -0 "\$APP_PID"/);
-	assert.match(code, /launchctl list "\$SHIPIT_JOB"/);
+	assert.match(code, /"\$SHIPIT_PROBE" list "\$SHIPIT_JOB"/);
+	assert.equal(plan.env.LO_UPDATE_WATCHDOG_SHIPIT_PROBE, "launchctl");
+	assert.equal(plan.env.LO_UPDATE_WATCHDOG_PLIST_READER, "/usr/bin/plutil");
 
 	// The relaunch attempt is not conditional on reaching the end of a wait: the
 	// deadline path falls through to it (review Q1), and the decision it waits on
@@ -536,8 +542,9 @@ test("the watchdog is built from the app's pid and the ShipIt job, not a name pa
 	assert.match(plan.script, /open -a "\$BUNDLE"/);
 	assert.match(plan.script, new RegExp(WATCHDOG_TOKEN));
 	// The on-disk half of the decision: the version in the target bundle's own
-	// Info.plist, read with plutil rather than through a preference domain.
-	assert.match(plan.script, /plutil -extract CFBundleShortVersionString raw/);
+	// Info.plist, read by the platform's plist reader (`plutil` on macOS) rather
+	// than through a preference domain.
+	assert.match(plan.script, /"\$PLIST_READER" -extract CFBundleShortVersionString raw/);
 	assert.match(plan.script, /LO_UPDATE_WATCHDOG_TARGET_VERSION/);
 	/*
 	 * And that read is bounded, because it runs inside the poll loop: an
@@ -651,6 +658,24 @@ function runWatchdog({ plan, binDir }) {
 }
 
 /**
+ * Whether the watchdog's own process group has been vacated.
+ *
+ * `runWatchdog` spawns the script detached, so it leads its own group and
+ * anything it starts - the relaunch, a backgrounded read - is a member. 
+ * `kill(-pgid, 0)` raises ESRCH on an empty group, which is the check the branch
+ * with no signals needs: its only route to a relaunch is the bound, and a bound
+ * that leaves a process behind is the one thing that branch could add.
+ */
+function processGroupIsEmpty(pid) {
+	try {
+		process.kill(-pid, 0);
+		return false;
+	} catch (error) {
+		return error.code === "ESRCH";
+	}
+}
+
+/**
  * A fixture "app" bundle plus the two commands the watchdog shells out to.
  *
  * The bundle carries a real `Info.plist` because the swap's own state is read
@@ -691,12 +716,49 @@ function makeWatchdogFixture(dir, version = "0.17.0") {
 		`#!/bin/sh\nif [ "$1" = "list" ]; then\n\tif [ -f "${stateFile}" ]; then exit 0; fi\n\texit 113\nfi\nexit 0\n`,
 		"utf8",
 	);
-	spawnSync("/bin/chmod", ["+x", openShim, launchctlShim, executable]);
+	/*
+	 * The plist reader, in the shape the script invokes it: `-extract
+	 * CFBundleShortVersionString raw -o - <plist>`.
+	 *
+	 * Substituted rather than used for real, for the same reason `launchctl` is:
+	 * the shipped one is `/usr/bin/plutil`, an absolute path that does not exist
+	 * off macOS, and a probe a test cannot install is not one the script's
+	 * behaviour can be asserted against. Taking it from the host is how the
+	 * swap-landed case came to assert a macOS-only early exit on ubuntu-latest.
+	 * The tags are stripped so the same shim reads the fixture's plist whether the
+	 * key and its string share a line or not, and an invocation the script does
+	 * not make is refused rather than answered.
+	 */
+	const plistReaderShim = join(binDir, "plutil");
+	writeFileSync(
+		plistReaderShim,
+		`#!/bin/sh
+case "$*" in
+	*"-extract CFBundleShortVersionString raw"*) ;;
+	*) echo "unexpected plutil invocation: $*" >&2; exit 1 ;;
+esac
+plist=""
+for arg in "$@"; do plist="$arg"; done
+[ -n "$plist" ] && [ -r "$plist" ] || exit 1
+tr -d '\\n\\t' < "$plist" | sed -n 's|.*<key>CFBundleShortVersionString</key><string>\\([^<]*\\)</string>.*|\\1|p'
+`,
+		"utf8",
+	);
+	spawnSync("/bin/chmod", [
+		"+x",
+		openShim,
+		launchctlShim,
+		plistReaderShim,
+		executable,
+	]);
 
 	return {
 		bundle,
 		binDir,
 		stateFile,
+		// Both probes, so the darwin plan can be driven on any host: the script
+		// calls the command the plan names, and the plan is the platform's.
+		probes: { jobProbe: launchctlShim, plistReader: plistReaderShim },
 		launchLog: log,
 		setVersion,
 		launches: () =>
@@ -748,6 +810,11 @@ test("the watchdog relaunches a real process tree and never exits without trying
 			executableName: "Fixture",
 			appPid: pid,
 			shipItJob: "com.local-operator.ShipIt",
+			// The darwin plan, with both probes pointed at the fixtures above: the
+			// branch under test is the platform's, and a test host has neither
+			// `launchctl`'s domain to ask nor a `plutil` to read with.
+			platform: "darwin",
+			signals: fixture.probes,
 			...fast,
 			...overrides,
 		});
@@ -835,6 +902,13 @@ test("the watchdog leaves early when the swap has landed, job or no job", async 
 			appPid: pid,
 			shipItJob: "com.local-operator.ShipIt",
 			targetVersion: "0.18.0",
+			// The darwin plan, with both probes pointed at the fixtures: the swap
+			// this case waits on is read through the plist-reader shim, so the case
+			// asserts the branch wherever it runs instead of only where `plutil`
+			// happens to exist (which is how it passed on a Mac and failed on
+			// ubuntu-latest).
+			platform: "darwin",
+			signals: fixture.probes,
 			// A bound long enough that reaching it is distinguishable from leaving
 			// on the swap: a pass here cannot be a pass by timeout.
 			timeoutSeconds: 120,
@@ -948,6 +1022,91 @@ test("the watchdog leaves early when the swap has landed, job or no job", async 
 		assert.equal(await waitForLaunches(fixture, before + 1), true);
 		assert.ok(elapsed < 10000, `expected no appear window, took ${elapsed}ms`);
 	}
+});
+
+/**
+ * The branch for a platform with neither probe: the bound decides, and alone.
+ *
+ * Why this case is not decoration: the app's watchdog is macOS-only (its caller
+ * refuses to plan one anywhere else), but the script's two probes were not stated
+ * anywhere - they were whatever the host that generated the script happened to
+ * have. `plutil` exists only on macOS, so the swap-landed case above asserted an
+ * early exit that could not fire on the CI runner, and `main` went red on every
+ * push from the commit that added it (runs 34695505505, 34695566539, 34696129340,
+ * 34699012497: `expected the swap to end the wait, took 126265ms`). The fix is
+ * that the platform is in the plan (see `watchdogSignals`), and this is the other
+ * half of it: a plan for a platform without launchd or plutil must still behave,
+ * and must not read "cannot ask" as an answer.
+ *
+ * The fixture is in the shape that ends the wait in seconds on the darwin branch -
+ * the job's state file is loaded and the bundle already reports the target
+ * version - so a false early exit here is visible as one. Neither tool is
+ * provided to this run, and the assertions also pin that the script names
+ * neither, so a later edit cannot quietly reintroduce a dependency on a tool the
+ * platform lacks.
+ */
+test("without launchd or plutil the bound decides, and nothing is left behind", async () => {
+	const dir = tempDir("lo-watchdog-nosignals-");
+	const fixture = makeWatchdogFixture(dir, "0.18.0");
+	const planFor = (pid, overrides = {}) =>
+		buildWatchdogPlan({
+			appBundlePath: fixture.bundle,
+			executableName: "Fixture",
+			appPid: pid,
+			shipItJob: "com.local-operator.ShipIt",
+			targetVersion: "0.18.0",
+			timeoutSeconds: 4,
+			intervalSeconds: 1,
+			settleSeconds: 1,
+			appearSeconds: 1,
+			platform: "linux",
+			...overrides,
+		});
+
+	// The resolution itself: a platform with neither tool gets neither probe.
+	assert.deepEqual(watchdogSignals("linux"), {
+		jobProbe: null,
+		plistReader: null,
+	});
+	const shape = planFor(1);
+	assert.equal(shape.env.LO_UPDATE_WATCHDOG_SHIPIT_PROBE, "");
+	assert.equal(shape.env.LO_UPDATE_WATCHDOG_PLIST_READER, "");
+	const code = shape.script
+		.split("\n")
+		.filter((line) => !line.trimStart().startsWith("#"))
+		.join("\n");
+	assert.doesNotMatch(code, /launchctl|plutil/);
+
+	// Both signals that end the wait early on macOS are in their "decided" shape
+	// here - the job is loaded, the bundle reports the target version - and still
+	// cannot end it: the bound is the only decider left, so the app comes back at
+	// ~4s plus the settle, never before.
+	writeFileSync(fixture.stateFile, "loaded\n", "utf8");
+	const app = startProcess("/bin/sleep", ["30"]);
+	const before = fixture.launches().length;
+	const watchdog = runWatchdog({ plan: planFor(app.pid), binDir: fixture.binDir });
+	const started = Date.now();
+	app.kill();
+	const result = await watchdog.exit;
+	const elapsed = Date.now() - started;
+	assert.equal(result.code, 0);
+	assert.ok(
+		elapsed >= 3000,
+		`expected the bound to decide, exited after ${elapsed}ms`,
+	);
+	assert.equal(await waitForLaunches(fixture, before + 1), true);
+	assert.equal(fixture.launches().length, before + 1);
+	assert.match(fixture.launches()[before], /open -a /);
+	// And nothing of the watchdog's own is left running: the script is spawned
+	// detached, so it leads its own process group, and an empty group is the whole
+	// of what "no orphan" means here.
+	await new Promise((resolve) => setTimeout(resolve, 300));
+	assert.equal(
+		processGroupIsEmpty(watchdog.child.pid),
+		true,
+		"the watchdog left a process in its own group",
+	);
+	rmSync(fixture.stateFile, { force: true });
 });
 
 /**
@@ -2749,7 +2908,7 @@ test("a version read that never answers is killed, not left running", () => {
 	const read = plan.script.match(/^bundle_version\(\) \{\n[\s\S]*?^\}$/m);
 	assert.ok(read, "bundle_version is in the generated script");
 	const substituted = read[0].replace(
-		/\/usr\/bin\/plutil -extract CFBundleShortVersionString raw -o - "\$_plist"/,
+		/"\$PLIST_READER" -extract CFBundleShortVersionString raw -o - "\$_plist"/,
 		`/bin/sleep ${hangSeconds}`,
 	);
 	assert.notEqual(substituted, read[0], "the reader was substituted");

--- a/src/main/update-install.ts
+++ b/src/main/update-install.ts
@@ -74,11 +74,12 @@ export const WATCHDOG_TIMEOUT_SECONDS = 600;
 /**
  * How long the watchdog's on-disk version read may take before it is killed.
  *
- * The read is `plutil` on the target bundle's own Info.plist for every poll, and
- * the path is `/Applications` in every real layout - so a real read is
- * milliseconds and this bound only ever fires on a path whose mount has stopped
- * answering, where the alternative is a read that outlives the script's own
- * deadline and leaves the user with no app at all (review R17).
+ * The read is the plan's plist reader (`plutil`) on the target bundle's own
+ * Info.plist for every poll, and the path is `/Applications` in every real
+ * layout - so a real read is milliseconds and this bound only ever fires on a
+ * path whose mount has stopped answering, where the alternative is a read that
+ * outlives the script's own deadline and leaves the user with no app at all
+ * (review R17).
  */
 export const PLIST_READ_TIMEOUT_SECONDS = 5;
 
@@ -826,6 +827,12 @@ export type WatchdogPlan = {
  * before: `sh -c` puts the script in its own command line, and a script
  * carrying `/Applications/Local Operator.app/...` would show up in any process
  * listing of it.
+ *
+ * The two probes travel the same way, and they are the reason the plan carries a
+ * platform at all (`watchdogSignals`): both are macOS tools, so the script is
+ * generated for the platform it will run on rather than reading them off
+ * whichever host built it. Only the app calls this in production, on macOS, and
+ * it says so with `platform: "darwin"`.
  */
 /**
  * The version the watchdog's on-disk swap check may be handed, or null.
@@ -856,6 +863,39 @@ export function watchdogSwapTarget(input: {
 	return input.target;
 }
 
+export type WatchdogSignals = {
+	/** The command that asks launchd about a job by label, or null off macOS. */
+	jobProbe: string | null;
+	/** The command that reads a bundle's own Info.plist version, or null off macOS. */
+	plistReader: string | null;
+};
+
+/**
+ * The probes the watchdog script may use, from the platform it is planned for.
+ *
+ * Why the platform is carried in the plan rather than assumed: both signals the
+ * script waits on are macOS tools - launchd's `launchctl list <label>` and
+ * `/usr/bin/plutil` reading the bundle's own version - so a script generated on
+ * a host without them asks questions nothing can answer. That is not a
+ * hypothetical: the swap-landed case of the watchdog's own test asserted an
+ * early exit that could only fire where `plutil` exists, passed on the developer
+ * machine it was written on, and failed on `ubuntu-latest` on every push from
+ * the commit that added it (`expected the swap to end the wait, took 126265ms` -
+ * the read answered nothing on every poll, so the wait ran out its 120s bound).
+ * A test that reads its probe availability off its own host is not a test of the
+ * platform the app runs on.
+ *
+ * `null` means the platform has the tool nowhere, and the script treats it as an
+ * unavailable signal rather than as a negative answer: no job probe cannot mean
+ * "the job is not loaded", and no reader cannot mean "the swap has not landed".
+ * The bound is then the only decider, which still relaunches at the deadline and
+ * still never exits silently.
+ */
+export function watchdogSignals(platform: NodeJS.Platform): WatchdogSignals {
+	if (platform !== "darwin") return { jobProbe: null, plistReader: null };
+	return { jobProbe: "launchctl", plistReader: "/usr/bin/plutil" };
+}
+
 export function buildWatchdogPlan(input: {
 	appBundlePath: string;
 	executableName: string;
@@ -872,7 +912,25 @@ export function buildWatchdogPlan(input: {
 	appearSeconds?: number;
 	/** How long the on-disk version read may take before it is killed. */
 	plistReadTimeoutSeconds?: number;
+	/**
+	 * The platform the script is planned for. Defaults to `darwin`: this watchdog
+	 * exists for Squirrel.Mac's ShipIt and nothing else, and a caller that says
+	 * nothing gets the platform the feature is for.
+	 */
+	platform?: NodeJS.Platform;
+	/**
+	 * The probes to generate into the script, when the caller has its own.
+	 *
+	 * A seam, and the only one here: the darwin plan cannot be driven anywhere
+	 * without fixtures for both probes - `/usr/bin/plutil` does not exist off
+	 * macOS, and the real `launchctl` would ask the launchd domain of whoever runs
+	 * the test - so the caller can substitute the two commands and the darwin
+	 * branch is exercised on any host instead of only on a Mac. Production passes
+	 * neither this nor `platform` and gets `watchdogSignals("darwin")`.
+	 */
+	signals?: WatchdogSignals;
 }): WatchdogPlan {
+	const signals = input.signals ?? watchdogSignals(input.platform ?? "darwin");
 	const timeoutSeconds = input.timeoutSeconds ?? WATCHDOG_TIMEOUT_SECONDS;
 	const intervalSeconds = input.intervalSeconds ?? 3;
 	const settleSeconds = input.settleSeconds ?? 5;
@@ -925,13 +983,22 @@ BUNDLE="\${LO_UPDATE_WATCHDOG_APP_BUNDLE:-}"
 NAME="\${LO_UPDATE_WATCHDOG_APP_NAME:-}"
 SHIPIT_JOB="\${LO_UPDATE_WATCHDOG_SHIPIT_JOB:-}"
 TARGET_VERSION="\${LO_UPDATE_WATCHDOG_TARGET_VERSION:-}"
+# The two probes, from the platform the plan was built for. Empty means the
+# platform has no such tool and the signal is unavailable - not "the job is not
+# loaded" and not "the swap has not landed". shipit_loaded, swap_landed and
+# job_known each decline on it rather than answering, so a host without them
+# waits out the bound and still relaunches.
+SHIPIT_PROBE="\${LO_UPDATE_WATCHDOG_SHIPIT_PROBE:-}"
+PLIST_READER="\${LO_UPDATE_WATCHDOG_PLIST_READER:-}"
 if [ -z "$APP_PID" ] || [ -z "$BUNDLE" ]; then
 	exit 1
 fi
 now() { date +%s; }
 app_running() { kill -0 "$APP_PID" 2>/dev/null; }
 # launchctl list <label> exits 113 when the job is not loaded, 0 when it is.
-shipit_loaded() { [ -n "$SHIPIT_JOB" ] && launchctl list "$SHIPIT_JOB" >/dev/null 2>&1; }
+# With no probe there is no launchd to ask, and this answers "cannot ask" rather
+# than "not loaded": job_known below requires the probe for the same reason.
+shipit_loaded() { [ -n "$SHIPIT_PROBE" ] && [ -n "$SHIPIT_JOB" ] && "$SHIPIT_PROBE" list "$SHIPIT_JOB" >/dev/null 2>&1; }
 # (b), the swap's own state: is the app at the target path AT OR BEYOND the
 # version this update was for? plutil rather than \`defaults read\`, which reads
 # through a preference domain and can answer from a stale cache; a half-written
@@ -1009,15 +1076,15 @@ bundle_version() {
 	_stamp="$$-$(now)"
 	_out="\${TMPDIR:-/tmp}/lo-update-watchdog-version-$_stamp.out"
 	# The pid the bound kills IS the reader: \`exec\` replaces the subshell rather
-	# than wrapping plutil, so nothing is reparented when the kill lands. The
+	# than wrapping the reader, so nothing is reparented when the kill lands. The
 	# previous shape killed a subshell whose whole job was to drop a completion
 	# marker, and the read that subshell had forked was left blocked under pid 1 -
 	# one more per poll, for as long as the mount stayed dead (review round 4,
-	# Q7). Completion is read off the answer itself instead: plutil writes the
+	# Q7). Completion is read off the answer itself instead: the reader writes the
 	# version into this file and nothing else does, so bytes in it mean the read
 	# answered, and a read that fails writes none and is stopped by the same
 	# deadline.
-	( exec /usr/bin/plutil -extract CFBundleShortVersionString raw -o - "$_plist" ) >"$_out" 2>/dev/null &
+	( exec "$PLIST_READER" -extract CFBundleShortVersionString raw -o - "$_plist" ) >"$_out" 2>/dev/null &
 	_read_pid=$!
 	_waited=0
 	while [ ! -s "$_out" ]; do
@@ -1035,6 +1102,11 @@ bundle_version() {
 	printf '%s\n' "$_version"
 }
 swap_landed() {
+	# A platform with no plist reader cannot ask this question at all, and the
+	# answer it must not give is "not landed yet" either: the signal is declined
+	# and the job and the bound decide instead. \`bundle_version\` is only ever
+	# reached from here.
+	[ -n "$PLIST_READER" ] || return 1
 	[ -n "$TARGET_VERSION" ] || return 1
 	installed=$(bundle_version) || return 1
 	installed=\${installed#v}
@@ -1044,7 +1116,7 @@ swap_landed() {
 	version_at_least "$installed" "$target"
 }
 job_known=0
-[ -n "$SHIPIT_JOB" ] && job_known=1
+[ -n "$SHIPIT_PROBE" ] && [ -n "$SHIPIT_JOB" ] && job_known=1
 decided() {
 	if [ "$job_known" -eq 1 ] && ! shipit_loaded; then return 0; fi
 	swap_landed && return 0
@@ -1095,6 +1167,10 @@ exit 0
 			LO_UPDATE_WATCHDOG_APP_NAME: input.executableName,
 			LO_UPDATE_WATCHDOG_SHIPIT_JOB: input.shipItJob ?? "",
 			LO_UPDATE_WATCHDOG_TARGET_VERSION: input.targetVersion ?? "",
+			// Empty off macOS, which the script reads as "this signal is not available
+			// here" rather than as a negative answer (see `watchdogSignals`).
+			LO_UPDATE_WATCHDOG_SHIPIT_PROBE: signals.jobProbe ?? "",
+			LO_UPDATE_WATCHDOG_PLIST_READER: signals.plistReader ?? "",
 		},
 		timeoutSeconds,
 	};

--- a/src/main/update-service.ts
+++ b/src/main/update-service.ts
@@ -945,6 +945,12 @@ export class UpdateService {
 				target: targetVersion,
 				running: app.getVersion(),
 			}),
+			// Stated rather than read off `process.platform` at the plan: this
+			// watchdog exists for Squirrel.Mac's ShipIt, the guard above already
+			// refuses it anywhere else, and the script's two probes (launchd's job
+			// lookup, `plutil`) are generated for the platform the script runs on
+			// rather than for whichever host planned it (see `watchdogSignals`).
+			platform: "darwin",
 		});
 
 		try {


### PR DESCRIPTION
## What and why — two disclosed changes

This PR now carries two changes. The first fixes the reason the 0.17.2 release
failed. The second fixes the reason `main` is red: the watchdog test the first
change's own release blocked on, which fails on every push because it asserts a
macOS-only path from a Linux runner.

**Change class: C0/C1 — build tooling and a testability fix, no user-visible
surface, no behaviour change on macOS.** No design round applies.

---

## 1. The disk images are notarized at an absolute path

The 0.17.2 publish run (run 34695627933, job "Build macOS App") failed in the new
disk image notarization step, and the failure was a real bug in that step:

```
Notarizing disk image: dist/local-operator-ui-0.17.2-universal.dmg
Disk image notarization failed: Error: Failed to notarize via notarytool.  Failed with unexpected result:
Error: The value '/var/folders/36/.../T/electron-notarize-8p0wn7/dist/local-operator-ui-0.17.2-universal.dmg' is invalid for '<file-path>': The file couldn't be opened because it doesn't exist.
```

That path is not one anybody asked for, and the image was never there.
`@electron/notarize` 2.5.0 resolves the path itself, against a directory of its
own, in `node_modules/@electron/notarize/lib/notarytool.js`:

```js
function notarizeAndWaitForNotaryTool(opts) {
    return __awaiter(this, void 0, void 0, function* () {
        d('starting notarize process for app:', opts.appPath);
        return yield helpers_1.withTempDir((dir) => __awaiter(... {
            const fileExt = path.extname(opts.appPath);
            let filePath;
            if (fileExt === '.dmg' || fileExt === '.pkg') {
                filePath = path.resolve(dir, opts.appPath);   // line 112
```

`dir` is its submission temp dir - the `T/electron-notarize-*` in the log - so a
relative `appPath` resolves *inside that temp dir*. The step discovered the
images as `join(dist, name)` while `--dist` defaults to the relative `dist`, i.e.
`dist/local-operator-ui-0.17.2-universal.dmg`: a valid path from the working
directory and an invalid one by the time the library used it. The same value
covers the staple inside the library, and `sha512Base64`, `statSync` and
`removeTransientZip` after it. The app-bundle notarization in `afterSign` never
hit this because electron-builder hands it an absolute `appOutDir`.

**The fix** (`scripts/notarize-artifacts.mjs`): resolve the images to absolute
paths once, at discovery, so every consumer uses the same path.

```js
const distDir = resolve(dist);
const discovered = existsSync(distDir) ? readdirSync(distDir) : [];
const dmgs = dmgArtifacts(
	artifactPaths ??
		discovered
			.filter((name) => name.endsWith(".dmg"))
			.map((name) => join(distDir, name)),
).map((dmgPath) => resolve(dmgPath));
```

`--dist` behaves the same whether absolute or relative (CI passes none, so the
relative default is what shipped the bug). Exports and the documented ordering -
submit/staple, then re-hash, then rewrite the ymls - are unchanged.

**The new test** (`scripts/update-robustness.test.mjs`, wired into
`pnpm test:desktop`) drives the real `notarizeArtifacts` with
`@electron/notarize` stubbed through the file's existing esbuild plugin
mechanism, because no machine here can reach Apple's service and this class of
bug otherwise fails in a release and nowhere else: the path handed to `notarize()`
is absolute for the relative `--dist`, for an absolute one, and for a relative
`artifactPaths` entry; and a rejecting stub fails the step - `assert.rejects`
plus the CLI's exit status, asserted through a child process running the shipped
script so a later `catch` cannot turn the step into a silent no-op. Both cases
fail on the pre-fix tree:

```
✖ the notarization step hands the notarizer an absolute path
  AssertionError [ERR_ASSERTION]: a relative --dist reached the notarizer as
  ../../../../var/folders/.../T/lo-notarize-FgMtGb/dist/local-operator-ui-0.18.0-universal.dmg
    expected: true
✖ a rejected notarization fails the step and exits non-zero
  AssertionError [ERR_ASSERTION]: Expected values to be strictly equal: expected: true
ℹ pass 0  ℹ fail 2
```

---

## 2. The watchdog's platform is stated, so its swap check is asserted where it can run

`main` is red on every push since the commit that added the watchdog's swap check
- runs 34695505505, 34695566539, 34696129340, 34699012497 - on exactly one test:

```
not ok 248 - the watchdog leaves early when the swap has landed, job or no job
  error: 'expected the swap to end the wait, took 126265ms'
# tests 274   # pass 269   # fail 1   # skipped 4
```

The script's two probes are macOS tools - launchd's `launchctl list <label>` and
`/usr/bin/plutil` reading the bundle's own `Info.plist` - and **the test read
their availability off the host that ran it**. `plutil` lives only at that
absolute path on macOS, so on `ubuntu-latest` the version read answered nothing on
every poll, `swap_landed` stayed false for the whole bound, and the case that
asserts a landed swap ends the wait in seconds asserted the 120 s deadline
instead. It passed on the machine the feature was written on and could not pass
anywhere else - the same defect class as §1, a test asserting a path it cannot
reach.

**The fix**: the platform travels in the plan (`watchdogSignals`) and the script
is generated for the platform it will run on rather than for whichever host built
it. Both probes are commands the plan names, so a test can install fixtures for
them and drive the darwin branch from any host; the shipped caller states
`platform: "darwin"`, and it already refuses to plan a watchdog anywhere else
(`process.platform !== "darwin"` → no plan). With no probe, a signal is
*unavailable* rather than negative - no job probe cannot mean "the job is not
loaded", no reader cannot mean "the swap has not landed" - so `job_known` requires
the probe and `swap_landed` declines, leaving the bound as the only decider: still
a relaunch, never a silent exit.

**Watchdog behaviour on macOS is unchanged.** The generated darwin script differs
from the previous one only in reading those two commands from the environment;
diffing old and new with comments stripped gives exactly four hunks, all of them
inert when the probes resolve to `launchctl` and `/usr/bin/plutil`:

```
> SHIPIT_PROBE="${LO_UPDATE_WATCHDOG_SHIPIT_PROBE:-}"
> PLIST_READER="${LO_UPDATE_WATCHDOG_PLIST_READER:-}"
< shipit_loaded() { [ -n "$SHIPIT_JOB" ] && launchctl list "$SHIPIT_JOB" ...; }
> shipit_loaded() { [ -n "$SHIPIT_PROBE" ] && [ -n "$SHIPIT_JOB" ] && "$SHIPIT_PROBE" list "$SHIPIT_JOB" ...; }
< 	( exec /usr/bin/plutil -extract CFBundleShortVersionString raw -o - "$_plist" ) ...
> 	( exec "$PLIST_READER" -extract CFBundleShortVersionString raw -o - "$_plist" ) ...
> 	[ -n "$PLIST_READER" ] || return 1        # swap_landed, declines with no reader
< [ -n "$SHIPIT_JOB" ] && job_known=1
> [ -n "$SHIPIT_PROBE" ] && [ -n "$SHIPIT_JOB" ] && job_known=1
```

**The tests**, both branches driven explicitly rather than inherited:

- **darwin** (the early exit on a landed swap, the job-gone path, the job that
  appears and then goes, no relaunch while the app is alive): now run with a
  `plutil` fixture beside the existing `launchctl` and `open` ones, and the plan
  names those fixtures through the same seam production leaves alone. This is the
  branch that used to be mac-only by accident.
- **no signals** (new): `platform: "linux"` with both signals in their "decided"
  shape - job loaded, bundle already reporting the target version - asserting no
  early exit (the bound decides, then the relaunch happens), nothing left in the
  watchdog's own process group afterwards, and that the generated script names
  neither `launchctl` nor `plutil`.

**The failure reproduces locally by removing the reader from the darwin plan** -
which is exactly what a Linux runner has - and it produces the CI's own message:

```
✖ the watchdog leaves early when the swap has landed, job or no job
  AssertionError [ERR_ASSERTION]: expected the swap to end the wait, took 121315ms
```

and with the same plan built for `linux`, the pre-fix script takes the false early
exit the new case pins:

```
AssertionError [ERR_ASSERTION]: expected the bound to decide, exited after 2309ms
```

---

## Evidence

All gates re-run at head `3d4520a2d` in `~/local-operator-ui-worktrees/fix-notarize-dmg`:

| Gate | Result |
| --- | --- |
| `pnpm test:desktop` | **277 pass, 0 fail** (274 on main) |
| `pnpm lint` | exit 0 - 24 warnings, all pre-existing `useTopLevelRegex` in `src/` files this PR does not touch |
| `pnpm check-types` | exit 0 (main + renderer) |
| `pnpm check-themes` | exit 0 - freshness + 1912 contrast assertions across 12 themes |
| `pnpm verify-macos-artifacts` | exit 1, as it must (below) |
| full suite on Node 22.13.1 (CI's major) | 277 pass, 0 fail |

**CI on the head is green in the job that was red.** `ci.yml` runs on pushes to
`main`/`dev-*`, not on pull requests, so this PR carries no checks of its own; the
same commit pushed to a scratch `dev-*` branch produced a real ubuntu-latest /
Node 22 run of the identical job ([run 34699818807](https://github.com/damianvtran/local-operator-ui/actions/runs/34699818807)),
**Desktop Tests: success**:

```
ok 247 - the watchdog relaunches a real process tree and never exits without trying
ok 248 - the watchdog leaves early when the swap has landed, job or no job
ok 249 - without launchd or plutil the bound decides, and nothing is left behind
ok 268 - the notarization step hands the notarizer an absolute path
ok 269 - a rejected notarization fails the step and exits non-zero
# tests 277   # pass 273   # fail 0   # skipped 4
desktop suite: pass=273 fail=0
```

**On the base.** Upstream moved by one commit while this PR was open (`5f8d0ec94 feat(chat): render /usage as a real provider usage view (#110)`), so the scratch run above was against this branch's base rather than that head. The two commits touch none of this PR's four files (upstream's only `package.json` change adds `scripts/usage-view.test.mjs` and `scripts/usage-container.test.mjs` to `test:desktop`, which will make the suite larger); GitHub reports the PR `CLEAN`/`MERGEABLE`, and no rebase was performed.

(The 4 skips are pre-existing and present on `main`; `main`'s own run of the same
job is 274 tests / 269 pass / **1 fail** / 4 skipped. The scratch branch is
deleted; the run is retained. The notarization-only head was also checked this way
at run 34698993259, which is where the watchdog failure appeared under this PR's
name before this second commit fixed it.)

The artifact gate still fails closed on the images nobody can staple
retroactively, and still passes the app inside them:

```
Checking app: /Applications/Local Operator.app
Checking disk image: /Users/damian/Downloads/local-operator-ui-0.17.0-universal.dmg
PASS app-codesign: codesign --verify --deep --strict on the app
PASS app-spctl: spctl -a -vvv -t exec on the app
PASS app-stapler: stapler validate on the app
FAIL dmg-spctl: spctl -a -vvv -t open on the disk image -> rejected | source=no usable signature
FAIL dmg-stapler: stapler validate on the disk image -> does not have a ticket stapled to it.
2 of 5 artifact checks failed. The release must not be published until the disk image is signed, notarized and stapled.
verify-macos-artifacts EXIT=1
```

The step's own default invocation, run through the real CLI with the notarizer
stubbed, now hands the library an absolute path and completes the re-hash and the
yml rewrite:

```
$ cd /tmp/lo-probe2 && node --import <stub-hook> scripts/notarize-artifacts.mjs    # no --dist, as CI runs it
Notarizing disk image: /private/tmp/lo-probe2/dist/local-operator-ui-0.18.0-universal.dmg
Updated latest-mac.yml: local-operator-ui-0.18.0-universal.dmg size 5
Disk image notarized and stapled: /private/tmp/lo-probe2/dist/local-operator-ui-0.18.0-universal.dmg
exit=0
```

## What I deliberately did not do

- **No local proof of a real notarization.** There are no Apple credentials here
  and none can be, so a real submission, staple and ticket can only be re-verified
  by re-running the release workflow (`publish.yml`, job "Build macOS App", step
  "Notarize and staple the disk images"). Everything above is the path the step
  hands the library and its failure handling; the upload itself is unverified, and
  I have not and cannot verify it locally. Stated plainly rather than implied as
  covered.
- **No behaviour change on macOS** in the watchdog: the darwin diff is the four
  hunks above, and the darwin branch's cases still assert the same outcomes as
  before, now through fixtures the plan names.
- **No version bump.** `package.json` stays at `0.17.2`; the release bump is a
  separate step.
- **Nothing else touched**: no workflow change, no change to
  `verify-macos-artifacts.mjs`, no change to `reapFailedInstall`'s `/bin/launchctl
  remove` path (a separate macOS-only cleanup, never exercised off macOS), no
  dependency update.
- **Adjacent observation, not fixed**: `pnpm check-evidence` did not complete in
  ~5 minutes in the worktree and is not wired into any workflow, so it is neither
  a gate this PR can turn green nor one it can break.
